### PR TITLE
Fix errors in Build Guide for MacOS

### DIFF
--- a/doc/build_system/config_macos.md
+++ b/doc/build_system/config_macos.md
@@ -56,7 +56,7 @@ From the root of the repository, execute `cmake` specifying the path to an arbit
 For example:
 
 ```bash
-cmake -B cmake-build -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=$HOME/Qt5.15.11/5.15.11/clang_64
+cmake -B cmake-build -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=$HOME/Qt/5.15.2/clang_64
 ```
 
 ### Custom generator


### PR DESCRIPTION
changing it to the correct default installation path and same version of Qt as described in line 46.

Signed-off-by: finnschi <47210121+finnschi@users.noreply.github.com>