### PR TITLE
Set Python multiprocessing.set_executable

### DIFF
--- a/src/bin/python/py-interp/main.cpp
+++ b/src/bin/python/py-interp/main.cpp
@@ -36,8 +36,8 @@ main(int argc, char **argv)
     bundle.initializeAfterQApplication(); // cause init() to be called
 #endif
 
-    Py_InitializeEx( 1 );
     Py_SetProgramName( Py_DecodeLocale( argv[0], nullptr ) );
+    Py_InitializeEx( 1 );
 
     static wchar_t delim = L'\0';
 

--- a/src/lib/app/PyTwkApp/PyInterface.cpp
+++ b/src/lib/app/PyTwkApp/PyInterface.cpp
@@ -274,6 +274,23 @@ namespace TwkApp
 
     Mu::Module* python = new Mu::PyModule( muContext(), "python" );
     muContext()->globalScope()->addSymbol( python );
+
+    //
+    //  Set python3 as multiprocessing executable
+    //
+
+    evalPython(""
+        "import multiprocessing, os, sys\n"
+        "bin_dir, bin_name = os.path.split(sys.executable)\n"
+        "bin_name, bin_ext = os.path.splitext(bin_name)\n"
+        "for python_process in ('python', 'python3', 'py-interp'):\n"
+        "  python_exe = os.path.join(bin_dir, python_process + bin_ext)\n"
+        "  if os.path.exists(python_exe):\n"
+        "    multiprocessing.set_executable(python_exe)\n"
+        "    break\n"
+        ""
+    );
+
   }
 
   void finalizePython()


### PR DESCRIPTION
Set Python multiprocessing.set_executable [SG-30002]

### Summarize your change.

Python's documentation recommends that python embedders set the path of the Python interpreter to use when starting a child process. 

https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_executable 

### Describe the reason for the change.

This commit fixes a Python issue in RV by allowing the use of multiprocessing.pool.Threadpool. [SG-30002]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Kerby Geffrard <kerby.geffrard@autodesk.com>