### PR TITLE
120: Fix gltext memory leak (and other mem leaks)

### DIFF
--- a/src/lib/app/mu_rvui/commands.mud
+++ b/src/lib/app/mu_rvui/commands.mud
@@ -752,7 +752,7 @@ Similar to addSource(), but returns the name of the source node created.
 addSourcesVerbose """
 Similar to addSources(), but returns the names of the source nodes created.
 Note that unlike addSources(), addSource(), and addSourceVerbose() which all
-take a sring[] as input parameter, addSourcesVerbose() takes a string[][].
+take a string[] as input parameter, addSourcesVerbose() takes a string[][].
 
 Examples using addSourcesVerbose():
 rv.commands.addSourcesVerbose([["clip1"], ["clip2"]])

--- a/src/lib/mu/MuPy/PyModule.cpp
+++ b/src/lib/mu/MuPy/PyModule.cpp
@@ -529,8 +529,9 @@ namespace Mu
       if( PyUnicode_Check( pobj ) )
       {
         PyObject* utf8 = PyUnicode_AsUTF8String( pobj );
-        return Value(
-            Pointer( c->stringType()->allocate( PyBytes_AsString( utf8 ) ) ) );
+        Value ret( Pointer( c->stringType()->allocate( PyBytes_AsString( utf8 ) ) ) );
+        Py_XDECREF( utf8 );
+        return ret;
       }
       else if( PyBytes_Check( pobj ) )
       {


### PR DESCRIPTION
### 120: Fix gltext memory leak (and other mem leaks)

### Linked issues
Fixes #120 
Fixes #118 

### Summarize your change.

Fixed the gltext memory leak by fixing the PyUnicode_AsUTF8String() which was used without its associated Py_XDECREF().

Note that this memory leak occurred not only in gltext but also whenever an Python RV package was calling an RV cmd with text parameters.

### Describe the reason for the change.

This fix addresses the following Open RV reported issue:
https://github.com/AcademySoftwareFoundation/OpenRV/issues/120

#### Problem:
Using gltext seems to cause a memory leak issue.
The reporter provided an example mode that creates a watermark using gltext that shows the issue, however it seems to also happen with the Color Inspecter tool shipped with Openrv (uses gltext). Memory usage of RV will continue to increase causing RV to slow down and or eventually crash.

#### Cause:
I was able to identify the source of the memory leak using XCode/instruments.
The leak is in the Python->Mu code (PyModule::py2mu()) which is reponsible of converting Python objects to Mu objects.
More specifically when converting a Python string to Mu.
PyUnicode_AsUTF8String() was used without its associated Py_XDECREF().

#### Solution:
Added Py_XDECREF().

#### Also in this commit:
A mechanics was put in place 4 years ago to prevent a playback during a review session from being interrupted by the garbage collector which was causing some playback hiccups ie skipped frames. We had decided to disable the garbage collector during the playback which resolved the Marvel’s issue. Now because of this mechanism, the Color Inspector tool (or any mu code being executed) will 'seem' to leak memory during playback but as soon as the playback is stopped then the garbage collector will do its job and makes all the ‘allocated memory’ during the playback, available again to the RV process. However, the side effect is that RV will have a bigger memory footprint : proportional to whatever memory is allocated in Mu scripts from the start of the playback until the playback is stopped.
As decided this morning at the RV dailies, I have added an environment variable to disable this mechanism if desired. The no garbage collector cleanup up during playback would be the default behaviour and would guarantee that no hiccups occur during playback.

To re-enable the garbage collector from operating during a playback:
export RV_DISABLE_GARBAGE_COLLECTION_DURING_PLAYBACK=0

#### Also in this commit:
Fixed a Typo in addSourcesVerbose where sring was used instead of string.
(Most probably my bad!)

### Describe what you have tested and on which operating system.

This commit was successfully built on all 3 platforms and tested on macOS Monterey.

#### Testing Protocole:

Please validate repro steps.
I recommend using the following command which uses 60 fps to speed up the memory leakage:
./rv.exe smptebars,start=1,end=100,fps=60.movieproc

First set the following env var to 0 to make sure that garbage collection takes place during playback
export RV_DISABLE_GARBAGE_COLLECTION_DURING_PLAYBACK=0

Then you can validate without the env var.

Signed-off-by: Bernard Laberge [bernard.laberge@autodesk.com](mailto:bernard.laberge@autodesk.com)

