### PR TITLE
Fix rvio Error encoding audio frame

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -4619,6 +4619,9 @@ MovieFFMpegWriter::fillAudio(Movie* inMovie, double overflow, bool lastPass)
     //
 
     track->audioFrame->nb_samples = nsamps;
+    track->audioFrame->format = audioFormat;
+    track->audioFrame->channels = audioCodecContext->channels;
+    track->audioFrame->channel_layout = audioCodecContext->channel_layout;
     avcodec_fill_audio_frame(track->audioFrame, audioChannels,
         audioFormat, (uint8_t*)m_audioSamples, totalOutputSize, 0);
     int gotAudio = 0;


### PR DESCRIPTION
### Fix rvio Error encoding audio frame

### Linked issues

### Summarize your change.

Properly initialize the AVFrame associated with the audio to be encoded prior to calling the FFmpeg method : avcodec_fill_audio_frame()

### Describe the reason for the change.

While testing the rvio software implementation, we realize that the Open RV rvio (hardware) implementation had an issue with the audio encoding: it was returning the following error:
ERROR: Error encoding audio frame: Invalid argument

This error was NOT reproducible on the commercial version of RV.

After investigation, it was found that Open RV uses a more recent version of FFmpeg than the commercial version : 4.4.3 for Open RV, 4.2.1 for RV Commercial. The newer FFmpeg version requires the audio AVFrame passed to avcodec_fill_audio_frame() to be fully initialized. The older FFmpeg version worked without it.
I double checked that all avcodec_fill_audio_frame() calls are done with a fully initialized AVFrame.

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

Signed-off-by: Bernard Laberge [bernard.laberge@autodesk.com](mailto:bernard.laberge@autodesk.com)
