### PR TITLE
Strip debug symbols from binaries when installing release on Linux

### DIFF
--- a/cmake/install/pre_install_linux.cmake
+++ b/cmake/install/pre_install_linux.cmake
@@ -32,6 +32,29 @@ FUNCTION(before_copy_platform FILE_PATH RET_VAL)
   RETURN()
 ENDFUNCTION()
 
-FUNCTION(after_copy_platform FILE_PATH)
+SET(STRIP_IGNORE_LIST
+  "csv"
+  "gzip"
+  "json"
+  "octet-stream"
+  "pdf"
+  "x-bytecode.python"
+  "x-bzip2"
+  "x-dosexec"
+  "x-tar"
+  "zip"
+)
 
+FUNCTION(after_copy_platform FILE_PATH)
+  IF(CMAKE_INSTALL_CONFIG_NAME MATCHES "^Release$")
+    EXECUTE_PROCESS(COMMAND file --mime-type ${FILE_PATH} OUTPUT_VARIABLE FILE_CMD_OUT)
+    IF(${FILE_CMD_OUT} MATCHES ": application\/(.+)\n")
+      IF(NOT "${CMAKE_MATCH_1}" IN_LIST STRIP_IGNORE_LIST)
+        EXECUTE_PROCESS(COMMAND strip -S ${FILE_PATH} RESULT_VARIABLE STRIP_EXIT_CODE)
+        IF(NOT STRIP_EXIT_CODE EQUAL 0)
+           MESSAGE(FATAL_ERROR "Unable to strip ${FILE_PATH} with mime type application/${CMAKE_MATCH_1}. Consider adding it to the ignore list.")
+        ENDIF()
+      ENDIF()
+    ENDIF()
+  ENDIF()
 ENDFUNCTION()


### PR DESCRIPTION
[Strip debug symbols from binaries when installing release on Linux]

### Summarize your change.

This brach adds some additional code to the RV installation step. When executed it will check the file to be installed to see if its a binary, and if so strip out any debugging symbols it finds. Certain mime types that cause errors with the strip command have been filtered out, and an error message will be displayed on any types that may fail in the future indicating that they may need to be added to the ignore list.

I did this at installation time instead of build time (with the -s option in CXX_FLAGS) so that we would also strip third-party binaries that we install, since we don't pass out CXX_FLAGS down to them when we build them.

### Describe the reason for the change.

It will reduce the size of the linux installation and should improve load performance.

### Describe what you have tested and on which operating system.

Built on Linux Rocky 9.  Reduced installation size from 3.5 to 1.3 GB.