### PR TITLE
Fix RV unable to open pre-signed S3 URLs

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -1109,10 +1109,8 @@ MovieFFMpegReader::open(const string &filename,
 bool
 MovieFFMpegReader::openAVFormat()
 {
-    bool fileExists = boost::filesystem::exists(UNICODE_STR(m_filename));
-
-    // Look for current timing information in the MovieInfo
     const bool filepathIsURL = TwkUtil::pathIsURL(m_filename);
+    const bool fileExists = !filepathIsURL && boost::filesystem::exists(UNICODE_STR(m_filename));
     if (!filepathIsURL && !fileExists)
     {
         TWK_THROW_EXC_STREAM(

--- a/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
@@ -2610,34 +2610,34 @@ FileSourceIPNode::openMovieTask(const string& filename,
 string 
 FileSourceIPNode::cacheHash(const string& filename, const string& prefix)
 {
-    boost::filesystem::path p(UNICODE_STR(filename));
     string hashString;
 
-    if (boost::filesystem::exists(p))
+    const bool filepathIsURL = TwkUtil::pathIsURL(filename);
+    if (!filepathIsURL)
     {
-        try
+        boost::filesystem::path p(UNICODE_STR(filename));
+        if (boost::filesystem::exists(p))
         {
-            boost::uintmax_t size = boost::filesystem::file_size(p);
-            time_t modtime = boost::filesystem::last_write_time(p);
+            try
+            {
+                const auto size = boost::filesystem::file_size(p);
 
-            //
-            //  not sure if last_write_time is really what we want. does it
-            //  change when touched or the file is copied?
-            //
-            //  should this function be hashing the first 256 bytes or so of
-            //  the file to be safe?
-            //
+                //
+                //  should this function be hashing the first 256 bytes or so of
+                //  the file to be safe?
+                //
 
-            ostringstream name;
-            boost::hash<string> string_hash;
-            name << filename << "::" << size; 
-            ostringstream fullHash;
-            fullHash << prefix << hex << string_hash(name.str()) << dec;
-            hashString = fullHash.str();
-        }
-        catch (...)
-        {
-            // nothing
+                ostringstream name;
+                boost::hash<string> string_hash;
+                name << filename << "::" << size; 
+                ostringstream fullHash;
+                fullHash << prefix << hex << string_hash(name.str()) << dec;
+                hashString = fullHash.str();
+            }
+            catch (...)
+            {
+                // nothing
+            }
         }
     }
 


### PR DESCRIPTION
Fix RV unable to open pre-signed S3 URLs [SG-29243]

### Summarize your change.

#### Problem 
An RV user reported they couldn't File Open pre-signed S3 URLs. 

#### Cause 
Now I always assumed (incorrectly) that RV did not support File/Open pre-signed URLs. 
Now it looks like this limitation was OS specific because of the boost::filesystem::exists() that is called when File/Open a pre-signed URL. 
It looks like boost::filesystem::exists() complies to the maximum path length on each OS: 
260 on Windows 
1024 on Mac 
4096 on CentOS 

Note that I also tested std::filesystem::exists() and it behaves just like the boost one. 
Which is expected because I believe std::filesystem originates from boost::filesystem. 

#### Solution 
In this commit, I made sure to NOT call boost::filesystem::exists() if the movie path is a URL. 
I was able to validate this fix on Mac, Windows 10, CentOS 7.9, and Rocky Linux 8.7. 

### Describe the reason for the change.

This commit fixes an issue which would prevent RV from opening pre-signed S3 URLs. [SG-29961]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <bernard.laberge@autodesk.com>