### PR TITLE
Update contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,13 +1,31 @@
 # Contributors
 
-This is a list of the people who have contributed code to the Open RV project, sorted alphabetically by first name. 
+Here is a list of the people who've contributed code to the Open RV project, sorted by first name. 
 
+* adro79 ([adro79](https://github.com/adro79))
 * Alain Compagnat ([compaga](https://github.com/compaga))
 * Bernard Laberge ([bernie-laberge](https://github.com/bernie-laberge))
+* Brian Hanke ([https://github.com/brianhanke](https://github.com/brianhanke))
 * Eric Desruisseaux ([eric-desruisseaux-adsk](https://github.com/eric-desruisseaux-adsk))
+* finnschi ([https://github.com/finnschi](https://github.com/finnschi))
 * Guillaume Brossard ([guillaume-brossard](https://github.com/guillaume-brossard))
 * Ian Savoie ([savoiei](https://github.com/savoiei))
+* Inouk Babin-Ruel ([tbabiin](https://github.com/tbabiin))
+* johhnry ([johhnry](https://github.com/johhnry))
 * Kerby Geffrard ([geffrak](https://github.com/geffrak))
 * Martin Chesnay ([mchesnay](https://github.com/mchesnay))
+* Matt Daw ([mattdaw](https://github.com/mattdaw))
 * Nicolas Montmarquette ([nmontmarquette](https://github.com/nmontmarquette))
 * Roger Nelson ([rogernelson](https://github.com/rogernelson))
+
+A special recognition to the Tweak Software original founders, and to all the developers who contributed to RV before it became Open RV. Their passion, dedication, and hard work have shaped RV into the powerful media review and playback software it is today.
+
+Andrew Gardner
+Jim Hourihan
+Alan Trombla
+Jon Morley
+Arkell Rasiah
+Danielle Ann
+Louise Rasmussen
+Chris Horvath
+Seth Rosenthal


### PR DESCRIPTION
[ 11: Update contributors ]
Fixes: #11 

This branch updates the contributors to OpenRV up to today's date and adds acknowledgement for the original RV contributors before the project was open-sourced.