### PR TITLE
SG-29809: Fix unable to write RV settings on Windows

### DIFF
--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -48,6 +48,7 @@
 #endif
 
 #include <QtCore/qlogging.h>
+#include <QtCore/QStandardPaths>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QDesktopWidget>
 #include <QtWidgets/QGridLayout>
@@ -1470,7 +1471,7 @@ RvApplication::initializeQSettings(string altPath)
         QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, config);
         QSettings::setPath(QSettings::NativeFormat, QSettings::SystemScope, config);
     #elif defined(PLATFORM_WINDOWS)
-        QString config(home + "/Application Data");
+        QString config = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
         if (altPath.size()) config = altPath.c_str();
         QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, config);
         QSettings::setPath(QSettings::IniFormat, QSettings::SystemScope, config);


### PR DESCRIPTION
SG-29809: Fix unable to write RV settings on Windows

1. Description of changes
This commit fixes the following Open RV reported issue on Windows:
https://github.com/AcademySoftwareFoundation/OpenRV/issues/53

#### Problem:
RV settings (QSettings) default location on Windows is obsolete ([home]/Application Data)
Qt automatically falls back to the default [home]/AppData location but in some environment/users, an error is reported. I was not able to reproduce this error and even the user who reported it said that it was giving an error on his laptop but not on his workstation.

#### Solution:
Now using QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) which maps to [home]AppData/Roaming on Windows and validated that the OpenRV.ini file is correctly saved to the same location as before (AppData/Roaming).

Note: A roaming profile has all the functionality of a local profile but can be transferred from one PC to another. Essentially, the user’s profile and files are downloaded to any computer that they log onto. When the user logs off, the changes in a roaming profile are synchronized with the server copy of the profile. This cycle repeats itself when the user logs on to their profile.

2. Automation
Not covered by automated tests

3. Any tips for QA for testing?
Please validate the the RV.ini file is still stored at the same location on Windows:
For Open RV:
[home]/AppData/Roaming/Autodesk/OpenRV.ini
For Commercial RV:
[home]/AppData/Roaming/TweakSoftware/RV.ini
Thanks
