### PR TITLE
Fix dup MMR UI entries when enabling PresentationMode

### DIFF
--- a/src/lib/app/RvApp/RvSession.cpp
+++ b/src/lib/app/RvApp/RvSession.cpp
@@ -1752,6 +1752,13 @@ RvSession::addSourceMediaRep(const std::string& srcNodeName,
     return result;
 }
 
+// Returns true if the switch node as parameter belongs to an RVSwitchGroup
+static bool isGroupedSwitchNode( SwitchIPNode const * const switchNode)
+{
+    return switchNode && switchNode->group()!=nullptr &&
+           switchNode->group()->protocol() == "RVSwitchGroup";
+}
+
 // Find and return the Switch node(s) associated with the specified source node name if any
 vector<SwitchIPNode*>
 RvSession::findSwitchIPNodes(const string& srcNodeOrSwitchNodeName)
@@ -1776,7 +1783,8 @@ RvSession::findSwitchIPNodes(const string& srcNodeOrSwitchNodeName)
                 graph().findNodeAssociatedWith(srcNode->group(), "RVSwitch"));
         }
 
-        if (switchNode)
+        // Make sure that the switch node (if any) is part of a switch group
+        if (switchNode && isGroupedSwitchNode(switchNode))
         {
             switchNodes.push_back(switchNode);
         }
@@ -1784,7 +1792,9 @@ RvSession::findSwitchIPNodes(const string& srcNodeOrSwitchNodeName)
 
     for (NodeVector::iterator i = nodes.begin(); i != nodes.end(); ++i)
     {
-        if (SwitchIPNode* switchNode = dynamic_cast<SwitchIPNode*>(*i))
+        // Make sure that the switch node (if any) is part of a switch group
+        SwitchIPNode* switchNode = dynamic_cast<SwitchIPNode*>(*i);
+        if (switchNode && isGroupedSwitchNode(switchNode))
         {
             switchNodes.push_back(switchNode);
         }

--- a/src/lib/app/mu_rvui/commands.mud
+++ b/src/lib/app/mu_rvui/commands.mud
@@ -611,6 +611,7 @@ The PixelImageInfo objects will be in order of front to back.
 sourcesAtFrame """
 Returns an array of the names of source nodes (RVFileSource or
 RVImageSource) which would be evaluated at the given frame.
+The array is guaranteed to contain only unique names (no duplicates).
 """
 
 renderedImages """


### PR DESCRIPTION
Fix dup MMR UI entries when enabling PresentationMode [SG-30496]

### Summarize your change.

#### Problem: 
In RV 2023, we've added a new MMR UI when multiple sources are present at the current frame 
Now one of our QAs found out that when presentation mode is enabled with a single source present on the timeline then the MMR UI lists a duplicate of the same source in the UI. 

#### Cause: 
This is caused by the RV commands sourcesAtFrames() which does not guarantee the uniqueness of the sources returned. When presentation mode is enabled, then the same sources are listed twice causing this issue. 

#### Solution: 
Modified sourcesAtFrame() command so that the same source is only listed once while preserving the order because some code might have relied on it (it is customary for RV code (client code or our own) to fetch the sourcesAtFrame() and then only apply it on the very first found. So even if the code could be simplified, it is important to respect the original order. 

Also fixed in this commit: 
I further restricted the RvSession::findSwitchIPNodes() internal method to make sure that the switch node (if any) is part of a switch group. This proved necessary to differentiate between an MMR SwitchGroup containing a SwitchNode and an RVFolderGroup which also contains a SwitchNode : an RVFolderGroup is used for caching purposes by the RV Screening Room Mu code (shotgrid_review_app.mu) 

### Describe the reason for the change.

This commit fixes an issue where a MMR UI entries would be duplicated when enabling PresentationMode [SG-30496]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <bernard.laberge@autodesk.com>