### PR TITLE
Fix RV crashes when RV_SOURCE_TILING=1

### DIFF
--- a/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
@@ -1325,13 +1325,21 @@ FileSourceIPNode::evaluate(const Context& context)
                         static_cast<float>(tilingInfo.numTiles) *
                         static_cast<float>(aFullPlaneFB->height()) + 0.5f);
 
-                    const int tileSizeX = static_cast<int>(1.0f /
+                    int tileSizeX = static_cast<int>(1.0f /
                         static_cast<float>(tilingInfo.numTiles) *
                         static_cast<float>(aFullPlaneFB->width()) + 0.5f);
 
-                    const int tileSizeY = static_cast<int>(1.0f /
+                    int tileSizeY = static_cast<int>(1.0f /
                         static_cast<float>(tilingInfo.numTiles) *
                         static_cast<float>(aFullPlaneFB->height()) + 0.5f);
+
+                    // Make sure that the last tiles doe not overshoot the full
+                    // plane which would cause an access violation.
+                    // Note that this can happen because of the round up in the
+                    // previous float to integer conversion.
+                    // Example: numTiles=6, aFullPlaneFB->height=94605
+                    tileSizeX = std::min(tileSizeX, aFullPlaneFB->width()-tilePosX);
+                    tileSizeY = std::min(tileSizeY, aFullPlaneFB->height()-tilePosY);
 
                     unsigned char* tilePixels = 
                         ( aFullPlaneFB->pixels<unsigned char>() +


### PR DESCRIPTION
Fix RV crashes when RV_SOURCE_TILING=1 [SG-28211]

### Summarize your change.

#### Problem: 
In the scenario reported by a customer, a large 1444x94605 image is used with RV_SOURCE_TILING=1 to prevent any filtering in 1:1 view mode in RV. Random crashes were being reported. 

#### Cause: 
The RV_SOURCE_TILING mechanism effectively dissects the original texture in tiles that can be processed by the GPU without being downscaled. Each tile being a child in memory of the original texture. 
The random crashes were caused by the last tile which could end up being 1 line too big, effectively overshooting the original texture by one line due to rounding in the float to integer conversion. 

#### Solution: 
Now making sure that the last tile does not overshoot the original parent buffer by clipping that extra line if necessary. 

### Describe the reason for the change.

This commit fixes some intermittent crashes in RV when working with large images and the RV_SOURCE_TILING environment variable is active. [SG-28211]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.
This commit was successfully built on all 3 platforms and tested on
macOS Monterey.

Signed-off-by: Bernard Laberge
[bernard.laberge@autodesk.com](mailto:bernard.laberge@autodesk.com)
