### PR TITLE
Fix Info Strip (F7) not showing the correct filename

### DIFF
--- a/src/lib/ip/IPCore/CMakeLists.txt
+++ b/src/lib/ip/IPCore/CMakeLists.txt
@@ -240,6 +240,7 @@ TARGET_LINK_LIBRARIES(
           Mu
           Boost::filesystem
           ${CMAKE_DL_LIBS}
+          IPBaseNodes
 )
 
 IF(RV_TARGET_WINDOWS)

--- a/src/lib/ip/IPCore/Transform2DIPNode.cpp
+++ b/src/lib/ip/IPCore/Transform2DIPNode.cpp
@@ -15,6 +15,7 @@
 #include <TwkMath/Iostream.h>
 #include <TwkFB/FrameBuffer.h>
 #include <TwkFB/Operations.h>
+#include <IPBaseNodes/SwitchIPNode.h>
 #include <stl_ext/stl_ext_algo.h>
 #include <iostream>
 #include <cmath>
@@ -226,6 +227,16 @@ Transform2DIPNode::evaluate(const Context& context)
     {
         root->stencilBox.min = Vec2f(x0, y0);
         root->stencilBox.max = Vec2f(x1, y1);
+
+        // Propagate the stencil to the source group if separated by a switch node (MMR)
+        if (dynamic_cast<const SwitchIPNode*>(root->node))
+        {
+            for (IPImage* child = root->children; child; child = child->next)
+            {
+                child->stencilBox.min = root->stencilBox.min;
+                child->stencilBox.max = root->stencilBox.max;
+            }
+        }
     }
     else
     {


### PR DESCRIPTION
Fix Info Strip (F7) not showing the correct filename [SG-28826]

### Summarize your change.

#### Problem: 
Since the introduction of Multiple Media Representations (MMR), when comparing two media from ShotGrid (Compare in RV), the info strip (FN-F7) is not always showing the correct filename test if the Compare mode is Wipe. Note that the comparison is correct, it is just the HUD's Info Strip that is showing the incorrect filename. 

#### Cause: 
The Info Strips' filename in Comparison/Wipe mode, is based on the stencil.visibleBox param (4 values) set by the wipe.mu package on the closest RVTransform2D node. For Compare in RV operation, it is the RVTransform2D belonging to the DefaultStack node. 

Now the way the info strips is able to retrieve the filename associated to the source node closest to the mouse pointer is from the exra_commands.mu.recordPixelInfo() which calls the RV command imagesAtPixel(). 
The imagesAtPixel(x, y) relies on computePixelImages(x, y) which computes the closest source node with respect to the specified mouse position. 
Now, to do so, computePixelImages() assumes that RV's ImageRenderer has tagged the image rendered for the source node with the stencil.visibleBox that was set by the wipe.mu package. However, the way it works is that the RVTransform2D (Transform2DIPNode::evaluate()) sets the stencilBox on its input. 
When MMR is disabled, then this input is the IPImage associated with the SourceGroup. 
However, when MMR is enabled, then this input is the IPImage associated with the SwitchGroup. Since that the stencilBox for the associated SourceGroup is not set when MMR is enabled, then it is what makes the Info Strips' filename to be unreliable because it is like all the sources share the same stencilBox. 

#### Solution: 
In the Transform2DIPNode::evaluate(), propagate the stencil to the source group if separated by a switch node (MMR). 
Note that my first solution to this problem, which I did not like one bit, was adding complexity to the computePixelImages() subroutine. 
The proposed solution is much simpler. 

### Describe the reason for the change.

This commit fixes an issue where the Info Strip overlay would not show the proper source information. This would happen when working with several clips in the Player with the MMR active.  [SG-28826]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <bernard.laberge@autodesk.com>