### PR TITLE
Add Support for Directories in RV Packages SupportPath

### DIFF
--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -456,7 +456,7 @@ FUNCTION(rv_stage)
       COMMENT "Creating ${_package_filename} ..."
       OUTPUT ${_package_filename}
       DEPENDS ${_files} ${_package_file}
-      COMMAND zip -v -J ${_package_filename} ${_files} ${_package_file}
+      COMMAND zip -v -j ${_package_filename} ${_files} ${_package_file}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 

--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -4,16 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Empty those lists at the begining of a configure stage
-SET(RV_PACKAGE_LIST
-    ""
-    CACHE INTERNAL ""
-)
-SET(INSTALLED_RV_PACKAGE_LIST
-    ""
-    CACHE INTERNAL ""
-)
-
 #
 # Create & populate a list of all the shared libraries for later testing.
 MACRO(ADD_SHARED_LIBRARY_LIST new_entry)
@@ -456,7 +446,7 @@ FUNCTION(rv_stage)
       COMMENT "Creating ${_package_filename} ..."
       OUTPUT ${_package_filename}
       DEPENDS ${_files} ${_package_file}
-      COMMAND zip -v -j ${_package_filename} ${_files} ${_package_file}
+      COMMAND zip -v ${_package_filename} ${_files} ${_package_file}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 

--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -403,7 +403,7 @@ FUNCTION(rv_stage)
 
     IF(NOT arg_FILES)
       FILE(
-              GLOB _files
+              GLOB_RECURSE _files
               RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
               *
       )
@@ -456,7 +456,7 @@ FUNCTION(rv_stage)
       COMMENT "Creating ${_package_filename} ..."
       OUTPUT ${_package_filename}
       DEPENDS ${_files} ${_package_file}
-      COMMAND zip -v -j ${_package_filename} ${_files} ${_package_file}
+      COMMAND zip -v -J ${_package_filename} ${_files} ${_package_file}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 

--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -151,6 +151,9 @@ def prepare() -> None:
     old_cmakelist_path = os.path.join(
         SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt.old"
     )
+    if os.path.exists(old_cmakelist_path):
+        os.remove(old_cmakelist_path)
+
     os.rename(cmakelist_path, old_cmakelist_path)
     with open(old_cmakelist_path) as old_cmakelist:
         with open(cmakelist_path, "w") as cmakelist:

