### PR TITLE
Fix Mac install

### DIFF
--- a/cmake/install/pre_install_darwin.cmake
+++ b/cmake/install/pre_install_darwin.cmake
@@ -83,6 +83,6 @@ FUNCTION(after_copy_platform FILE_PATH)
     RETURN()
   ENDIF()
 
-  EXECUTE_PROCESS(COMMAND python3 ${PROJECT_SOURCE_DIR}/src/build/remove_absolute_rpath.py --target ${FILE_PATH} COMMAND_ERROR_IS_FATAL ANY)
+  EXECUTE_PROCESS(COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/../../src/build/remove_absolute_rpath.py --target ${FILE_PATH} COMMAND_ERROR_IS_FATAL ANY)
 
 ENDFUNCTION()


### PR DESCRIPTION
This branch fixes the Mac installation.

The problem is the CMake variable `PROJECT_SOURCE_DIR` is not available on the install step (only configure and build).  Since no variables involving the source dir are present at installation time, the only suitable replacement I could find was to use a path relative to the current directory `CMAKE_CURRENT_LIST_DIR`.  

Tested on Mac 13.3.1