### PR TITLE
Fit first media correctly after launching RV

### DIFF
--- a/src/lib/ip/IPCore/IPCore/Session.h
+++ b/src/lib/ip/IPCore/IPCore/Session.h
@@ -1018,6 +1018,7 @@ class Session : public TwkApp::Document
     ProfilingRecordVector m_profilingSamples;
     Timer                m_profilingTimer;
 
+    bool                 m_preFirstNonEmptyRender;
     bool                 m_postFirstNonEmptyRender;
 
     const VideoDevice*   m_controlVideoDevice;

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -369,6 +369,7 @@ Session::Session(IPGraph* graph)
       m_syncLastTime(0),
       m_syncPredictionEnabled(true),
       m_syncTargetRefresh(-1.0),
+      m_preFirstNonEmptyRender(false),
       m_postFirstNonEmptyRender(false),
       m_batchMode(false),
       m_nextVSyncTime(0.0),
@@ -4506,7 +4507,12 @@ Session::userGenericEvent(const string& eventName,
     GenericStringEvent event(eventName, this, contents, senderName);
     sendEvent(event);
     m_currentSession = s;
-    if (!m_postFirstNonEmptyRender && eventName =="after-progressive-loading" ){
+
+    if (eventName == "before-progressive-loading") {
+        m_preFirstNonEmptyRender = true;
+    }
+
+    if (m_preFirstNonEmptyRender && !m_postFirstNonEmptyRender && eventName =="after-progressive-loading"){
         m_postFirstNonEmptyRender = true;
     } 
         


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.
Added a new bool var in Session.cpp to check for a certain event (before-progressive-loading) that happens before the "after-progressive-loading" event.
The m_postFirstNonEmptyRender variable used to delay the window fitting calls would always be called after launching RV, because an "after-progressive-loading" event is launched even if there are no media loaded (see RvApplication.cpp L:744).
The "before-progressive-loading" event is now used to prepare to check for the "after-progressive-loading" event. Because the former should only be called when media is wanting to get loaded.
There could have been a possibility to remove the "after-progressive-loading" event call in RvApplication.cpp, but since Session.cpp is not the only listener/receiver of events, it didn't feel wise to do. 
### Describe the reason for the change.
The "Fit Window to First media" checkbox wouldn't work when we loaded the media after launching RV.
### Describe what you have tested and on which operating system.
MacOS
### Add a list of changes, and note any that might need special attention during the review.
- Session.cpp/.h
### If possible, provide screenshots.