### PR TITLE
Rocky 9 Build Guide

### DIFF
--- a/docs/build_system/config_linux_rocky9.md
+++ b/docs/build_system/config_linux_rocky9.md
@@ -1,0 +1,69 @@
+# Building Open RV on CentOS 7
+
+## Summary
+
+1. [Install Basics](#install-basics)
+1. [Install tools and build dependencies](#install-tools-and-build-dependencies)
+1. [Install CMake](#install-cmake)
+1. [Install Qt5](#install-qt)
+
+## Install Basics
+
+Make sure we have some basic tools available on the workstation:
+
+```bash
+sudo dnf install wget git
+```
+
+## Install tools and build dependencies
+
+Some of the build dependencies come from outside the main AppStream repo. So first we will enable those and then install our dependencies:
+
+```bash
+sudo dnf install epel-release
+sudo dnf config-manager --set-enabled crb devel
+sudo dnf install alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex gcc gcc-c++ libXcomposite libXi-devel libaio-devel libffi-devel nasm ncurses-devel nss libtool libxkbcommon libXcomposite libXdamage libXrandr libXtst libXcursor meson ninja-build openssl-devel perl-FindBin pulseaudio-libs pulseaudio-libs-glib2 ocl-icd ocl-icd-devel opencl-headers python3 python3-devel qt5-qtbase-devel readline-devel sqlite-devel tcl-devel tcsh tk-devel yasm zip zlib-devel 
+```
+
+You can disable the devel repo afterwards since dnf will warn about it:
+```bash
+sudo dnf config-manager --set-disabled devel
+```
+
+### GLU
+
+You may or may not have libGLU on your system depending on your graphics driver setup.  To know you can check if you have the lib /usr/lib64/libGLU.so.1.  If it's there you can skip this step, there's nothing further to do in this section.  If not, you can install the graphics drivers for your system. As as last resort, you can install a software (mesa) libGLU version, but you may not have ideal performance with this option.  To do so:
+
+```bash
+sudo dnf install mesa-libGLU mesa-libGLU-devel
+```
+
+### Install the python requirements
+
+Some of the RV build scripts requires extra python packages. They can be installed using the requirements.txt at the root of the repository.
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+## Install CMake
+
+You need CMake version 3.24+ to build RV. The dnf-installable version is not quite recent enough, you'll to build and install CMake from sources.
+
+```bash
+wget https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0.tar.gz
+tar -zxvf cmake-3.24.0.tar.gz
+cd cmake-3.24.0
+./bootstrap --parallel=32  # 32 or whatever your machine allows
+make -j 32  # 32 or whatever your machine allows
+sudo make install
+
+cmake --version  # confirm the version of your newly installed version of CMake
+cmake version 3.24.0
+```
+
+## Install Qt
+
+Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). Logs, Android, iOS and WebAssembly are not required to build OpenRV.
+
+WARNING: If you fetch Qt from another source, make sure to build it with SSL support, that it contains everything required to build PySide2, and that the file structure is similar to the official package.

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -3,35 +3,36 @@
 SOURCED=0
 if [ -n "$ZSH_EVAL_CONTEXT" ]; then
   [[ $ZSH_EVAL_CONTEXT =~ :file$ ]] && SOURCED=1
+  SCRIPT=$0
 elif [ -n "$KSH_VERSION" ]; then
   [[ "$(cd $(dirname -- $0) && pwd -P)/$(basename -- $0)" != "$(cd $(dirname -- ${.sh.file}) && pwd -P)/$(basename -- ${.sh.file})" ]] && SOURCED=1
+  SCRIPT=$0
 elif [ -n "$BASH_VERSION" ]; then
   [[ $0 != "$BASH_SOURCE" ]] && SOURCED=1
+  SCRIPT=${BASH_SOURCE[0]}
 elif grep -q dash /proc/$$/cmdline; then
   case $0 in *dash*) SOURCED=1 ;; esac
+  x=$(lsof -p $$ -Fn0 | tail -1); SCRIPT=${x#n}
 fi
 
+SCRIPT_HOME=`readlink -f $(dirname $SCRIPT)`
 if [[ $SOURCED == 0 ]]; then
-  echo "Please call: source $BASH_SOURCE"
+  echo "Please call: source $SCRIPT"
   exit 1
 fi
-
 
 QT_VERSION="${QT_VERSION:-5.15.2}"
 if [[ "$OSTYPE" == "linux"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
   QT_HOME="${QT_HOME:-$HOME/Qt/${QT_VERSION}/gcc_64}"
-  SCRIPT_HOME=`readlink -f $(dirname $0)`
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
   QT_HOME="${QT_HOME:-$HOME/Qt/${QT_VERSION}/clang_64}"
-  SCRIPT_HOME=`readlink -f $(dirname $0)`
 elif [[ "$OSTYPE" == "msys"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Visual Studio 16 2019}"
   QT_HOME="${QT_HOME:-c:/Qt/Qt/${QT_VERSION}/msvc2019_64}"
   WIN_PERL="${WIN_PERL:-c:/Strawberry/perl/bin}"
   CMAKE_WIN_ARCH="${CMAKE_WIN_ARCH:--A x64}"
-  SCRIPT_HOME=`readlink -f $(dirname ${BASH_SOURCE[0]})`
   SETUPTOOLS_USE_DISTUTILS=stdlib
 else
   echo "OS does not seem to be linux, darwin or msys. Exiting."
@@ -77,7 +78,7 @@ echo "CMAKE_GENERATOR is $CMAKE_GENERATOR"
 echo "QT_HOME is $QT_HOME"
 if [[ "$OSTYPE" == "msys"* ]]; then echo "WIN_PERL is $WIN_PERL"; fi
 
-echo "To override any of them do unset [name]; export [name]=value; source $0" 
+echo "To override any of them do unset [name]; export [name]=value; source $SCRIPT" 
 echo
 echo "If this is your first time building RV try rvbootstrap (release) or rvbootstrapd (debug)"
 echo "To build quickly after bootstraping try rvmk (release) or rvmkd (debug)"


### PR DESCRIPTION
This provides a build guide for Rocky 9.  It's similar to the CentOS build guide, but Rocky9 is a lot more minimalistic out-of-the-box, so a number of build requirements that are pre-installed on CentOS are not on Rocky9.  Thus using the CentOS build guide is not ideal since those missing packages must be manually tracked down.  This new guide is intended to make life easier for Rocky/RHEL9 users. 

I also fixed the rvcmds to base the script home on the shell scripting language instead of the OS, since the two were being conflated. It's the shell version and not the OS that determines the right command.

Tested on a fresh install of Rocky 9.1.
