### PR TITLE
Improve the documentation on how to get Qt

### DIFF
--- a/doc/build_system/config_linux_centos7.md
+++ b/doc/build_system/config_linux_centos7.md
@@ -83,6 +83,8 @@ sudo make install
 
 Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). Logs, Android, iOS and WebAssembly are not required to build OpenRV.
 
+WARNING: If you decide fetch Qt from another source, make sure to build it with SSL support and that  it contains everything required to build PySide2 and that the file structure is similar to the official package.
+
 ## Configure
 
 The project uses CMake and requires a configure step before building. It is during the configure step that you provide your Qt package.

--- a/doc/build_system/config_linux_centos7.md
+++ b/doc/build_system/config_linux_centos7.md
@@ -81,9 +81,7 @@ sudo make install
 
 ## Install Qt
 
-A full distribution of Qt 5.15 is required to build RV. You can download Qt 5.15.2 from the [Qt page](https://www.qt.io/download) (an account might be required).
-
-From the online installer, select everything under 5.15.2 except Logs, and Android.
+Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). Logs, Android, iOS and WebAssembly are not required to build OpenRV.
 
 ## Configure
 

--- a/doc/build_system/config_macos.md
+++ b/doc/build_system/config_macos.md
@@ -43,9 +43,7 @@ python3 -m pip install -r requirements.txt
 
 ## Install Qt
 
-A full distribution of Qt 5.15 is required to build RV. You can download Qt 5.15.2 from the [Qt page](https://www.qt.io/download) (an account might be required).
-
-From the online installer, select everything under 5.15.2 except Logs, Android, and iOS.
+Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). Logs, Android, iOS and WebAssembly are not required to build OpenRV.
 
 ## Configure
 

--- a/doc/build_system/config_macos.md
+++ b/doc/build_system/config_macos.md
@@ -45,6 +45,10 @@ python3 -m pip install -r requirements.txt
 
 Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). Logs, Android, iOS and WebAssembly are not required to build OpenRV.
 
+
+WARNING: If you decide fetch Qt from another source, make sure to build it with SSL support and that  it contains everything required to build PySide2 and that the file structure is similar to the official package.
+FYI. Qt5 from homebrew is known to not work well with OpenRV.
+
 ## Configure
 
 The project uses CMake and requires a configure step before building. It is during the configure step that you provide your Qt package.

--- a/doc/build_system/config_windows.md
+++ b/doc/build_system/config_windows.md
@@ -29,6 +29,9 @@ Download the last version of Qt 5.15.x that you can get using the online install
 
 Note: You will also need `jom`, and it is included with Qt Creator (available from the Qt online installer). If you do not want to install Qt Creator, you can download it from [here](https://download.qt.io/official_releases/jom/) and copy the executable into the QT installation root directory under Tools/QtCreator/bin/jom.
 
+WARNING: If you decide fetch Qt from another source, make sure to build it with SSL support and that  it contains everything required to build PySide2 and that the file structure is similar to the official package. 
+FYI. Qt from MSYS2 is missing QtWebEngine.
+
 ## 3. Install Strawberry Perl
 
 Download and install the 64-bit version of [Strawberry Perl](https://strawberryperl.com/)

--- a/doc/build_system/config_windows.md
+++ b/doc/build_system/config_windows.md
@@ -25,9 +25,9 @@ Note: The current version of PySide2 required by RV (5.15.2.1) cannot be built w
 
 ## 2. Install Qt
 
-Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://account.qt.io/s/downloads) (an account might be required).
+Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). Logs, Android, iOS and WebAssembly are not required to build OpenRV.
 
-Note: If you do have jom installed you will need it to build. You can download it from here: https://download.qt.io/official_releases/jom/.  The contents of the package need to be copied into the QT installation directory under Tools/QtCreator/bin/jom.
+Note: You will also need `jom`, and it is included with Qt Creator (available from the Qt online installer). If you do not want to install Qt Creator, you can download it from [here](https://download.qt.io/official_releases/jom/) and copy the executable into the QT installation root directory under Tools/QtCreator/bin/jom.
 
 ## 3. Install Strawberry Perl
 


### PR DESCRIPTION
* Windows's documentation referenced a link to https://account.qt.io, which is the route for commercial users of Qt to get the installer.
* Clarify how to get JOM.
* Using the exact wording on all three platforms.
* Warnings about other sources of Qt.

Signed-off-by: Kerby Geffrard <kerby.geffrard@autodesk.com>