### PR TITLE
Added variable to fix the annotations panel closure bug

### DIFF
--- a/src/plugins/rv-packages/annotate/PACKAGE
+++ b/src/plugins/rv-packages/annotate/PACKAGE
@@ -1,7 +1,7 @@
 package: Annotation
 author: Autodesk, Inc.
 organization: Autodesk, Inc.
-version: 1.15
+version: 1.16
 rv: 3.12.15
 openrv: 1.0.0
 requires: ''

--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -1685,6 +1685,7 @@ class: AnnotateMinorMode : MinorMode
         _syncAutoStart     = false;
         _cursorChar        = char(0x1);
         _autoSave          = true;
+        _hideDrawPane      = 0;
 
         let m = mainWindowWidget(),
             g = QActionGroup(m);

--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -166,6 +166,8 @@ class: AnnotateMinorMode : MinorMode
 
     char              _cursorChar;
 
+    int              _hideDrawPane;
+
     \: colorToArray (float[]; Color c) { float[] {c.x, c.y, c.z, c.w}; }
     \: arrayToColor (Color; float[] a) { Color(a[0], a[1], a[2], a[3]); }
     method: encodedName (string; string name) { regex.replace("\.", _user, "+"); }
@@ -1529,12 +1531,14 @@ class: AnnotateMinorMode : MinorMode
         if (_currentDrawMode eq _selectDrawMode)
         {
             _leaveUiVisible = true;
+            _hideDrawPane = _hideDrawPane + 1;
             if (_active) toggle();
         }
         else
         {
             if (!_active) toggle();
             _leaveUiVisible = false;
+            _hideDrawPane = 0;
         }
 
         if (_activeSampleColor)
@@ -2192,10 +2196,11 @@ class: AnnotateMinorMode : MinorMode
 
     method: deactivate (void;)
     {
-        if (!_leaveUiVisible)
+        if (_hideDrawPane > 1 || !_leaveUiVisible)
         {
             if (_manageDock neq nil) _manageDock.hide();
             if (_drawDock neq nil) _drawDock.hide();
+            _hideDrawPane = 0;
         }
 
         setCursor(CursorDefault);

--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -141,7 +141,6 @@ class: AnnotateMinorMode : MinorMode
     QToolBar          _toolBar;
     QLabel            _toolSliderLabel;
     QtColorTriangle   _colorTriangle;
-    bool              _leaveUiVisible;
     bool              _setColorLock;
     bool              _activeSampleColor;
     Color             _sampleColor;
@@ -1530,14 +1529,12 @@ class: AnnotateMinorMode : MinorMode
     {
         if (_currentDrawMode eq _selectDrawMode)
         {
-            _leaveUiVisible = true;
             _hideDrawPane = _hideDrawPane + 1;
             if (_active) toggle();
         }
         else
         {
             if (!_active) toggle();
-            _leaveUiVisible = false;
             _hideDrawPane = 0;
         }
 
@@ -1675,7 +1672,6 @@ class: AnnotateMinorMode : MinorMode
         _textPlacementMode = false;
         _machine           = "computer";
         _user              = remoteLocalContactName();
-        _leaveUiVisible    = false;
         _setColorLock      = false;
         _activeSampleColor = false;
         _sampleCount       = 0;
@@ -2197,7 +2193,7 @@ class: AnnotateMinorMode : MinorMode
 
     method: deactivate (void;)
     {
-        if (_hideDrawPane > 1 || !_leaveUiVisible)
+        if (_hideDrawPane != 1)
         {
             if (_manageDock neq nil) _manageDock.hide();
             if (_drawDock neq nil) _drawDock.hide();


### PR DESCRIPTION
Added the _hideDrawPane variable to keep track of when to hide the draw pane. This will allow the closure of the annotations panel when "Select/Scrub Time" Tool is selected.

Variable has 3 stages: 
0 - Initial value/Nothing selected
1 - When the "Select/Scrub Time" Tool is selected
2 - When the "Select/Scrub Time" Tool is selected and the 'x' icon is selected