### PR TITLE
Cmake: add Qt5 `resources` and `translations` folder variables

### DIFF
--- a/cmake/dependencies/qt5.cmake
+++ b/cmake/dependencies/qt5.cmake
@@ -20,6 +20,15 @@ IF(NOT RV_DEPS_QT5_LOCATION
   )
 ENDIF()
 
+SET(RV_DEPS_QT5_RESOURCES_FOLDER
+    "${RV_DEPS_QT5_LOCATION}/resources"
+    CACHE STRING "Path to the Qt resources files folder"
+)
+SET(RV_DEPS_QT5_TRANSLATIONS_FOLDER
+    "${RV_DEPS_QT5_LOCATION}/translations"
+    CACHE STRING "Path to the Qt translations files folder"
+)
+
 FILE(GLOB QT5_CMAKE_DIRS ${RV_DEPS_QT5_LOCATION}/lib/cmake/*)
 FOREACH(
   QT5_CMAKE_DIR
@@ -125,13 +134,13 @@ IF(RV_TARGET_LINUX)
 
   MESSAGE(STATUS "Copying Qt resources files ...")
   FILE(
-    COPY "${RV_DEPS_QT5_LOCATION}/resources"
+    COPY "${RV_DEPS_QT5_RESOURCES_FOLDER}"
     DESTINATION "${RV_STAGE_ROOT_DIR}"
   )
 
   MESSAGE(STATUS "Copying Qt translations files ...")
   FILE(
-    COPY "${RV_DEPS_QT5_LOCATION}/translations"
+    COPY "${RV_DEPS_QT5_TRANSLATIONS_FOLDER}"
     DESTINATION "${RV_STAGE_ROOT_DIR}"
   )
 ENDIF()


### PR DESCRIPTION
## Issue: #2 

This PR adds two cached variables for the Qt5 dependency:

- `RV_DEPS_QT5_RESOURCES_FOLDER` (defaults to `"${RV_DEPS_QT5_LOCATION}/resources"`)
- `RV_DEPS_QT5_RESOURCES_FOLDER` (defaults to `"${RV_DEPS_QT5_LOCATION}/translations"`)

The variables can be set like this:

```
$ cmake -B cmake-build \
  -DRV_DEPS_QT5_LOCATION=/usr/lib64/qt5 \
  -DRV_DEPS_QT5_RESOURCES_FOLDER=/usr/share/qt5/resources \
  -DRV_DEPS_QT5_TRANSLATIONS_FOLDER=/usr/share/qt5/translations
```

Feel free to correct this @geffrak if you were thinking about something else!