### PR TITLE
Fix crash clearing session

### DIFF
--- a/src/lib/app/RvApp/RvGraph.cpp
+++ b/src/lib/app/RvApp/RvGraph.cpp
@@ -137,9 +137,16 @@ RvGraph::initializeIPTree(const VideoModules& modules)
     }
 
     //
-    //  Delete all nodes until none are left.
+    //  Delete all nodes until none are left, but first set the view node
+    //  to the last node.  If we don't do this, once we delete the view node
+    //  we will reset it to the next node and repeat that until we reach 
+    //  the end. Each time we do this is will re-evaluate the graph, which
+    //  is needlessly costly since we are about to delete all nodes.
     //
-
+    if (!m_viewNodeMap.empty())
+    {
+       setViewNode(m_viewNodeMap.rbegin()->second);
+    }
     while (!m_viewNodeMap.empty())
     {
         IPNode* n = m_viewNodeMap.begin()->second;


### PR DESCRIPTION
Fix crash clearing session [SG-29596]

### Summarize your change.

This is a fix for clearing the session after opening the annotation tools. I didn't find the exact cause of the crash, but I saw it was in the re-evaluation of the graph. The re-evaluation was occurring because when we delete all the nodes, once we reach the view node, we will detect we've deleted the current view node and set it to the next node, which causes a re-evaluation of the graph. Then we'll delete that node and repeat the evaluation on the next node in a loop until we've reach the end. This is pointless and costly since we are deleting all the nodes anyway.

To fix this, I just set the view node to the last node before deleting the list, so we avoid all these re-evaluations and thus avoid the crash too.

### Describe the reason for the change.

This commit fixes an issue where clearing the session could potentially end up in a crash [SG-29596]

Note that this fix originates from the RV 2023 commercial release.

(https://community.shotgridsoftware.com/t/rv-2023-0-0-release-is-available/17227)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Roger Nelson <roger.nelson@autodesk.com>