### PR TITLE
Fix OCIO issues after reloading an RV session

### DIFF
--- a/src/plugins/rv-packages/ocio_source_setup/PACKAGE
+++ b/src/plugins/rv-packages/ocio_source_setup/PACKAGE
@@ -1,7 +1,7 @@
 package: OpenColorIO Basic Color Management
 author: Autodesk, Inc.
 organization: Autodesk, Inc.
-version: 2.4
+version: 2.5
 requires: ''
 rv: 4.0
 openrv: 1.0.0


### PR DESCRIPTION
Fix OCIO issues after reloading an RV session [SG-29679]

### Summarize your change.

#### Problem 
After reloading an already OCIO corrected RV session, any sources added in RV afterwards does not get properly color space identified. 
Another side effect of the same issue: It is not possible to de-activate the OCIO correction on a per source basis in that same scenario. 

#### Cause 

Before this commit from 7 years ago, the default (non OCIO) pipelines were assumed to be: 
DEFAULT_RV_PIPE = { 
"RVLinearizePipelineGroup": ["RVLinearize", "RVLensWarp"], 
"RVLookPipelineGroup": ["RVLookLUT"], 
"RVDisplayPipelineGroup": ["RVDisplayColor"], 
} 
With this commit from 7 years ago, then the default RV pipelines could be anything since it assumed to be the first one being encountered. 
Now the problem with this approach is what if the first correction pipeline is OCIO based (which happens after reloading an already OCIO corrected RV sequence file), then the default (non OCIO) pipelines become OCIO based and this messes up the color space determination of any subsequently added file. 

#### Solution 

I have explored different options to solve this issue to minimize its impact and this is why I propose here to simply detect this special case where the first correction pipeline is OCIO based and to fall back on the RV non OCIO default pipeline in that case. It solves the client reported issue and it also solves the other discovered issue of not being able to de-activate the existing OCIO correction contained in the RV session file. 
For all other cases, it will behave the same as before this commit. 

### Describe the reason for the change.

Fixed an issue with the OCIO menu not being updated when adding media to an existing RV session. [SG-29679]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <bernard.laberge@autodesk.com>