### PR TITLE
Copy OpenSSL files to Python build folder to fix _ssl and _hashlib

### DIFF
--- a/src/build/make_python.py
+++ b/src/build/make_python.py
@@ -487,6 +487,19 @@ def configure() -> None:
                     else:
                         makefile.write(new_line)
 
+    # Adds the openssl libs to the Python build environment.
+    openssl_libs = []
+    if platform.system() == "Darwin":
+        openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.dylib*"))
+    elif platform.system() == "Linux":
+        openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.so*"))
+    elif platform.system() == "Windows":
+        openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "bin", "lib*"))
+
+    for lib_path in openssl_libs:
+        print(f"Copying {lib_path} to the python source")
+        shutil.copyfile(lib_path, os.path.join(SOURCE_DIR, os.path.basename(lib_path)))
+
 
 def build() -> None:
     """
@@ -494,7 +507,6 @@ def build() -> None:
     """
 
     if platform.system() == "Windows":
-
         build_args = [
             os.path.join(SOURCE_DIR, "PCBuild", "build.bat"),
             "-p",


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

N/A

### Summarize your change.

Add the OpenSSL shared libraries to Python's build environment before building.

### Describe the reason for the change.

This is to avoid the error of not being able to build _ssl and _hashlib's native Python module. 

### Describe what you have tested and on which operating system.

- [x] Windows
- [x] MacOS 
- [x] Linux

### Add a list of changes, and note any that might need special attention during the review.

N/A

### If possible, provide screenshots.

Get's rid of 

```
Following modules built successfully but were removed because they could not be imported:
_hashlib              _ssl                                     


Could not build the ssl module!
Python requires an OpenSSL 1.0.2 or 1.1 compatible libssl with X509_VERIFY_PARAM_set1_host().
LibreSSL 2.6.4 and earlier do not provide the necessary APIs, https://github.com/libressl-portable/portable/issues/381
```