### PR TITLE
[116: Fix segfault in httpGet command]

### DIFF
--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -1740,7 +1740,7 @@ NODE_IMPLEMENTATION(httpGet, void)
     StringType::String* authEvent  = NODE_ARG_OBJECT(3, StringType::String);
     StringType::String* progEvent  = NODE_ARG_OBJECT(4, StringType::String);
     bool                ignore     = NODE_ARG(5, bool);
-    bool                urlIsEncoded = NODE_ARG(7, bool);
+    bool                urlIsEncoded = NODE_ARG(6, bool);
 
     RvWebManager::HeaderList headers;
 


### PR DESCRIPTION
### Summarize your change.

Fix out of bounds memory access in httpGet command

### Describe the reason for the change.

Segfault when testing httpGet in custom package.

### Describe what you have tested and on which operating system.

macOS 13.2.1

Test script below no longer crashes, prints contents of github.com to console:

`RV.app/Contents/MacOS/RV -pyeval "from rv import commands; onReplyEvent = lambda event: print(event.contents()); commands.bind('default','global','on-reply-event', onReplyEvent, 'desc'); commands.httpGet('https://github.com', [], 'on-reply-event');"`

### Add a list of changes, and note any that might need special attention during the review.

Parameter index corrected in MuUICommands.cpp

### If possible, provide screenshots.