### PR TITLE
Fix RV crashes when creating new viewable stack

### DIFF
--- a/src/plugins/rv-packages/session_manager/PACKAGE
+++ b/src/plugins/rv-packages/session_manager/PACKAGE
@@ -1,7 +1,7 @@
 package: Session Manager
 author: Autodesk, Inc.
 organization: Autodesk, Inc.
-version: 1.8
+version: 1.9
 rv: 3.12.15
 openrv: 1.0.0
 requires: ''

--- a/src/plugins/rv-packages/session_manager/session_manager.mu
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu
@@ -982,6 +982,7 @@ class: SessionManagerMode : MinorMode
     QIcon              _videoIcon;
     bool               _inputOrderLock;
     bool               _disableUpdates;
+    bool               _progressiveLoadingInProgress;
     QTimer             _lazySetInputsTimer;
     QTimer             _lazyUpdateTimer;
     QTimer             _mainWinVisTimer;
@@ -1345,7 +1346,7 @@ class: SessionManagerMode : MinorMode
 
     method: updateInputs (void; string node)
     {
-        if (_disableUpdates) return;
+        if (_disableUpdates || _progressiveLoadingInProgress) return;
 
         _inputOrderLock = true;
 
@@ -1943,13 +1944,13 @@ class: SessionManagerMode : MinorMode
     method: beforeProgressiveLoading (void; Event event)
     {
         event.reject();
-        _disableUpdates = true;
+        _progressiveLoadingInProgress = true;
     }
 
     method: afterProgressiveLoading (void; Event event)
     {
         event.reject();
-        _disableUpdates = false;
+        _progressiveLoadingInProgress = false;
         updateTree();
         updateInputs(viewNode());
     }
@@ -2825,7 +2826,8 @@ class: SessionManagerMode : MinorMode
         _inputOrderLock = false;
         _editors        = QTreeWidgetItem[]();
         _quitting       = false;
-        _disableUpdates = (loadTotal() != 0);
+        _disableUpdates = false;
+        _progressiveLoadingInProgress = (loadTotal() != 0);
 
         init(name,
              [ ("new-node", updateTreeEvent, "New user node"),


### PR DESCRIPTION
Fix RV crashes when creating new viewable stack

### Linked issues

### Summarize your change.

This PR fixes RV crashes when creating a new viewable stack

#### Problem
In RV, one can use the Session Manager to select multiple layers of an OpenEXR image file and create a viewable stack with them:
<img width="1027" alt="how_to_create_a_new_viewable_stack_in_RV" src="https://github.com/AcademySoftwareFoundation/OpenRV/assets/117092886/4519384a-da3d-4e5a-82c5-f17241fff180">

Since RV 2021.0.3, this workflow makes RV crash.

#### Cause
This issue was introduced in RV 2021.0.3. 
It is an unfortunate side effect of a cleanup we did with the before-progressive-loading and after-progressive-loading events (they were not consistently generated).
The crash occurs because the QTreeView is being modified behind the scene while we iterate through its elements.
Now there is a variable dedicated to disabling the updates while we are iterating through the QTreeView : _disableUpdates. But the after-progressive-loading event automatically re-enable the updates which is exactly why RV crash in this particular scenario: 
1. _disableUpdates is set to true
2. then we iterate through the the QTreeView elements
3. A source is created, he after-progressive-loading event automatically re-enables the updates : _disableUpdates=false
4. When continuing the iteration of the QTreeView elements, a crash occurs because the QTreeView has changed.

#### Solution
In a perfect world, we would have been able to change the type of _disableUpdates to an int and increment/decrement the variable accordingly. But I don't think we can guarantee at this point that relevant events affecting the _disableUpdates variables are symmetrical. Therefore I am proposing the following simple scheme instead:
I added another variable to keep track of the progressive source loading : _progressiveLoadingInProgress.
So when either _progressiveLoadingInProgress OR _disableUpdates
This way, even if a new source is created while iterating through the UI, then the updates are kept disabled.

### Describe what you have tested and on which operating system.
Tested on MacOS (platform independent code - mu)

### Add a list of changes, and note any that might need special attention during the review.
