### PR TITLE
Add property to sequence and stack to disable reversed blending mode

### DIFF
--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/SequenceIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/SequenceIPNode.h
@@ -126,6 +126,8 @@ private:
     FloatProperty*     m_outputFPS;
     IntProperty*       m_outputSize;
     IntProperty*       m_interactiveSize;
+    StringProperty*    m_inputsBlendingModes;
+    IntProperty*       m_supportReversedOrderBlending;
 
     /// this signal is called before all state change
     VoidSignal         m_changingSignal;

--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/StackIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/StackIPNode.h
@@ -101,6 +101,7 @@ class StackIPNode : public IPNode
     IntProperty*                m_outputSize;
     IntProperty*                m_autoSize;
     IntProperty*                m_interactiveSize;
+    IntProperty*                m_supportReversedOrderBlending;
 
   private:
     static std::string m_defaultCompType;

--- a/src/lib/ip/IPCore/IPCore/IPImage.h
+++ b/src/lib/ip/IPCore/IPCore/IPImage.h
@@ -246,6 +246,9 @@ class IPImage
     static IPImageID* newNoImageID();
     static IPImageID* newErrorImageID();
 
+    static BlendMode getBlendModeFromString( const char* blendModeString );
+
+
     //
     //  These will only return true if the image was made using the
     //  above special image constructors. 
@@ -445,6 +448,9 @@ class IPImage
     size_t           cropEndY;
     
     std::string      source;
+
+    bool supportReversedOrderBlending;
+ 
   private:
     void clear();
     bool renderIDNeedsCompute() const { return m_renderID == ""; }

--- a/src/lib/ip/IPCore/IPImage.cpp
+++ b/src/lib/ip/IPCore/IPImage.cpp
@@ -38,38 +38,39 @@ const char* IPImage::waveformTagValue() { return "_waveform"; }
 void
 IPImage::init()
 {
-    fb              = 0;
-    noIntermediate  = false;
-    next            = 0;
-    children        = 0;
-    info            = 0;
-    dataType        = NoInternalDataType;
-    pixelAspect     = 0.0;      // ignore if 0
-    initPixelAspect = 0.0;
-    minMax          = false;
-    blendMode       = UnspecifiedBlendMode;
-    renderType      = BlendRenderType;
-    ignore          = false;
-    missing         = false;
-    invalid         = false;
-    useBackground   = false;
-    destination     = CurrentFrameBuffer;
-    shaderExpr      = 0;
-    mergeExpr       = 0;
-    branchCount     = 0;
-    m_coordID       = size_t(-1);
-    device          = 0;
-    unpremulted     = false;
-    m_renderIDHash  = 0;
-    imageNum        = -1;
-    samplerType     = Rect2DSampler;
-    hashCount       = 0;
-    isHistogram     = false;
-    isCropped       = false;
-    cropStartX      = 0;
-    cropStartY      = 0;
-    cropEndX        = 0;
-    cropEndY        = 0;
+    fb                           = 0;
+    noIntermediate               = false;
+    next                         = 0;
+    children                     = 0;
+    info                         = 0;
+    dataType                     = NoInternalDataType;
+    pixelAspect                  = 0.0;      // ignore if 0
+    initPixelAspect              = 0.0;
+    minMax                       = false;
+    blendMode                    = UnspecifiedBlendMode;
+    renderType                   = BlendRenderType;
+    ignore                       = false;
+    missing                      = false;
+    invalid                      = false;
+    useBackground                = false;
+    destination                  = CurrentFrameBuffer;
+    shaderExpr                   = 0;
+    mergeExpr                    = 0;
+    branchCount                  = 0;
+    m_coordID                    = size_t(-1);
+    device                       = 0;
+    unpremulted                  = false;
+    m_renderIDHash               = 0;
+    imageNum                     = -1;
+    samplerType                  = Rect2DSampler;
+    hashCount                    = 0;
+    isHistogram                  = false;
+    isCropped                    = false;
+    cropStartX                   = 0;
+    cropStartY                   = 0;
+    cropEndX                     = 0;
+    cropEndY                     = 0;
+    supportReversedOrderBlending = true;
 }
 
 IPImage::IPImage(const IPNode* n) : node(n) { init(); }
@@ -306,6 +307,22 @@ IPImage::newErrorImageID()
     IPImageID* id = new IPImageID(fb->identifier());
     delete fb;
     return id;
