### PR TITLE
Rebuild packages on file changes

### DIFF
--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -394,6 +394,7 @@ FUNCTION(rv_stage)
       FILE(
               GLOB_RECURSE _files
               RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+              CONFIGURE_DEPENDS
               *
       )
     ELSE()

--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -451,7 +451,7 @@ FUNCTION(rv_stage)
     ADD_CUSTOM_COMMAND(
       COMMENT "Creating ${_package_filename} ..."
       OUTPUT ${_package_filename}
-      DEPENDS ${_temp_file}
+      DEPENDS ${_temp_file} ${_files} ${_package_file}
       COMMAND ${CMAKE_COMMAND} -E tar "cfv" ${_package_filename} --format=zip --files-from=${_temp_file}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )


### PR DESCRIPTION
### Summarize your change.

Adds the rv package content as a dependency to the .rvpkg file generation command.

### Describe the reason for the change.

When working on a package, building RV will now re-build and re-install the package.

### Describe what you have tested and on which operating system.

I had this change locally on my Mac while implementing a new feature and it's working well.

### Add a list of changes, and note any that might need special attention during the review.

N/A

### If possible, provide screenshots.

N/A