### PR TITLE
Fix switch node EDL timings

### DIFF
--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/SwitchIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/SwitchIPNode.h
@@ -94,6 +94,7 @@ private:
     FloatProperty*              m_outputFPS;
     IntProperty*                m_outputSize;
     IntProperty*                m_autoSize;
+    IntProperty*                m_autoEDL;
 };
 
 } // Rv

--- a/src/lib/ip/IPBaseNodes/SwitchIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/SwitchIPNode.cpp
@@ -43,6 +43,7 @@ SwitchIPNode::SwitchIPNode(const std::string& name,
     m_outputSize->back() = 480;
 
     m_useCutInfo       = declareProperty<IntProperty>("mode.useCutInfo", 1);
+    m_autoEDL = declareProperty<IntProperty>("mode.autoEDL", 1);
     m_alignStartFrames = declareProperty<IntProperty>("mode.alignStartFrames", 0);
     m_autoSize         = declareProperty<IntProperty>("output.autoSize", 1);
     m_activeInput      = declareProperty<StringProperty>("output.input", "");
@@ -104,7 +105,7 @@ SwitchIPNode::propertyChanged(const Property* p)
 {
     if (!isDeleting())
     {
-        if (p == m_useCutInfo || p == m_alignStartFrames || p == m_outputFPS)
+        if (p == m_useCutInfo || p == m_alignStartFrames || p == m_outputFPS || p == m_autoEDL)
         {
             lock();
             m_rangeInfoDirty = true;
@@ -200,6 +201,7 @@ SwitchIPNode::computeRanges()
 
     const bool useCutInfo = m_useCutInfo->front();
     const bool alignStartFrames = m_alignStartFrames->front();
+    const bool autoEDL= m_autoEDL->front();
 
     for (size_t i = 0; i < ninputs; i++)
     {
@@ -259,7 +261,7 @@ SwitchIPNode::computeRanges()
 
     m_info.cutIn = m_info.start;
     m_info.cutOut = m_info.end;
-    m_offset = m_info.start - 1;
+    m_offset = autoEDL ? m_info.start - 1 : 0;
 
     if (m_outputFPS->front() == 0.0 && !m_rangeInfos.empty())
     {

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -469,6 +469,9 @@ def _create_sources(item, context=None):
                 )
 
         switch_group = commands.nodeConnections(source_group)[1][0]
+        switch = extra_commands.nodesInGroupOfType(switch_group, 'RVSwitch')[0]
+        commands.setIntProperty('{}.mode.autoEDL'.format(switch), [0])
+
         return switch_group, active_source
 
     return source_group, active_source


### PR DESCRIPTION
This is bringing back a fix I did earlier, but after the branch off for OpenRV, so it wasn't part of the initial OpenRV code.  The issue is that when we have a switch node.  Here's my original PR description:

This branch fixes the timing when a Sequence node without autoEDL is connected to a SourceNode via a SwitchNode. Normally, the SwitchNode is computing an offset for autoEDL mode so that its frames are always starting at 1 (so it can basically unwrap the autoEDL behaviour to find the real frames). With autoEDL though, raw frame numbers are input so we do not want this. The simplest fix I can think of is to pass the autoEDL mode in the context when we metaEvaluate the graph when computing the ranges. This way if we are connected to a Sequence node with autoEDL disabled, we can ignore the offset.