### PR TITLE
Properly install RV_PACKAGE_LIST with rvpkg at the end of the build

### DIFF
--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -4,17 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Empty those lists at the begining of a configure stage
-SET(RV_PACKAGE_LIST
-    ""
-    CACHE INTERNAL ""
-)
-SET(INSTALLED_RV_PACKAGE_LIST
-    ""
-    CACHE INTERNAL ""
-)
-
-#
 # Create & populate a list of all the shared libraries for later testing.
 MACRO(ADD_SHARED_LIBRARY_LIST new_entry)
   LIST(APPEND _shared_libraries "${new_entry}")
@@ -403,12 +392,14 @@ FUNCTION(rv_stage)
 
     IF(NOT arg_FILES)
       FILE(
-              GLOB _files
-              RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-              *
+        GLOB _files
+        RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+        *
       )
-    else()
-      SET(_files ${arg_FILES})
+    ELSE()
+      SET(_files
+          ${arg_FILES}
+      )
     ENDIF()
 
     LIST(REMOVE_ITEM _files Makefile CMakeLists.txt ${_package_file})


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Summarize your change.

In #161, I introduced a change to clean the RV_PACKAGE_LIST at each configure stage so that if we update a package version, we don't have the old package in the RV_PACKAGE_LIST. This behaviour is buggy, so I prefer to revert that bit and try again another time with another approach. 

### Describe the reason for the change.

It breaks the rvinstall target that installs all the packages. 

### Describe what you have tested and on which operating system.

I tested on MacOS Ventura, but it's pretty much platform agnostic. 

### Add a list of changes and note any needing special attention during the review.

N/A

### If possible, provide screenshots.

N/A