### PR TITLE
Disable Qt's HDPI environment variables

### DIFF
--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -102,6 +102,8 @@
 #include <QtGui/QtGui>
 #include <RvCommon/RvDocument.h>
 
+#include <QtGlobal>
+
 extern const char* rv_linux_dark;
 
 //
@@ -203,6 +205,17 @@ utf8Main(int argc, char *argv[])
 #ifdef PLATFORM_LINUX
     XInitThreads();
 #endif
+
+    const bool noHighDPISupport = getenv("RV_QT_HDPI_SUPPORT") == nullptr;
+    if (noHighDPISupport)
+    {
+        qunsetenv("QT_SCALE_FACTOR");
+        qunsetenv("QT_SCREEN_SCALE_FACTORS");
+        qunsetenv("QT_AUTO_SCREEN_SCALE_FACTOR");
+        qunsetenv("QT_ENABLE_HIGHDPI_SCALING");
+        qunsetenv("QT_SCALE_FACTOR_ROUNDING_POLICY");
+        qunsetenv("QT_DEVICE_PIXEL_RATIO");
+    }
 
     const char* pythonPath = getenv("PYTHONPATH");
     const char* pythonHome = getenv("PYTHONHOME");

--- a/src/bin/nsapps/RV/main.cpp
+++ b/src/bin/nsapps/RV/main.cpp
@@ -261,6 +261,17 @@ int main(int argc, char *argv[])
     // if GLView is changed to inherit from QOpenGLWidget.
     QApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
 
+    const bool noHighDPISupport = getenv("RV_QT_HDPI_SUPPORT") == nullptr;
+    if (noHighDPISupport)
+    {
+        unsetenv("QT_SCALE_FACTOR");
+        unsetenv("QT_SCREEN_SCALE_FACTORS");
+        unsetenv("QT_AUTO_SCREEN_SCALE_FACTOR");
+        unsetenv("QT_ENABLE_HIGHDPI_SCALING");
+        unsetenv("QT_SCALE_FACTOR_ROUNDING_POLICY");
+        unsetenv("QT_DEVICE_PIXEL_RATIO");
+    }
+
     const char* pythonPath = getenv("PYTHONPATH");
     if (pythonPath) pythonPath = strdup(pythonPath);
 


### PR DESCRIPTION
Disable Qt's HDPI environment variables [SG-30447]

Fix corruption when playing media with inserts [SG-29243]

### Summarize your change.

If RV_QT_HDPI_SUPPORT is not set, unset QT's scaling environment variables because RV is known to not work well with them.

### Describe the reason for the change.

Added the RV_QT_HDPI_SUPPORT environment variable for systems connected to a high DPI monitor. This new environment variable controls whether or not RV considers the QT environment variables defined on the system that might be used by other software. If RV_QT_HDPI_SUPPORT is set, RV uses the QT environment variables set on the system. If not, RV ignores any external QT environment variables. [SG-30447]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <kerby.geffrard@autodesk.com>