### PR TITLE
Include sysctl on Mac only

### DIFF
--- a/src/lib/base/TwkUtil/SystemInfo.cpp
+++ b/src/lib/base/TwkUtil/SystemInfo.cpp
@@ -18,7 +18,7 @@
 #endif
 #include <windows.h>
 #include <assert.h>
-#else
+#elif __APPLE__
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
Closes #20 

The sysctl include is not needed on CentOS7 and as of glibc 2.32 it has been removed.  So support distros/compilers later than that by removing it completely on Linux.