+}
+
+IPImage::BlendMode
+IPImage::getBlendModeFromString( const char* blendModeString )
+{
+    IPImage::BlendMode blendMode = IPImage::Over;
+
+    if      (!strcmp(blendModeString, "over"))         blendMode = IPImage::Over;
+    else if (!strcmp(blendModeString, "add"))          blendMode = IPImage::Add;
+    else if (!strcmp(blendModeString, "difference"))   blendMode = IPImage::Difference;
+    else if (!strcmp(blendModeString, "-difference"))  blendMode = IPImage::ReverseDifference;
+    else if (!strcmp(blendModeString, "dissolve"))     blendMode = IPImage::Dissolve;
+    else if (!strcmp(blendModeString, "replace"))      blendMode = IPImage::Replace;
+    else if (!strcmp(blendModeString, "topmost"))      blendMode = IPImage::Replace;
+
+    return blendMode;
 }
 
 bool 

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -1944,6 +1944,19 @@ ImageRenderer::renderAllChildren(InternalRenderContext& context)
     //
     //  Render the current image's children recursively
     //
+
+    // Note on reverse-order blending : Reversing the order of inputs when 
+    // blending has a huge impact; The first input becomes the top one. 
+    // For blend modes like 'Add' this has no impact, but for others it does.
+    // This mode was implemented when the StackIPNode/SequenceIPNode did not
+    // properly support multi-blend-modes, ie.: all inputs would have the same
+    // blend mode. 
+    //
+    // In order to support per-input blending modes, a new flag
+    // (supportReversedOrderBlending) was created to allow an IPNode to 
+    // instruct the ImageRenderer that a given IPImage does not support
+    // reversing the order of input blending.
+
     bool reverse = false;
     bool dontBlendFirst = false;
     const IPImage* root = context.image;
@@ -1953,6 +1966,7 @@ ImageRenderer::renderAllChildren(InternalRenderContext& context)
     //
 
     if (!context.mergeContext && 
+        root->supportReversedOrderBlending &&
         root->renderType != IPImage::GroupType)  
     {
         switch (context.blendMode)
@@ -2027,16 +2041,7 @@ ImageRenderer::renderAllChildren(InternalRenderContext& context)
             childContext.image = i;
             if (i->device) childContext.device = i->device;
 
-            if (dontBlendFirst && i == root->children && !context.doBlend)
-            {
-                childContext.blendMode = IPImage::Replace;
-                context.doBlend = true; // set to true, because the first 'no blend' has already happened.
-                                        // we want to blend for the rest of the rendering pass
-            }
-            else 
-            {
-                setupBlendMode(childContext);
-            }
+            setupBlendMode(childContext);
 
             renderRecursive(childContext);
         }


### PR DESCRIPTION
Add property to sequence and stack to disable reversed blending mode

### Summarize your change.

To support per-segment blending modes, the SequenceIPNode node was enhanced with a property-container to 
handle per-input blending modes. 

Since ImageRenderer::renderAllChildren did not properly support multiple 
blend modes, I had to add a flag to disable reverse-order blending. 
Reverse-order blending is a mechanism that seemed in place for shader-based 
compositing (currently disabled) and that sometimes inverses the order in 
which inputs are composited. This means that in RV the first input of a 
LayoutGroup becomes the top layer (lastly blended). This also has the side 
effect of forcing a "Replace" blend mode on the first drawn input. I would 
have prefered to completely remove this mode, but this would have required a 
lot of backward-compat code so I simply added a flag in IPImage to disable it 
when required. For now, both the SequenceIPNode and the StackIPNode can disable 
it (they each own a property for that). RV should remain untouched. 

files modifications 
------------------- 

-Both the StackIPNode and the SequenceIPNodes must be configured to yield 
IPImage nodes that don't support the reverse-order blending mode. 

src/lib/ip/IPBaseNodes/SequenceIPNode.cpp 
src/lib/ip/IPBaseNodes/SequenceIPNode.h 

-Added per-input blending modes. 
-Added a flag to toggle support of reverse-order blending. 

src/lib/ip/IPBaseNodes/StackIPNode.cpp 
src/lib/ip/IPBaseNodes/StackIPNode.h 
src/lib/ip/IPCore/IPImage.cpp 
src/lib/ip/IPCore/IPImage.h 

-Refactored a piece of code to convert blending mode names into their 
numerical values. 
-Added the new supportReversedOrderBlending flag in IPImage to force-disable 
the reverse-order blending. 

src/lib/ip/IPCore/ImageRenderer.cpp 


### Describe the reason for the change.

When importing a multi-track OTIO in RV, tracks are composited in the reverse order (bottom track on top instead of top track on top).
To support per-segment blending modes, the SequenceIPNode node was enhanced with a property-container to 
handle per-input blending modes. 

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Roger Nelson <roger.nelson@autodesk.com>