### PR TITLE
Fix PySide2 build break with recent macOS/Xcode.app

### DIFF
--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -125,6 +125,23 @@ def prepare() -> None:
     print(f"Installing numpy with {install_numpy_args}")
     subprocess.run(install_numpy_args).check_returncode()
 
+    cmakelist_path = os.path.join(
+        SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt"
+    )
+    old_cmakelist_path = os.path.join(
+        SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt.old"
+    )
+    os.rename(cmakelist_path, old_cmakelist_path)
+    with open(old_cmakelist_path) as old_cmakelist:
+        with open(cmakelist_path, "w") as cmakelist:
+            for line in old_cmakelist:
+                new_line = line.replace(
+                    " set(HAS_LIBXSLT 1)",
+                    " #set(HAS_LIBXSLT 1)",
+                )
+
+                cmakelist.write(new_line)
+
 
 def remove_broken_shortcuts(python_home: str) -> None:
     """
@@ -176,6 +193,7 @@ def build() -> None:
         f"--openssl={os.path.join(OPENSSL_OUTPUT_DIR, 'bin')}",
         "--verbose-build",
         f"--parallel={os.cpu_count() or 1}",
+        "--skip-docs",
     ]
 
     # PySide2 v5.15.2.1 builds with errors on Windows using Visual Studio 2019.


### PR DESCRIPTION


<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Summarize your change.

Patch the PySide2 build to not use libXSLT.

### Describe the reason for the change.

Since the last update of MacOS (or Xcode.app?), we can't build PySide2 anymore. The issue seems caused by the way PySide2 finds and uses libXSLT. It's mixing multiple versions of MacOSX.sdk.

### Describe what you have tested and on which operating system.

MacOS 13.3, Xcode 14.3.
