### PR TITLE
Fix viewer not updated after RV reload() command

### DIFF
--- a/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
+++ b/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
@@ -383,8 +383,26 @@ RvBottomViewToolBar::receiveEvent(const Event& event)
             bb->setIcon(QIcon(":/images/control_bplay.png"));
             bf->setIcon(QIcon(":/images/control_play.png"));
         }
+        else if (name == "play-mode-changed")
+        {
+            if (QToolButton*b = dynamic_cast<QToolButton*>(widgetForAction(m_playModeAction)))
+            {
+                switch (m_session->playMode())
+                {
+                    case 0: // Session::PlayLoop
+                        b->setIcon(m_playModeLoopIcon);
+                        break;
+                    case 1: // Session::PlayOnce
+                        b->setIcon(m_playModeOnceIcon);
+                        break;
+                    case 2: // Session::PlayPingPong
+                        b->setIcon(m_playModePingPongIcon);
+                        break;
+                }
+            }
+        }
     }
-    
+
     return EventAcceptAndContinue;
 }
 //

--- a/src/lib/ip/IPCore/IPCore/ImageRenderer.h
+++ b/src/lib/ip/IPCore/IPCore/ImageRenderer.h
@@ -697,6 +697,8 @@ public:
     void                       setDrawReady(bool v);
     void                       setUploadReady(bool v);
     void                       notifyUpload();
+    void                       freeUploadedTextures();
+    
 
     // resets node ptr on all rendered image links to this node
     void                       unlinkNode(IPCore::IPNode * node); 
@@ -815,9 +817,8 @@ public:
     //  Same fb identifier different pixel aspect means a new upload
     std::string logicalImageHash(const IPImage*) const;
 
-    void clearImages();
     void freeOldTextures();
-    
+
     void uploadAuxImage(LogicalImage*,
                         const FrameBuffer*);
     

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -3934,6 +3934,21 @@ ImageRenderer::freeOldTextures()
     }
 }
 
+void
+ImageRenderer::freeUploadedTextures()
+{
+    for (FBToTextureMap::iterator it = m_uploadedTextures.begin();
+         it != m_uploadedTextures.end();
+         it++)
+    {
+        m_glState->deleteGLTexture(it->second->id);
+        if (it->second->bufferId) glDeleteBuffers(1, &it->second->bufferId);
+        delete it->second;
+    }
+    m_uploadedTextures.clear();
+}
+
+
 bool
 ImageRenderer::compatible(const FrameBuffer* fb,
                           const TextureDescription* tex) const

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -1748,7 +1748,7 @@ Session::setPlayMode(PlayMode mode)
     {
         m_playMode = mode;
         updateGraphInOut();
-        userGenericEvent("play-mode-changed", "");
+        userGenericEvent("play-mode-changed", std::to_string((int) mode));
         m_playModeChangedSignal();
     }
 }
@@ -2173,6 +2173,11 @@ Session::reload(int start, int end)
 
     graph().flushRange(start, end);
     clearVideoDeviceCaches();
+
+    // We need to manually free the already uploaded textures here because
+    // their content risks of no longer matching the reloaded media.
+    if (m_renderer) m_renderer->freeUploadedTextures();
+
     updateGraphInOut();
     askForRedraw();
 }
@@ -4462,7 +4467,10 @@ Session::userGenericEvent(const string& eventName,
                     contents == "rvui.previousMarkedFrame()" ||
                     contents == "rvui.nextMarkedFrame()" ||
                     contents == "extra_commands.stepForward(1)" ||
-                    contents == "extra_commands.stepBackward(1)"
+                    contents == "extra_commands.stepBackward(1)" ||
+                    contents == "commands.setPlayMode(PlayOnce)" ||
+                    contents == "commands.setPlayMode(PlayPingPong)" ||
+                    contents == "commands.setPlayMode(PlayLoop)"
                 )
             )
         )


### PR DESCRIPTION
Fix viewer not updated after RV reload() command [SG-30348]

### Summarize your change.

#### Problem 
The RV reload() command which is used by the "RV/Tools/Force Reload..." menu options instructs RV to reload media files. 
The command works as expected except for the current frame which never seems to be updated. 
However, if one selects the next frame and then goes back to the previous frame then the viewer gets updated. 
This clunky work around is not available when viewing a single frame which is why the client is interested into a fix for this issue. 
The client tested the issue on multiple versions of RV and confirms that this regression was introduced in RV 7.1 (2015) 

#### Cause 
I found the cause of the regression which had to do with the RV's Image Renderer refactoring that took place in RV 2015.
In the refactored image renderer, there is a simple cache of uploaded textures for the current frame (ImageRenderer::m_uploadedTextures). Since that when reloading a media file, the unique identifier associated with the frame buffer does not change (because it is the exact same filename that gets reloaded). 

#### Solution 
Added a ImageRenderer::freeUploadedTextures() that takes care of freeing the uploaded textures cache and use it in the reload() RV command. This means that this fix's impact is limited to the RV reload() command which greatly minimizes the risks. 

Note that I also removed the clearImages() method which was not defined (nor used thankfully) 

### Describe the reason for the change.

This commit fixes an issue about the Player not updating the current frame when an RV reload() command or Force Reload menu option is being done. [SG-30348]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <bernard.laberge@autodesk.com>