### PR TITLE
Thread.cpp: change ucontext to ucontext_t

### DIFF
--- a/src/lib/mu/Mu/Thread.cpp
+++ b/src/lib/mu/Mu/Thread.cpp
@@ -74,7 +74,7 @@ Thread::Thread(Process* p, bool appthread) :
 #endif
 
 #ifdef PLATFORM_LINUX
-    _threadState = (size_t*)(new ucontext);
+    _threadState = (size_t*)(new ucontext_t);
 #endif
 
     if (isApplicationThread())


### PR DESCRIPTION
Fix error when building on Linux (At least on Arch Linux)

Signed-off-by: adro79 <57686179+adro79@users.noreply.github.com>