### PR TITLE
Disable OpenSSL asm runtimes on Windows

### DIFF
--- a/src/build/make_openssl.py
+++ b/src/build/make_openssl.py
@@ -180,6 +180,7 @@ def configure() -> None:
             configure_args.append("darwin64-x86_64-cc")
     elif platform.system() == "Windows":
         configure_args.append("VC-WIN64A")
+        configure_args.append("no-asm")
     else:
         configure_args.append("linux-x86_64")
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Summarize your change.

Reverts #150 on Windows.

### Describe the reason for the change.

There are reports in the field that there are build failures related to nasm on the OpenSSL build. It seems to work fine in my test environment, but not everywhere. It's safe to disable it on Windows since it was disabled at first. It only got enabled because it was required on MacOS and I wanted to have the same configuration on all 3 platforms.

### Describe what you have tested and on which operating system.

It's a revert. It's the configuration that is being used in the Commercial RV build.

### Add a list of changes, and note any that might need special attention during the review.

N/A

### If possible, provide screenshots.

N/A