### PR TITLE
Fix intermittent No Audio on the first open/play

### DIFF
--- a/src/lib/ip/IPCore/IPCore/Session.h
+++ b/src/lib/ip/IPCore/IPCore/Session.h
@@ -1078,7 +1078,6 @@ class Session : public TwkApp::Document
     mutable bool          m_framePatternFail;
     mutable int           m_framePatternFailCount;
     mutable FdataDeque    m_lastFData;
-    bool                  m_viewNodeChanged {false};
   public:
     static Session*      m_currentSession;
 };

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -2991,7 +2991,12 @@ IPGraph::audioConfigure(const AudioConfiguration& config)
     }
 
     if ( m_clearAudioCacheRequested.exchange(false) )
+    {
         m_audioCache.clear();
+        lockAudioInternal();
+        m_audioCacheComplete = false;
+        unlockAudioInternal();
+    }
 
     m_audioCache.unlock();
 

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -799,14 +799,6 @@ Session::setAudioTimeShift(double d, double sensitivity)
 void
 Session::playAudio()
 {
-    // we need to clear the cache if the view node has been
-    // changed since last audio play
-    if (m_viewNodeChanged)
-    {
-        graph().requestClearAudioCache();
-        m_viewNodeChanged = false;
-    }
-
     m_audioPlay = true;
     setAudioTimeShift(std::numeric_limits<double>::max());
     if (audioRenderer()) audioRenderer()->play(this);
@@ -1295,7 +1287,10 @@ Session::setViewNode(const std::string& nodeName, bool force)
             if (node != oldNode) setSessionStateFromNode(graph().viewNode());
             userGenericEvent("after-graph-view-change", nodeName);
             m_afterGraphViewChangeSignal(node);
-            m_viewNodeChanged = true;
+
+            // We need to clear the audio cache if the view node has been
+            // changed since the last audio play
+            graph().requestClearAudioCache();
         }
 
         return true;


### PR DESCRIPTION
Fix intermittent No Audio on the first open/play [SG-29287+SG-28578]

### Summarize your change.

#### Problem 
In some hard to reproduce situations, after loading some media, the 'Audio BUFFERING' HUD indicator was displayed and stuck and the cache was never filled. Starting a playback would end up with no audio. 

#### Cause 
In a very specific code path, the audio cache is cleared but the m_audioCacheComplete flag is NOT reset. This prevented the audio cache thread from waking up because the IPGraph::maybeDispatchAudioThread() logic depends on the m_audioCacheComplete flag. 

#### Solution 
Reset the m_audioCacheComplete flag whenever the audio cache is cleared. 
I searched for them all and there was only one place where the audio cache was cleared and the m_audioCacheComplete was not reset. This is what I fixed in this commit. 

### Describe the reason for the change.

This commit fixes 2 audio related issues:
Fixed an issue where the audio would not play when launching RV through python commands in a terminal when the Audio Cache option was active (Scrubbing On By Default (Cache All Audio)). [SG-29287]
Fixed an intermittent issue in RV where no audio would play the first time RV the application was open or starting playback. [SG-28578]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.
This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge [bernard.laberge@autodesk.com](mailto:bernard.laberge@autodesk.com)