### PR TITLE
[ 106: Update openexr to 3.1.7 ] 

### DIFF
--- a/cmake/dependencies/openexr.cmake
+++ b/cmake/dependencies/openexr.cmake
@@ -12,14 +12,14 @@ SET(_target
 )
 
 SET(_version
-    "3.1.5"
+    "3.1.7"
 )
 SET(_download_url
     "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v${_version}.zip"
 )
 
 SET(_download_hash
-    "a211c5c9f0796ad5c895fe0d2ce6a3f8"
+    "a278571601083a74415d40d2497d205c"
 )
 
 SET(_install_dir


### PR DESCRIPTION
Fixes #106 

this is to fix DWAA compressed EXR files crashing openRV on windows

Tested and built on windows 10 , needs to be built tested on macOS and linux before merge. 

Updated both hash and version
