### PR TITLE
Remove dead link

### DIFF
--- a/doc/build_system/config_linux_centos7.md
+++ b/doc/build_system/config_linux_centos7.md
@@ -21,7 +21,7 @@ sudo yum install sudo wget git
 
 ## Install devtoolset-9
 
-By default the CentOS 7.9 built-in tools won't match the requirements we have to build RV. Install [devtoolset-9](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-9/] to remedy the situation.
+By default the CentOS 7.9 built-in tools won't match the requirements we have to build RV. Install devtoolset-9 to remedy the situation.
 
 ```bash
 sudo yum install centos-release-scl


### PR DESCRIPTION
The link to devtoolset-9 in the CentOS build guide is dead and I couldn't find any other good equivalents that described what it was, so I just removed the link.  The instructions below describe how to install it from yum, and that's all that is really needed.

This was report in issue https://github.com/AcademySoftwareFoundation/OpenRV/issues/38