--- a/src/lib/app/RvPackage/PackageManager.cpp
+++ b/src/lib/app/RvPackage/PackageManager.cpp
@@ -1112,10 +1112,10 @@ PackageManager::loadPackageInfo(const QString& infileNonCanonical)
 
         // Standardize the file and directory paths
         for (auto& fileName : package.files) {
-          fileName.replace("\\", "/");
+          fileName = QDir::toNativeSeparators(fileName);
         }
         for (auto& auxFolder : package.auxFolders) {
-          auxFolder.folder.replace("\\", "/");
+          auxFolder.folder = QDir::toNativeSeparators(auxFolder.folder);
         }
 
         for (auto& auxFolder : package.auxFolders) {

--- a/src/lib/app/RvPackage/PackageManager.cpp
+++ b/src/lib/app/RvPackage/PackageManager.cpp
@@ -1,9 +1,9 @@
 //
-//  Copyright (c) 2010 Tweak Software. 
+//  Copyright (c) 2010 Tweak Software.
 //  All rights reserved.
-//  
+//
 //  SPDX-License-Identifier: Apache-2.0
-//  
+//
 //
 #include <RvPackage/PackageManager.h>
 #include <TwkDeploy/Deploy.h>
@@ -164,11 +164,11 @@ versionCompatible (QString version, int maj, int min, int rev)
 
     bool compatible = false;
 
-    if (cmajor > -1) 
+    if (cmajor > -1)
     {
         compatible = cmajor <= maj;
 
-        if (cmajor == maj && cminor > -1) 
+        if (cmajor == maj && cminor > -1)
         {
             compatible = cminor <= min;
 
@@ -235,7 +235,7 @@ PackageManager::installPackage(Package& package)
     supportdir.cd(pname);
 
     //
-    //  Test to see if any of the package files are already there 
+    //  Test to see if any of the package files are already there
     //
 
     QStringList existingFiles;
@@ -465,7 +465,7 @@ PackageManager::installPackage(Package& package)
 	    {
 		outfilename = profdir.absoluteFilePath(filename).toUtf8().constData();
 	    }
-            else 
+            else
             {
                 outfilename = supportdir.absoluteFilePath(filename).toUtf8().data();
             }
@@ -487,7 +487,7 @@ PackageManager::installPackage(Package& package)
                 string cmd = makeFBIO;
                 cmd += " ";
                 cmd += dir.toUtf8().constData();
-                
+
                 if (system(cmd.c_str()) == -1)
                 {
                     cout << "ERROR: executing command " << cmd << endl;
@@ -577,9 +577,9 @@ PackageManager::installPackage(Package& package)
             entry.active   = true;
         }
 
-        if (versionCompatible (entry.rvversion, 3, 7, 99)) 
+        if (versionCompatible (entry.rvversion, 3, 7, 99))
             mlistV1.push_back(entry);
-        else                        
+        else
             mlistV2.push_back(entry);
     }
 
@@ -604,17 +604,17 @@ PackageManager::installPackage(Package& package)
 bool
 PackageManager::makeSupportDirTree(QDir& root)
 {
-    const char* dirs[] = {"Mu", "Python", "SupportFiles", "ConfigFiles", "ImageFormats", 
-                          "MovieFormats", "Packages", "lib", "libquicktime", 
+    const char* dirs[] = {"Mu", "Python", "SupportFiles", "ConfigFiles", "ImageFormats",
+                          "MovieFormats", "Packages", "lib", "libquicktime",
                           "Nodes", "Profiles", NULL};
 
     for (const char** d = dirs; *d; d++)
     {
-        if (!root.exists(*d)) 
+        if (!root.exists(*d))
         {
-            if (!root.mkdir(*d)) 
+            if (!root.mkdir(*d))
             {
-                //QMessageBox::critical(this, 
+                //QMessageBox::critical(this,
                 //                      QString("Support Directory Creation Failed"),
                 //                      QString("Unable to create %1 in directory %2\n").arg(QString(*d)).arg(root.absolutePath()));
                 return false;
@@ -714,7 +714,7 @@ PackageManager::uninstallPackage(Package& package)
 
             outfilename = outdir.absoluteFilePath(onlyFileName).toUtf8().constData();
         }
-        else if (filename.endsWith(".mu") || 
+        else if (filename.endsWith(".mu") ||
                  filename.endsWith(".mud") ||
                  filename.endsWith(".muc"))
         {
@@ -783,7 +783,7 @@ PackageManager::uninstallPackage(Package& package)
 	{
             outfilename = profdir.absoluteFilePath(filename);
 	}
-        else 
+        else
         {
             outfilename = supportdir.absoluteFilePath(filename);
         }
@@ -803,7 +803,7 @@ PackageManager::uninstallPackage(Package& package)
         }
     }
 
-    // 
+    //
     // Remove the dangling supportdir
     //
 
@@ -812,7 +812,7 @@ PackageManager::uninstallPackage(Package& package)
     //
     // Report what was unremovable
     //
-    
+
     if (notremoved.size())
     {
         QString s("Files which could not be removed:\n");
@@ -863,7 +863,7 @@ PackageManager::uninstallPackage(Package& package)
     package.installed = false;
     QFileInfo rinfo(package.file);
     writeInstallationFile(rinfo.absoluteDir().absoluteFilePath("rvinstall"));
-    
+
     return true;
 }
 
@@ -880,7 +880,7 @@ PackageManager::loadPackageInfo(const QString& infileNonCanonical)
         // So if unzOpen is unsuccessful using the canonical
         // file path we try again with the original
         // non-canonical absolute file path.
-    
+
         // NB: The file path we use for m_packages
         // i.e. 'infile' should be the file path that was
         // successful for unzOpen().
@@ -923,15 +923,18 @@ PackageManager::loadPackageInfo(const QString& infileNonCanonical)
                 temp[255] = 0;
                 files.push_back(temp);
                 QString f = temp;
-                // Check if it's a directory by checking if it ends with a '/'
-                if (f.endsWith("/"))
+
+                // Check if it's a directory
+                QFileInfo fInfo(f);
+                if (finfo.isDir())
                 {
                     m_packages.back().folders.push_back(f);
                 }
-                else{
+                else
+                {
                     if (f != "PACKAGE") m_packages.back().files.push_back(f);
                 }
-            } 
+            }
             while (unzGoToNextFile(file) == UNZ_OK);
 
             while (!unzeof(file))
@@ -1111,32 +1114,30 @@ PackageManager::loadPackageInfo(const QString& infileNonCanonical)
 				yaml_parser_delete(&parser);
 
         // Standardize the file and directory paths
-        for (auto& fileName : package.files) {
-          fileName = QDir::toNativeSeparators(fileName);
-        }
+        std::transform(package.files.begin(), package.files.end(), package.files.begin(),
+                        [](QString& fileName) { return QDir::toNativeSeparators(fileName); });
+
         for (auto& auxFolder : package.auxFolders) {
           auxFolder.folder = QDir::toNativeSeparators(auxFolder.folder);
-        }
 
-        for (auto& auxFolder : package.auxFolders) {
-          QString folderName = auxFolder.folder;
+          // Convert the folder name to lower case for case-insensitive comparison
+          QString lowerFolderName = auxFolder.folder.toLower();
           QString folderLocation = auxFolder.location;
 
-          for (auto& fileName : package.files) {
-            // Convert the folder and file names to lower case for case-insensitive comparison
-            QString lowerFolderName = folderName.toLower();
-            QString lowerFileName = fileName.toLower();
+          // Iterate through files and compare paths
+          std::for_each(package.files.begin(), package.files.end(),
+                         [&](const QString& fileName) {
+                           QString lowerFileName = QDir::toNativeSeparators(fileName).toLower();
 
-            // Check if the file is in the current folder or any of its subdirectories
-            if (lowerFileName.startsWith(lowerFolderName + '/')) {
-              AuxFile newAuxFile;
-              newAuxFile.file = fileName;
-              newAuxFile.location = folderLocation;
-              package.auxFiles.push_back(newAuxFile);
-            }
-          }
+                           // Check if the file is in the current folder or any of its subdirectories
+                           if (lowerFileName.startsWith(lowerFolderName + QDir::separator())) {
+                             AuxFile newAuxFile;
+                             newAuxFile.file = fileName;
+                             newAuxFile.location = folderLocation;
+                             package.auxFiles.push_back(newAuxFile);
+                           }
+                         });
         }
-
 
 				QRegExp rvpkgRE("(.*)-[0-9]+\\.[0-9]+\\.rvpkg");
 				QRegExp zipRE("(.*)\\.zip");
@@ -1220,7 +1221,7 @@ PackageManager::writeModeFile(const QString& filename,
     if (file.open(QIODevice::WriteOnly))
     {
         file.write((version == 1) ? "1\n" : "4\n", 2);
-        
+
         for (size_t i = 0; i < list.size(); i++)
         {
             const ModeEntry& e = list[i];
@@ -1239,7 +1240,7 @@ PackageManager::writeModeFile(const QString& filename,
                 line += QString(",") + e.rvversion;
             }
 
-            if (version >= 3 || version == 0) 
+            if (version >= 3 || version == 0)
             {
                 line += QString(e.optional ? ",true" : ",false");
             }
@@ -1326,7 +1327,7 @@ PackageManager::writeInstallationFile(const QString& filename)
             const Package& package = m_packages[i];
 
             QFileInfo info(package.file);
-            
+
             if (info.absoluteDir() == filedir)
             {
                 if (package.installed) file.write("*",1);
@@ -1339,7 +1340,7 @@ PackageManager::writeInstallationFile(const QString& filename)
 }
 
 
-void 
+void
 PackageManager::findPackageDependencies()
 {
     for (size_t i = 0; i < m_packages.size(); i++)
@@ -1364,7 +1365,7 @@ PackageManager::findPackageDependencies()
 //
 //  Swap $APPLICATION_DIR in for the actual (canonical) directory if it
 //  appears at the head of the package file path.  This is to enable a
-//  optional package that was switched "on" to be "remembered" across 
+//  optional package that was switched "on" to be "remembered" across
 //  use of different versions of RV (stored in different directories).
 //
 
@@ -1470,11 +1471,11 @@ PackageManager::loadPackages()
                 {
                     PackageManager::ModeEntry& entry = entries[i];
 
-                    if (entry.optional == false) 
+                    if (entry.optional == false)
                     {
                         for (size_t i =0; i < m_packages.size(); i++)
                         {
-                            if (QFileInfo(m_packages[i].file).fileName() == entry.package && m_packages[i].optional) 
+                            if (QFileInfo(m_packages[i].file).fileName() == entry.package && m_packages[i].optional)
                             //
                             //  Then this package has been "opted in" so reset optional flag
                             //
@@ -1592,12 +1593,12 @@ void
 PackageManager::removePackages(const QStringList& files)
 {
     QStringList toremove;
-    
+
     for (size_t i = 0; i < files.size(); i++)
     {
         for (size_t q = 0; q < m_packages.size(); q++)
         {
-	    //  Must canonicalize these to guard against things like varying 
+	    //  Must canonicalize these to guard against things like varying
 	    //  capitalization of driver letters on windows.
 	    //
             QFileInfo packageFI(m_packages[q].file);
@@ -1656,7 +1657,7 @@ PackageManager::removePackages(const QStringList& files)
 //  Default implementation uses cin/cout
 //
 
-bool 
+bool
 PackageManager::yesOrNo(const char* m1,
                         const char* m2,
                         const QString& msg,
@@ -1664,7 +1665,7 @@ PackageManager::yesOrNo(const char* m1,
 {
     char yorn = 0;
 
-    cout << m1 << endl 
+    cout << m1 << endl
          << m2 << endl
          << msg.toUtf8().constData();
 
@@ -1678,7 +1679,7 @@ PackageManager::yesOrNo(const char* m1,
     return yorn == 'y';
 }
 
-bool 
+bool
 PackageManager::fixLoadability(const QString& msg)
 {
     return yesOrNo("Unloadable Package Dependencies",
@@ -1687,7 +1688,7 @@ PackageManager::fixLoadability(const QString& msg)
                    "Load other packages first?");
 }
 
-bool 
+bool
 PackageManager::fixUnloadability(const QString& msg)
 {
     return yesOrNo("Loadable Package Dependencies",
@@ -1696,7 +1697,7 @@ PackageManager::fixUnloadability(const QString& msg)
                    "Unload other packages too?");
 }
 
-bool 
+bool
 PackageManager::installDependantPackages(const QString& msg)
 {
     return yesOrNo("Some Packages Depend on This One",
@@ -1705,7 +1706,7 @@ PackageManager::installDependantPackages(const QString& msg)
                    "Try and uninstall others first?");
 }
 
-bool 
+bool
 PackageManager::overwriteExistingFiles(const QString& msg)
 {
     return yesOrNo("Existing Package Files",
@@ -1714,7 +1715,7 @@ PackageManager::overwriteExistingFiles(const QString& msg)
                    "Overwrite existing files?");
 }
 
-void 
+void
 PackageManager::errorMissingPackageDependancies(const QString& msg)
 {
     cout << "ERROR: Some package dependancies are missing" << endl
@@ -1722,7 +1723,7 @@ PackageManager::errorMissingPackageDependancies(const QString& msg)
          << endl;
 }
 
-bool 
+bool
 PackageManager::uninstallDependantPackages(const QString& msg)
 {
     return yesOrNo("Some Packages Depend on This One",
@@ -1731,33 +1732,33 @@ PackageManager::uninstallDependantPackages(const QString& msg)
                    "Try and uninstall them first?");
 }
 
-void 
+void
 PackageManager::informCannotRemoveSomeFiles(const QString& msg)
 {
     cout << "INFO: Some Files Cannot Be Removed" << endl
          << msg.toUtf8().constData() << endl;
 }
 
-void 
+void
 PackageManager::errorModeFileWriteFailed(const QString& file)
 {
-    cout << "ERROR: File write failed: " 
+    cout << "ERROR: File write failed: "
          << file.toUtf8().constData() << endl;
 }
 
-void 
+void
 PackageManager::informPackageFailedToCopy(const QString& msg)
 {
     cout << "INFO: package failed to copy: "  << msg.toUtf8().constData() << endl;
 }
 
-void 
+void
 PackageManager::declarePackage(Package&, size_t)
 {
     // for UI
 }
 
-bool 
+bool
 PackageManager::uninstallForRemoval(const QString& msg)
 {
     return yesOrNo("Package is installed",
@@ -1767,7 +1768,7 @@ PackageManager::uninstallForRemoval(const QString& msg)
 }
 
 
-int 
+int
 PackageManager::auxFileIndex(Package& p, const QString& file)
 {
     for (int i = 0; i < p.auxFiles.size(); i++)
@@ -1885,7 +1886,7 @@ defaultSettingsFileName()
     return name;
 }
 
-RvSettings::RvSettings() 
+RvSettings::RvSettings()
 {
     //
     //  This function should only ever be called once per run.
@@ -1899,12 +1900,12 @@ RvSettings::RvSettings()
 
     QCoreApplication::setOrganizationName("Autodesk");
     QCoreApplication::setOrganizationDomain("autodesk.com");
-	
+
     //
     //  If -noPrefs command line flag was used, use empty alternate
     //  prefs file, so that default values are used, and any changes
     //  the users makes do not affect stored prefs.
-    //  
+    //
     if (PackageManager::ignoringPrefs())
     {
         QCoreApplication::setApplicationName("RVALT");
@@ -1923,7 +1924,7 @@ RvSettings::RvSettings()
         //  Note that in the noPrefs mode, overriding and clobbering settings
         //  are also ignored.
         //
-        return; 
+        return;
     }
 
     QString   prefsFileName = QFileInfo (defaultSettingsFileName()).fileName();
@@ -1938,13 +1939,13 @@ RvSettings::RvSettings()
 
 RvSettings::~RvSettings()
 {
-    if ( !m_userSettingsErrorAlredyReported && 
+    if ( !m_userSettingsErrorAlredyReported &&
          (m_userSettings->status() != QSettings::NoError) )
     {
         cerr << "ERROR: RvSettings encountered error with: '"
              << m_userSettings->fileName().toStdString() << "' err: "
              << m_userSettings->status() << endl;
-             
+
         m_userSettingsErrorAlredyReported = true;
     }
     delete m_userSettings;
@@ -1957,10 +1958,10 @@ RvSettings::getQSettings()
         QSettings::Format format(QSettings::IniFormat);
     #else
         QSettings::Format format(QSettings::NativeFormat);
-    #endif    
+    #endif
     QSettings* qs = new QSettings(format, QSettings::UserScope, "Autodesk", INTERNAL_APPLICATION_NAME);
     qs->setFallbacksEnabled(false);
-    
+
     if (qs->status() != QSettings::NoError)
     {
         cerr << "ERROR: RvSettings was unable to read settings for: '"
@@ -2004,7 +2005,7 @@ RvSettings::endGroup()
     m_userSettings->endGroup();
 }
 
-QVariant 
+QVariant
 RvSettings::value (const QString& key, const QVariant& defaultValue) const
 {
     SettingsMap::const_iterator i;
@@ -2038,7 +2039,7 @@ RvSettings::value (const QString& key, const QVariant& defaultValue) const
     return defaultValue;
 }
 
-void     
+void
 RvSettings::setValue (const QString& key, const QVariant& value)
 {
     SettingsMap::iterator i;
@@ -2075,11 +2076,11 @@ RvSettings::setValue (const QString& key, const QVariant& value)
     sync();
 }
 
-void     
+void
 RvSettings::sync()
 {
     m_userSettings->sync();
-    if ( !m_userSettingsErrorAlredyReported && 
+    if ( !m_userSettingsErrorAlredyReported &&
          (m_userSettings->status() != QSettings::NoError) )
     {
         cerr << "ERROR: RvSettings was unable to write settings for: '"

--- a/src/lib/app/RvPackage/RvPackage/PackageManager.h
+++ b/src/lib/app/RvPackage/RvPackage/PackageManager.h
@@ -83,6 +83,12 @@ class PackageManager
         QString location;
     };
 
+    struct AuxFolder
+    {
+        QString folder;
+        QString location;
+    };
+
     struct Package
     {
         Package() : installed(false),
@@ -115,8 +121,10 @@ class PackageManager
         QString        description;
         QList<Mode>    modes;
         QStringList    files;
+        QStringList    folders;
 
         QList<AuxFile> auxFiles;
+        QList<AuxFolder> auxFolders;
 
         bool           installed;
         bool           loadable;


### PR DESCRIPTION
### Add Support for Directories in RV Packages SupportPath

### Summarize your change.
When creating a package you can list folders with files that should be installed in the SupportPath Plugins folder rather than listing each file individually

### Describe the reason for the change.
It should be easier/quicker to create packages

### Describe what you have tested and on which operating system.
MacOS

### Add a list of changes, and note any that might need special attention during the review.
- Packages are zipped with directory structure
- All files in package and its directories are zipped
- The app will traverse the PACKAGE file and see the list of folders specified. Based on this, all files under the folder and its subdirectories will be added to location provided.

N.B. When creating PACKAGE file if you want to use new behaviour it takes the following format:
folders:
- folder: [FolderName]
   location: [LocationName]

### If possible, provide screenshots.