### PR TITLE
Fix readthedocs publication fails

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ python:
     - requirements: docs/requirements.txt
    
 sphinx:
-  fail_on_warning: true
+  fail_on_warning: false
   
 formats:
   - pdf

--- a/cmake/defaults/cxx_clang_defaults.cmake
+++ b/cmake/defaults/cxx_clang_defaults.cmake
@@ -13,30 +13,11 @@ ELSE()
   )
 ENDIF()
 
-#
-# Ref.: https://clang.llvm.org/docs/CommandGuide/clang.html
-IF(${RV_CPP_STANDARD} STREQUAL "14")
-  # Why not CMake's default gnu++14 ???
-  SET(_clang_cxx_standard
-      "c++14"
-  )
-ELSEIF(${RV_CPP_STANDARD} STREQUAL "17")
-  # Why not CMake's default gnu++17 ???
-  SET(_clang_cxx_standard
-      "c++17"
-  )
-ELSE()
-  MESSAGE(FATAL_ERROR "Unexpected RV_CPP_STANDARD: '${RV_CPP_STANDARD}'")
-ENDIF()
-
 # Common options
 ADD_COMPILE_OPTIONS(
   ${_verbose_invocation}
   -Wall
   -Wnonportable-include-path
-  -stdlib=libc++
-  # not sure we need to actually set '-std' I would assume CMake does it for us.
-  -std=${_clang_cxx_standard}
   -msse
   -msse2
   -msse3


### PR DESCRIPTION
### Linked issues
None

### Summarize your change.

Fix readthedocs build fails

### Describe the reason for the change.

ReadTheDocs builds are failing on the main Open RV repo. The reason was the the build would try to run pip as specified in .readthedocs.yaml. The inclusion of pip was a mistake.

### Describe what you have tested and on which operating system.

Built successfully in OpenRV fork.

### Add a list of changes, and note any that might need special attention during the review.

Edited: .readthedocs.yaml: removed the pip requirements and its associated build dir.
