### PR TITLE
Rename the MMR switch groups to something more meaningful

### DIFF
--- a/src/lib/app/RvApp/RvApp/RvSession.h
+++ b/src/lib/app/RvApp/RvApp/RvSession.h
@@ -213,11 +213,13 @@ class RvSession : public IPCore::Session
 
     //
     //  Returns the names of the media representations available for the Switch 
-    //  Group corresponding to the given RVFileSource node.
+    //  Group corresponding to the given RVFileSource node or RVSwitch node.
+    //  Also optionally returns the source nodes associated with these media reps.
     //
 
     void sourceMediaReps(const std::string& srcNodeOrSwitchNodeName, 
-                         StringVector& sourceMediaReps);
+                         StringVector& sourceMediaReps, 
+                         StringVector* sourceNodes = nullptr);
   
 
     //

--- a/src/lib/app/RvApp/RvSession.cpp
+++ b/src/lib/app/RvApp/RvSession.cpp
@@ -1886,10 +1886,12 @@ std::string RvSession::sourceMediaRep(
 // Finds and returns the Source Media Representation names available
 void RvSession::sourceMediaReps(
     const string& srcNodeOrSwitchNodeName,
-    StringVector &sourceMediaReps
+    StringVector& sourceMediaReps,
+    StringVector* sourceNodes /* = nullptr */
 )
 {
     sourceMediaReps.clear();
+    if (sourceNodes) sourceNodes->clear();
 
     // Find the Switch node associated with the specified switch or source node if any
     SwitchIPNode* switchNode = this->switchNode(srcNodeOrSwitchNodeName);
@@ -1910,6 +1912,7 @@ void RvSession::sourceMediaReps(
         if (srcNode)
         {
             sourceMediaReps.push_back(srcNode->mediaRepName());
+            if (sourceNodes) sourceNodes->push_back(srcNode->name());
         }
         return;
     }
@@ -1919,6 +1922,7 @@ void RvSession::sourceMediaReps(
         if (SourceIPNode* srcNode = sourceFromSwitchInput(switchNode->inputs()[i]))
         {
             sourceMediaReps.push_back(srcNode->mediaRepName());
+            if (sourceNodes) sourceNodes->push_back(srcNode->name());
         }
     }
 }

--- a/src/lib/app/mu_rvui/commands.mud
+++ b/src/lib/app/mu_rvui/commands.mud
@@ -832,6 +832,19 @@ current frame is used to determine the available media representations.
 
 """
 
+sourceMediaRepsAndNodes() """
+
+Returns an array of (mediaRepName, mediaRepSourceNode) pairs available for the
+switch node specified as parameter containing the media representations.
+Each pair consists of firstly the name of the media representation, and secondly
+of the source node of that media representation.
+Note that for convenience, a source node can be specified instead of the switch 
+node, in which case the associated switch node will be inferred.
+
+Returns an empty array if no media representations are found.
+
+"""
+
 sourceMediaRepSwitchNode() """
 
 Returns the name of the switch node associated with the given source node if any.

--- a/src/lib/app/py_rvui/rv_commands_setup.py
+++ b/src/lib/app/py_rvui/rv_commands_setup.py
@@ -304,6 +304,7 @@ all_mu_commands = [
     "sourceMediaReps",
     "sourceMediaRepSwitchNode",
     "sourceMediaRepSourceNode",
+    "sourceMediaRepsAndNodes"
 ]
 
 

--- a/src/lib/ip/IPBaseNodes/SourceGroupIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/SourceGroupIPNode.cpp
@@ -143,6 +143,12 @@ SourceGroupIPNode::setUINameFromMedia(int index)
 	}
     }
 
+    // Append the media representation's name if any
+    if (!m_sourceNode->mediaRepName().empty())
+    {
+        uiname += " (" + m_sourceNode->mediaRepName() + ")";
+    }
+
     NameSet existingNames;
 
     for (IPGraph::NodeMap::const_iterator i = graph()->viewableNodes().begin();


### PR DESCRIPTION
Rename the MMR switch groups to something more meaningful [SG-28740]

### Summarize your change.

#### Problem: 
With the new Multiple Media Representations feature, the ui names of the source nodes and switch nodes were not really meaningful. 

#### Solution: 
In this commit, the media representation name is used as the ui name by default.

### Describe the reason for the change.

The MMR switch groups and sources displayed in the Session Manager now use names that are now more meaningful. [SG-28740]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <bernard.laberge@autodesk.com>