### PR TITLE
OpenSSL: Re-enable assembly language routines

### DIFF
--- a/src/build/make_openssl.py
+++ b/src/build/make_openssl.py
@@ -24,6 +24,7 @@ OUTPUT_DIR = ""
 ARCH = ""
 PERL_ROOT = ""
 
+
 def get_openssl_args(root) -> List[str]:
     """
     Return the path to the openssl binary given a package root.
@@ -182,7 +183,6 @@ def configure() -> None:
     else:
         configure_args.append("linux-x86_64")
 
-    configure_args.append("no-asm")
     configure_args.append(f"--prefix={OUTPUT_DIR}")
     configure_args.append(f"--openssldir={OUTPUT_DIR}")
 
@@ -229,6 +229,7 @@ def install() -> None:
     patch_openssl_distribution()
     test_openssl_distribution()
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
@@ -241,7 +242,9 @@ if __name__ == "__main__":
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
     parser.add_argument("--arch", dest="arch", type=str, required=False, default="")
-    parser.add_argument("--perlroot", dest="perlroot", type=str, required=False, default="")
+    parser.add_argument(
+        "--perlroot", dest="perlroot", type=str, required=False, default=""
+    )
 
     parser.set_defaults(clean=False, configure=False, build=False, install=False)
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

https://github.com/openssl/openssl/issues/18225

### Summarize your change.

Removes the `no-asm` flag to OpenSSL's build to build with the assembly language routines.

### Describe the reason for the change.

When compiling OpenSSL using Xcode 11, disabling the assembly language routines breaks the TLS 1.2 support.

### Describe what you have tested and on which operating system.

Tested on MacOS Ventura 13.3.1 with an Apple Silicon SoC.

### Add a list of changes and note any needing special attention during the review.

The change will get applied to all 3 OSes to have the same behaviour on all OSes, but I didn't test on all 3 OSes yet. The additional tests will get executed once we pull that commit into ShotGrid RV's internal CI. 

### If possible, provide screenshots.

#### Before (Failed to fetch the site info):
![image](https://github.com/AcademySoftwareFoundation/OpenRV/assets/6785406/7c3234e0-9238-49cb-aae9-869c1ff802bf)

#### After (Site info are fetched, failing because of dummy credentials): 
![image](https://github.com/AcademySoftwareFoundation/OpenRV/assets/6785406/baf2e135-8964-4d5e-8175-455cbbbde10b)