### PR TITLE
Add a section on how to delete sources via the api

### DIFF
--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-two.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-two.md
@@ -2,8 +2,7 @@
 
 The UI needs to communicate with the core part of RV. This is done in two ways: by calling special command functions (commands) which act directly on the core (e.g. play() causes it to start playing), or by setting variables in the underlying image processing graph which control how images will be rendered.Inside each session there is a *directed acyclic graph* (DAG) which determines how images and audio will be evaluated for display. The DAG is composed of *nodes* which are themselves collections of *properties* .A node is something that produces images and/or audio as output from images and audio inputs (or no inputs in some cases). An example from RV is the *color* node; the color node takes images as input and produces images that are copies of the input images with the hue, saturation, exposure, and contrast potentially changed.A *property* is a state variable. The node's properties as a whole determine how the node will change its inputs to produce its outputs. You can think of a node's properties as *parameters* that change its behavior.RV's session file format (.rv file) stores all of the nodes associated with a session including each node's properties. So the DAG contains the complete state of an RV session. When you load an .rv file into RV, you create a new DAG based on the contents of the file. Therefore, *to change anything in RV that affects how an image looks, you must change a property in some node in its DAG* .There are a few commands which RV provides to get and set properties: these are available in both Mu and Python.Finally, there is one last thing to know about properties: they are arrays of values. So a property may contain zero values (it's empty) or one value or an array of values. The get and set functions above all deal with arrays of numbers even when a property only has a single value.[16](rv-reference-manual-chapter-sixteen.md#chapter-16-node-reference) lists all properties and their function for each node type.
 
-### 2.1 Top-Level Node Graph
-
+## 2.1 Top-Level Node Graph
 
 When RV is started with e.g. two media (movies, file sequences) it will create two top-level group nodes: one for each media source. These are called RVSourceGroup nodes. In addition, there are four other top-level group nodes created and one display group node for each output device present on the system.
 
@@ -31,7 +30,6 @@ Table 2.1:Commands used to manage nodes in the graph
 
 ### 2.2 Group Nodes and Pipeline Groups
 
-
 A group node is composed of multiple member nodes. The graph connectivity is determined by the value of the group node's properties or it is fixed. Group nodes can contain other group nodes. The member nodes are visible to the user interface scripting languages and their node names are unique in the graph. Nodes may only be connected to nodes that are members of the same group. In the case of top level nodes they can be connected to other top level nodes.
 
 A pipeline group is a type of group node that connects it members into a single pipeline (no branches). Every pipeline group has a string array property called pipeline.nodes which determines the types of the nodes in the pipeline and the order in which they are connected. Any node type other than view and display group nodes can be specified in the pipeline.nodes property.Each type of pipeline group has a default pipeline. Except for the RVLinearizePipelineGroup which has two nodes in its default pipeline all others have a single node with the exception of the view pipeline which is empty by default. By modifying the pipeline.nodes property in any of these pipeline groups the default member nodes can either be swapped out, removed completely, or additional nodes can be inserted.For example. the following python code will set the view pipeline to use a user defined node called “FilmLook”:
@@ -41,7 +39,6 @@ A pipeline group is a type of group node that connects it members into a single 
 ```
 
 ### 2.3 Source Group Node
-
 
 The source group node (RVSourceGroup) has fixed set of nodes and three pipeline groups which can be modified to customize the source color management.
 
@@ -79,11 +76,13 @@ Table 2.2:Commands used to manage and create source groups
 If you need to, RV can load sources asynchronously, also known as progressive source loading. Progessive source loading is turned off by default.
 
 **Use one of these methods to enable asynchronous source loading:**
+
 - Set `setProgressiveSourceLoading = true`
 - With the command line argument: `-progressiveSourceLoading 1`
 - With the environment variable: `RV_PROGRESSIVE_SOURCE_LOADING`
 
 > Note: `setProgressiveSourceLoading` affects the behaviour of the following scripting commands:
+>
 > - addSource()
 > - addSources()
 > - addSourceVerbose()
@@ -126,8 +125,19 @@ rv.commands.setFPS(60.00)
 
 `progressiveSourceLoading` returns the loading state of the current progressive source.
 
-### 2.4 View Group Node
+#### 2.3.2 Deleting a Source
 
+When you allocate a new source with `addSource()`, or one of its variants such as `addSourceVerbose()`, RV actually allocates a source group under the hood but only returns the RVFileSource node. Using `deleteNode()` on the returned RVFileSource node deletes the node but not the source group that was created.
+
+To properly delete a source, you must delete its associated source group by using the following:
+
+```py
+rv.commands.deleteNode(rv.commands.nodeGroup(<loaded_node>))
+```
+
+If you prefer, you can instead clear all the sources from the current session with `rv.commands.clearSession()`.
+
+### 2.4 View Group Node
 
 The view group (RVViewGroup) is responsible for viewing transforms and is the final destination for audio in most cases. The view group is also responsible for rendering any audio waveform visualization.Changing the view in RV is equivalent to changing the input of the view group. There is only one view group in an RV session.The view group contains a pipeline into which arbitrary nodes can be inserted for purposes of QC and visualization. By default, this pipeline is empty (it has no effect).
 
@@ -145,7 +155,6 @@ Table 2.3:High level commands used to change the view group inputs
 
 ### 2.5 Sequence Group Node
 
-
 The sequence group node causes its inputs to be rendered one after another in time.The internal RVSequence node contains an EDL data structure which determines the order and possibly the frame ranges for its inputs. By default the EDL is automatically created by sequencing the inputs in order from the first to last with their full frame ranges. The automatic EDL function can be turned off in which case arbitrary EDL data can be set including cuts back to a single source multiple times.Each input to a sequence group has a unique sub-graph associated with it that includes an RVPaint node to hold annotation per input and an optional retime node to force all input media to the same FPS.
 
 ![5_sequence_group.png](../../images/rv-reference-manual-5-rv-cxx-rv4-sequence-group-04.png)
@@ -153,7 +162,6 @@ The sequence group node causes its inputs to be rendered one after another in ti
 Figure 2.4:Sequence Group Internals
 
 ### 2.6 Stack Group Node
-
 
 The stack group node displays its inputs on top of each other and can control a crop per input in order to allow pixels from lower layers to be seen under upper layers. Similar to a sequence group, the stack group contains an optional retime node per input in order to force all of the input FPS' to the same value.Unlike the sequence group, the stack group's paint node stores annotation after the stacking so it always appears on top of all images.
 
@@ -163,7 +171,6 @@ Figure 2.5:Stack Group Internals
 
 ### 2.7 Layout Group Node
 
-
 The layout group is similar to a stack group, but instead of showing all of its inputs on top of one another, the inputs are transformed into a grid, row, column, or under control of the user (manually). Like the other group nodes, there is an optional retime node to force all inputs to a common FPS. Annotations on the layout group appear on top of all images regardless of their input order.
 
 ![7_layout_group.png](../../images/rv-reference-manual-7-rv-cxx-rv4-layout-group-06.png)
@@ -171,7 +178,6 @@ The layout group is similar to a stack group, but instead of showing all of its 
 Figure 2.6:Layout Group Internals
 
 ### 2.8 Display Group Node
-
 
 There is one display group for each video device accessible to RV. For example in the case of a dual monitor setup, there would be two display groups: one for each monitor. The display group has two functions: to prepare the working space pixels for display on the associated device and to set any stereo modes for that device.By default the display group's pipeline uses an RVDisplayColor node to provide the color correction. The user can use any node for that purpose instead or in addition to the existing RVDisplayColor. For example, when OpenColorIO is being used a DisplayOCIONode is used in place of the RVDisplayColor.For a given desktop setup with multiple monitors only one of the RVDisplayGroups is active at a time: the one corresponding to the monitor that RV's main window is on. In presentation mode, two RVDisplayGroups will be active: one for RV's main window and one for the presentation device. Each display group has properties which identify their associated device.Changes to a display group affect the color and stereo mode for the associated device only. In order to make a global color change that affects all devices, a node should be inserted into the view group's pipeline or earlier in the graph.
 
@@ -181,17 +187,18 @@ Figure 2.7:Display Group Internals
 
 ### 2.9 Addressing Properties
 
-
 A full property name has three parts: the node name, the component name, and the property name. These are concatenated together with dots like *nodename.componentname.propertyname* . Each property has its own type which can be set and retrieved with one of the set or get functions. You must use the correct get or set function to access the property. For example, to set the display gamma, which is part of the \`\`display” node, you need to use setFloatProperty() like so in Mu:
 
 ```
  setFloatProperty("display.color.gamma", float[] {2.2, 2.2, 2.2}, true) 
 ```
+
 or in Python:
 
+```py
+setFloatProperty("display.color.gamma",  [2.2, 2.2, 2.2], True) 
 ```
- setFloatProperty("display.color.gamma",  [2.2, 2.2, 2.2], True) 
-```
+
 In this case the value is being set to 2.2.
 
 ![9_prop_inactive.png](../../images/rv-reference-manual-9-rv-cxx-rv4-prop-inactive-08.png)
@@ -201,23 +208,27 @@ Figure 2.8:Conceptual diagram of RV Image and Audio Processing Graph for a sessi
 In an RV session, some node names will vary per the source(s) being displayed and some will not. Figure [2.8](#rv-pipeline-small) shows a pipeline diagram for one possible configuration and indicates which are per-source (duplicated) and which are not.At any point in time, a subset of the graph is active. For example if you have three sources in a session and RV is in sequence mode, at any given frame only one source branch will be active. There is a second way to address nodes in RV: by their types. This is done by putting a hash (#) in front of the type name. Addressing by node type will affect all of the currently active nodes of the given type. For example, a property in the color node is exposure which can be addressed directly like this in Mu:
 
 ```
- color.color.exposure 
+color.color.exposure 
 ```
+
 or using the type name like this:
 
 ```
- #RVColor.color.exposure 
+#RVColor.color.exposure 
 ```
+
 When the “#” type name syntax is used, and you use one of the set or get functions on the property, only nodes that are currently active and which are the first reachable of the given type will be considered. So in this case, if we were to set the exposure using type-addressing:
 
 ```
- setFloatProperty("#RVColor.color.exposure", float[] {2.0, 2.0, 2.0}, true) 
+setFloatProperty("#RVColor.color.exposure", float[] {2.0, 2.0, 2.0}, true) 
 ```
+
 or in Python:
 
+```py
+setFloatProperty("#RVColor.color.exposure", [2.0, 2.0, 2.0], True) 
 ```
- setFloatProperty("#RVColor.color.exposure", [2.0, 2.0, 2.0], True) 
-```
+
 In sequence mode (i.e. the default case), only one RVColor node is usually active at a time (the one belonging to the source being viewed at the current frame). In stack mode, the RVColor nodes for all of the sources could be active. In that case, they will all have their exposure set. In the UI, properties are almost exclusively addressed in this manner so that making changes affects the currently visible sources only. See figure [2.9](#active-nodes-in-the-image-processing-graph) for a diagrammatic explanation.
 
 ![10_prop_active.png](../../images/rv-reference-manual-10-rv-cx-rv4-prop-active-09.png)
@@ -227,22 +238,21 @@ Figure 2.9: Active Nodes in the Image Processing Graph <a id="active-nodes-in-th
 The active nodes are those nodes which contribute to the rendered view at any given frame. In this configuration, when the sequence is active, there is only one source branch active (the yellow nodes). By addressing properties using their node's type name, you can affect only active nodes with that type without needing search for the exact node(s).There is an additional shorthand using “@” in front of a type name:
 
 ```
- @RVDisplayColor.color.brightness 
+@RVDisplayColor.color.brightness 
 ```
+
 The above would affect only the first RVDisplayColor node it finds instead of all RVDisplayColor nodes of depth 1 like “#” does. This is useful with presentation mode for example because setting the brightness would be confined to the first RVDisplayColor node which would be the one associated with the presentation device. If “#” was used, all devices would have their brightness modified. The utility of the “@” syntax is limited compared to “#” so if you are unsure of which to use try “#” first.Chapter [16](rv-reference-manual-chapter-sixteen.md#chapter-16-node-reference) has all the details about each node type.
 
 ### 2.10 User Defined Properties
 
-
 It's possible to add your own properties when creating an RV file from scratch or from the user interface code using the newProperty() function.Why would you want to do this? There are a few reasons to add a user defined property:
 
-1.  You wish to save something in a session file that was created interactively by the user.
-2.  You're generating session files from outside RV and you want to include additional information (e.g. production tracking, annotations) which you'd like to have available when RV plays the session file.
+1. You wish to save something in a session file that was created interactively by the user.
+1. You're generating session files from outside RV and you want to include additional information (e.g. production tracking, annotations) which you'd like to have available when RV plays the session file.
 
 Some of the packages that come with RV show how to implement functionality for the above.
 
 ### 2.11 Getting Information From Images
-
 
 RV's UI often needs to take actions that depend on the context. Usually the context is the current image being displayed. Table [2.4](#command-functions-for-querying-displayed-images) shows the most useful command functions for getting information about displayed images.
 


### PR DESCRIPTION
### Linked issues

None. This is a trivial fix.

### Summarize your change.

Describe how to delete cleanly a source from the image graph. 

### Describe the reason for the change.

The documentation describes how to use `addSourcexxx()` to add a source to the image graph, but did not explain that simply deleting the returned node did not clean up the graph. This update fixes that.

### Add a list of changes, and note any that might need special attention during the review.

Only updated file is [Ref Manual: Chapter Two](docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-two.md)
Note that some trivial markdown clean up also happened. The only area of concern is section 2.3.2 Deleting a Source.