### PR TITLE
Add multiple sources at frame support to MMR UI

### DIFF
--- a/src/plugins/rv-packages/multiple_source_media_rep/PACKAGE
+++ b/src/plugins/rv-packages/multiple_source_media_rep/PACKAGE
@@ -1,9 +1,9 @@
 package: RV Multiple Source Media Representation Management
 author: Autodesk, Inc.
 organization: Autodesk, Inc.
-version: 1.1
+version: 1.3
 requires: ''
-rv: 2022.0.1
+rv: 2023.0.0
 openrv: 1.0.0
 system: true
 hidden: true

--- a/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep_utils.py
+++ b/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep_utils.py
@@ -11,6 +11,8 @@
 from rv import commands as rvc
 from rv import extra_commands as rve
 
+from collections import namedtuple
+
 
 def is_url(url):
     """
@@ -31,13 +33,27 @@ def get_switch_node(source):
     """
     Retrieves the first RVSwitch node at current frame.
     """
-
     if source:
         switch_nodes = rve.nodesInEvalPath(rvc.frame(), "RVSwitch", source)
         if switch_nodes:
             return switch_nodes[0]
 
     return ""
+
+
+def get_switch_nodes_at_current_frame():
+    """
+    Retrieves the list of RVSwitch nodes at current frame.
+    """
+    switch_nodes = []
+
+    sources = rvc.sourcesAtFrame(rvc.frame())
+    for source in sources:
+        src_switch_nodes = rve.nodesInEvalPath(rvc.frame(), "RVSwitch", source)
+        if src_switch_nodes:
+            switch_nodes.append(src_switch_nodes[0])
+
+    return switch_nodes
 
 
 def get_media_reps_sources(switch_node):
@@ -67,3 +83,79 @@ def get_source_media_info(source):
             info = rvc.sourceMediaInfo(source, media)
     finally:
         return info
+
+
+def get_media_rep(switch_nodes):
+    """
+    Returns the common media representation for the specified nodes if any
+    Note: Returns an empty string if no media representation exists.
+    Note: Returns "Mixed" if there are different media representations.
+    """
+    rep = ""
+
+    if switch_nodes:
+        rep = rvc.sourceMediaRep(switch_nodes[0])
+        for i in range(1, len(switch_nodes)):
+            new_rep = rvc.sourceMediaRep(switch_nodes[i])
+            if new_rep != rep:
+                rep = "Mixed"
+                break
+
+    return rep
+
+
+def get_media_rep_at_current_frame():
+    """
+    Returns the media representation at current frame.
+    Note: Returns an empty string if no media representation exists.
+    Note: Returns "Mixed" if there are different media representations
+    at the current frame.
+    """
+
+    switch_nodes = get_switch_nodes_at_current_frame()
+    return get_media_rep(switch_nodes)
+
+
+def get_extension_from_info_file(info_file):
+    """
+    Returns the extension from the infos["file"] media info
+    """
+    return (
+        ""
+        if not info_file
+        else "URL"
+        if is_url(info_file)
+        else info_file.split(".")[-1].upper()
+    )
+
+
+def get_common_source_media_infos(sources):
+    """
+    Returns the common infos shared by all the source nodes specified.
+    Note that the following info are returned as a named tupple:
+    resolution and extension.
+    """
+    resolution = ""
+    extension = ""
+    if sources:
+        infos = get_source_media_info(sources[0])
+        info_width = infos.get("width")
+        info_height = infos.get("height")
+        extension = get_extension_from_info_file(infos.get("file"))
+        for i in range(1, len(sources)):
+            new_infos = get_source_media_info(sources[i])
+            new_width = new_infos.get("width")
+            if new_width != info_width:
+                info_width = ""
+            new_height = new_infos.get("height")
+            if new_height != info_height:
+                info_height = ""
+            new_extension = get_extension_from_info_file(new_infos.get("file"))
+            if new_extension != extension:
+                extension = ""
+
+        if info_width and info_height:
+            resolution = "%s x %s" % (info_width, info_height)
+
+    infos = namedtuple("infos", ["resolution", "extension"])
+    return infos(resolution, extension)


### PR DESCRIPTION
Add multiple sources at frame support to MMR UI [SG-28863]

### Summarize your change.

#### Problem 
The original design of the Multiple Media Representations (MMR) did not address the use case of having multiple sources at the current frame. The current implementation is always showing/controlling the first source in the list: 
<img width="852" alt="mmr_mult_sources_at_frame_before" src="https://user-images.githubusercontent.com/117092886/235469978-e645b197-b6fb-405e-aa5d-a1d7f3a36106.png">


This commit implements the following: 
When multiple sources at the current frames are involved, then we populate the MMR UI menu differently : 
1. We first add the union of all the sources's media representations to the menu 
2. Then add each source's media representations to the menu 

This is what it looks like: 
<img width="890" alt="mmr_mult_sources_at_frame_after" src="https://user-images.githubusercontent.com/117092886/235470032-967af2a8-f87b-413a-94bf-856639762ae3.png">


When the sources are not sharing that exact same media representation, then 'Mixed' is shown in the MMR button menu: 
<img width="924" alt="mmr_mult_sources_at_frame_mixed_after" src="https://user-images.githubusercontent.com/117092886/235470043-de4380b5-364a-4426-94b2-14aa52f5a615.png">


### Describe the reason for the change.

We added the ability to select specific sources to specific clips when using the MMR feature in the context where there are several sources loaded in the Player, like when working in Stack or Layout mode. [SG-28863]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge <bernard.laberge@autodesk.com>