### PR TITLE
Fix OTIO import problem when no available_range on audio

### DIFF
--- a/src/plugins/rv-packages/otio_reader/PACKAGE
+++ b/src/plugins/rv-packages/otio_reader/PACKAGE
@@ -28,6 +28,8 @@ files:
     location: SupportFiles/$PACKAGE
   - file: effectHook.py
     location: SupportFiles/$PACKAGE
+  - file: genericEffectHook.py
+    location: SupportFiles/$PACKAGE
   - file: timeWarpHook.py
     location: SupportFiles/$PACKAGE
   - file: customTransitionHook.py
@@ -116,6 +118,13 @@ description: |
     </p>
     </li>
     
+    <li>
+    <p>
+    genericEffectHook.py
+    A for handling the Effect schema.
+    </p>
+    </li>
+
     <li>
     <p>
     timeWarpHook.py

--- a/src/plugins/rv-packages/otio_reader/genericEffectHook.py
+++ b/src/plugins/rv-packages/otio_reader/genericEffectHook.py
@@ -1,0 +1,8 @@
+#
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
+# 
+# SPDX-License-Identifier: Apache-2.0 
+#
+
+def hook_function(in_timeline, argument_map=None):
+    print("Warning: Unhandled effect (named {})".format(in_timeline.effect_name))

--- a/src/plugins/rv-packages/otio_reader/manifest.json
+++ b/src/plugins/rv-packages/otio_reader/manifest.json
@@ -17,6 +17,12 @@
         }, 
         {
            "OTIO_SCHEMA" : "HookScript.1",
+           "name" : "create_effect",
+           "execution_scope" : "in_process",
+           "filepath" : "genericEffectHook.py"
+        }, 
+        {
+           "OTIO_SCHEMA" : "HookScript.1",
            "name" : "export_cdl",
            "execution_scope" : "in_process",
            "filepath" : "cdlExportHook.py"
@@ -33,7 +39,6 @@
            "execution_scope" : "in_process",
            "filepath" : "retimeExportHook.py"
         },
-
         {
             "OTIO_SCHEMA" : "HookScript.1",
             "name" : "clip",
@@ -62,6 +67,7 @@
     ],
     "hooks" : {
         "CDL_to_rv" : ["create_cdl"],
+        "Effect_to_rv" : ["create_effect"],
         "export_RVLinearize" : ["export_cdl"],
         "FreezeFrame_to_rv": ["create_timewarp"],
         "LinearTimeWarp_to_rv": ["create_timewarp"],

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -391,15 +391,16 @@ def _create_collection(collection, context=None):
         return results[0]
 
 
-def _create_media(media_ref, context=None):
+def _create_media(media_ref, trimmed_range, context=None):
     context = context or {}
+    media_range = media_ref.available_range or trimmed_range
 
     if isinstance(media_ref, otio.schema.ExternalReference):
         media = [_get_media_path(str(media_ref.target_url), context)]
 
         if context.get("track_kind", None) == otio.schema.TrackKind.Audio:
             # Create blank video media to accompany audio for valid source
-            blank = _create_movieproc(media_ref.available_range)
+            blank = _create_movieproc(media_range)
             # Appending blank to media promotes name of audio file in RV
             media.append(blank)
         return media
@@ -415,12 +416,12 @@ def _create_media(media_ref, context=None):
                 context,
             )
         ]
-    return [_create_movieproc(media_ref.available_range, "smptebars")]
+    return [_create_movieproc(media_range, "smptebars")]
 
 
 def _create_sources(item, context=None):
     def add_media(media_ref, active_key, cmd, *cmd_args):
-        media = _create_media(media_ref, context)
+        media = _create_media(media_ref, item.trimmed_range(), context)
 
         if active_key:
             media += ["+mediaRepName", active_key]


### PR DESCRIPTION
This branch fixes a problem from a client OTIO that was being imported to RV.

The problem was that there was an audio clip which had no `available_range` on an audio-only clip (which is valid OTIO), so we would throw an exception when we tried to access its `start_time` property.

To fix it, we will use `trimmed_range` if no `available_range` is available.  This will mean the media will have exactly the same number of frames as the source (ie trimmed/ no handles) in these cases.

There were also a number of Effects were generating errors, so I added a hook for the generic Effect that will just print that we do not support effect [effect_name].  Users can add their own custom handling here for their effects.
