### PR TITLE
Add missing redraw in setMargins() command

### DIFF
--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -356,7 +356,9 @@ NODE_IMPLEMENTATION(setMargins, void)
 {
     Vector4f m = NODE_ARG (0, Vector4f);
     const bool allDevices = NODE_ARG(1, bool);
-    Session::currentSession()->setMargins(m[0], m[1], m[2], m[3], allDevices);
+    Session* s = Session::currentSession();
+    s->setMargins(m[0], m[1], m[2], m[3], allDevices);
+    s->askForRedraw(true /*force*/);
 }
 
 NODE_IMPLEMENTATION(margins, Mu::Vector4f)


### PR DESCRIPTION
Add missing redraw in setMargins() command [SG-28734]

### Summarize your change.

Add missing redraw in setMargins() command.

Note that all the simple commands, like setFrame() for example, calls askForRedraw(). 
setMargins() was not. 

### Describe the reason for the change.

Fixed the missing redraw when using the setMargins() RV command. [SG-28734]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.
This commit was successfully built on all 3 platforms and tested on
macOS Monterey.

Signed-off-by: Bernard Laberge
[bernard.laberge@autodesk.com](mailto:bernard.laberge@autodesk.com)
