### PR TITLE
Add http headers to ffmpeg request

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -1140,6 +1140,13 @@ MovieFFMpegReader::openAVFormat()
                 av_dict_set_int(&fmtOptions, "reconnect", 1, 0);
                 av_dict_set_int(&fmtOptions, "multiple_requests", 1, 0);
             }
+            else if (name == "headers")
+            {
+                av_dict_set(&fmtOptions, "headers", value.c_str(), 0);
+                av_dict_set_int(&fmtOptions, "seekable", 1, 0);
+                av_dict_set_int(&fmtOptions, "reconnect", 1, 0);
+                av_dict_set_int(&fmtOptions, "multiple_requests", 1, 0);
+            }
         }
     }
 


### PR DESCRIPTION
This is a followup to my last branch that added an event medialibrary.  I forgot to include the file that actually adds the headers sent by the events to the ffmpeg request.