### PR TITLE
Enable optional FFmpeg and mio_ffmpeg customization

### DIFF
--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -4,11 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-ADD_CUSTOM_TARGET(dependencies)
-SET(RV_DEPS_LIST
-    ""
-    CACHE INTERNAL ""
-)
+IF(NOT TARGET dependencies)
+  ADD_CUSTOM_TARGET(dependencies)
+ENDIF()
+
+IF(NOT DEFINED RV_DEPS_LIST)
+  SET(RV_DEPS_LIST
+      ""
+      CACHE INTERNAL ""
+  )
+ENDIF()
 
 FIND_PACKAGE(Git QUIET)
 IF(GIT_FOUND

--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -212,6 +212,15 @@ IF(RV_TARGET_WINDOWS)
   )
 ENDIF()
 
+IF(RV_FFMPEG_POST_CONFIGURE_STEP)
+  EXTERNALPROJECT_ADD_STEP(
+    ${_target} post_configure_step
+    ${RV_FFMPEG_POST_CONFIGURE_STEP}
+    DEPENDEES configure
+    DEPENDERS build
+  )
+ENDIF()
+
 FILE(MAKE_DIRECTORY ${_include_dir})
 
 FOREACH(

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -5449,7 +5449,8 @@ MovieFFMpegIO::MovieFFMpegIO(CodecFilterFunction codecFilter,
                              bool bruteForce,
                              int codecThreads,
                              string language,
-                             double defaultFPS)
+                             double defaultFPS,
+                             void (*registerCustomCodecs)() /*=nullptr*/)
     : MovieIO("MovieFFMpeg","v2"),
       m_codecFilter(codecFilter)
 {
@@ -5464,6 +5465,9 @@ MovieFFMpegIO::MovieFFMpegIO(CodecFilterFunction codecFilter,
 
     // Store a default frame rate just in case
     setDoubleAttribute("defaultFPS", defaultFPS);
+
+    // Register custom codecs if requested (optional)
+    if (registerCustomCodecs) registerCustomCodecs();
 
     // Init av
     avformat_network_init();

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
@@ -79,7 +79,8 @@ class MovieFFMpegIO : public MovieIO
                   bool bruteForce,
                   int codecThreads,
                   std::string language,
-                  double defaultFPS);
+                  double defaultFPS,
+                  void (*registerCustomCodecs)()=nullptr);
 
     virtual ~MovieFFMpegIO();
 

--- a/src/lib/image/mio_ffmpeg/CMakeLists.txt
+++ b/src/lib/image/mio_ffmpeg/CMakeLists.txt
@@ -4,29 +4,39 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-INCLUDE(cxx_defaults)
-
-SET(_target
-    "mio_ffmpeg"
+# Note: This cache variable can be overriden to FALSE in a super-project if a custom mio_ffmpeg is built as part of that super-project.
+SET(RV_BUILD_MIO_FFMPEG
+    TRUE
+    CACHE BOOL "Whether or not to build the Open RV mio_ffmpeg movie plugin"
 )
 
-LIST(APPEND _sources init.cpp)
+IF(RV_BUILD_MIO_FFMPEG)
 
-ADD_LIBRARY(
-  ${_target} SHARED
-  ${_sources}
-)
+  INCLUDE(cxx_defaults)
 
-TARGET_LINK_LIBRARIES(
-  ${_target}
-  PRIVATE MovieFFMpeg Boost::program_options TwkFB
-)
-
-IF(RV_TARGET_WINDOWS)
-  TARGET_COMPILE_OPTIONS(
-    ${_target}
-    PRIVATE "-D__STDC_CONSTANT_MACROS"
+  SET(_target
+      "mio_ffmpeg"
   )
-ENDIF()
 
-RV_STAGE(TYPE "MOVIE_FORMAT" TARGET ${_target})
+  LIST(APPEND _sources init.cpp)
+
+  ADD_LIBRARY(
+    ${_target} SHARED
+    ${_sources}
+  )
+
+  TARGET_LINK_LIBRARIES(
+    ${_target}
+    PRIVATE MovieFFMpeg Boost::program_options TwkFB
+  )
+
+  IF(RV_TARGET_WINDOWS)
+    TARGET_COMPILE_OPTIONS(
+      ${_target}
+      PRIVATE "-D__STDC_CONSTANT_MACROS"
+    )
+  ENDIF()
+
+  RV_STAGE(TYPE "MOVIE_FORMAT" TARGET ${_target})
+
+ENDIF() # IF (RV_BUILD_MIO_FFMPEG)


### PR DESCRIPTION
[ Enable optional FFmpeg and mio_ffmpeg customization ]

### Linked issues

### Describe the reason for the change.

These small changes are required so that one can customize both FFmpeg and mio_ffmpeg if say one project was to consume Open RV as a submodule.

### Summarize your change.

-  Only add cmake custom target 'dependencies' but only if it hasn't been created already (ADD_CUSTOM_TARGET(dependencies))-To allow a project consuming Open RV as a sub-module to add the target first.
-  FFmpeg.cmake : Add an optional post_configure_step that is added only if the RV_FFMPEG_POST_CONFIGURE_STEP cmake variable is defined-To allow applying patches/customization to FFmpeg.
- mio_ffmpeg : Skip building of Open RV mio_ffmpeg if cmake var OPEN_RV_SKIP_MIO_FFMPEG is set (optional) - To enable a project consuming Open RV as a sub-module to build its own customized version.
- MovieFFMpeg : Now set the cmake variable MOVIE_FFMPEG_SOURCE_DIR so that a project consuming Open RV as a sub-module can build its own customized version.
- MovieFFMpeg.cpp : Added  a mechanism to register custom codecs when MOVIE_FFMPEG_IO_REGISTER_CUSTOM_CODEC is defined.

### Describe what you have tested and on which operating system.

Successfully built on all platforms and tested on macOS

