### PR TITLE
Issue-169: [Bug]: OpenRV fails to rebuild on Windows

### DIFF
--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -151,6 +151,9 @@ def prepare() -> None:
     old_cmakelist_path = os.path.join(
         SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt.old"
     )
+    if os.path.exists(old_cmakelist_path):
+        os.remove(old_cmakelist_path)
+
     os.rename(cmakelist_path, old_cmakelist_path)
     with open(old_cmakelist_path) as old_cmakelist:
         with open(cmakelist_path, "w") as cmakelist:


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
Fixes #169 

### [169: Fix PySide2 build error]

### Describe the reason for the change.

Fixing build error that happens during a rebuild for Python/PySide

### Describe what you have tested and on which operating system.

Tested rebuilding on Windows 11.

### Add a list of changes, and note any that might need special attention during the review.

Fixing FileExistsError by removing the 'CMakeLists.txt.old' before renaming the current CMakeList file

### If possible, provide screenshots.