### PR TITLE
Fix flickering Sequence with SwitchNodes issue

### DIFF
--- a/src/lib/ip/IPBaseNodes/SwitchIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/SwitchIPNode.cpp
@@ -14,6 +14,7 @@
 #include <TwkMath/Function.h>
 #include <TwkFB/FrameBuffer.h>
 #include <TwkFB/Operations.h>
+#include <TwkUtil/EnvVar.h>
 #include <stl_ext/stl_ext_algo.h>
 #include <iostream>
 
@@ -22,7 +23,10 @@ using namespace TwkContainer;
 using namespace TwkMath;
 using namespace TwkFB;
 using namespace TwkAudio;
+using namespace TwkUtil;
 using namespace std;
+
+static ENVVAR_BOOL( evForceNoIntermediateForSwitchNodes, "RV_FORCE_NO_INTERMEDIATE_FOR_SWITCH_NODES", true );
 
 SwitchIPNode::SwitchIPNode(const std::string& name,
                            const NodeDefinition* def,
@@ -377,6 +381,8 @@ SwitchIPNode::evaluate(const Context& context)
                                 IPImage::BlendRenderType,
                                 width,
                                 height);
+
+    root->noIntermediate = evForceNoIntermediateForSwitchNodes.getValue();
 
     try
     {


### PR DESCRIPTION
Fix flickering Sequence with SwitchNodes issue [SG-28820]

### Summarize your change.

A flickering render issue was uncovered while testing for another issue: OTIO : Zooming out of the default output bounds does not reveal media.
I have identified the source of the flicker and I can even reproduce it without the recent otio modification. 
The flickering issue only occurs when a switch node is connected to an RV Sequence and that the underlying Source node has a DVE transformation applied to it. 
If one changes the view node to point directly to the Switch node then everything renders well without flickering. 
Same good rendering without flickering if one changes the view node to point to the Default Stack or the Default Layout. 

Now I have identified the root of the issue: 
It is caused by the convertBlendRenderTypeToIntermediate() which is done in the SequenceIPNode::evaluate(): 
It converts the rendering of the switch node to an intermedia but this results in flickering. 
If we prevent the SequenceIPNode::evaluate() from converting the rendering of the SwitchIPNode to an intermediate then the flickering issue is resolved. 

In the mean time, I have the following hack to propose: 
To prevent the SwitchIPNode rendering from being converted to an intermediate by the SequenceIP node along with an environment variable to disable the hack for debugging purpose. 

### Describe the reason for the change.

Fix flickering Sequence with SwitchNodes issue [SG-28820]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <bernard.laberge@autodesk.com>