### PR TITLE
Fix build on Linux

### DIFF
--- a/src/lib/app/EventMediaLibrary/CMakeLists.txt
+++ b/src/lib/app/EventMediaLibrary/CMakeLists.txt
@@ -19,9 +19,16 @@ ADD_LIBRARY(
   ${_sources}
 )
 
+FIND_PACKAGE(
+  Qt5
+  COMPONENTS Core
+  REQUIRED
+)
+
 TARGET_LINK_LIBRARIES(
   ${_target}
   PUBLIC RvApp TwkMediaLibrary
+  PRIVATE Qt5::Core
 )
 
 TARGET_INCLUDE_DIRECTORIES(


### PR DESCRIPTION
Fix the build.

The build on Linux is broken because of a missing dependencies on `Qt5::Core`

The file `EventMediaLibrary.cpp` includes `<QtCore/QUrl>` so we need to link with the `Qt5::Core` library.