### PR TITLE
Fix Windows FFMpeg build error

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -226,17 +226,6 @@ EXTERNALPROJECT_ADD(
   USES_TERMINAL_BUILD TRUE
 )
 
-# The enable-openssl config option expects the openssl names not to prefixed with lib, but our build of OpenSSL does add this prefix, so we'll make a copy of
-# the implibs to make it work correctly
-IF(RV_TARGET_WINDOWS)
-  EXTERNALPROJECT_ADD_STEP(
-    ${_target} copy_implibs
-    COMMAND ${CMAKE_COMMAND} -E copy ${RV_DEPS_OPENSSL_LIB_DIR}/libssl.lib ${RV_DEPS_OPENSSL_LIB_DIR}/ssl.lib
-    COMMAND ${CMAKE_COMMAND} -E copy ${RV_DEPS_OPENSSL_LIB_DIR}/libcrypto.lib ${RV_DEPS_OPENSSL_LIB_DIR}/crypto.lib
-    DEPENDERS configure
-  )
-ENDIF()
-
 IF(RV_FFMPEG_POST_CONFIGURE_STEP)
   EXTERNALPROJECT_ADD_STEP(
     ${_target} post_configure_step

--- a/cmake/dependencies/openssl.cmake
+++ b/cmake/dependencies/openssl.cmake
@@ -128,6 +128,17 @@ EXTERNALPROJECT_ADD(
   USES_TERMINAL_BUILD TRUE
 )
 
+# The enable-openssl config option expects the openssl names not to prefixed with lib, but our build of OpenSSL does add this prefix, so we'll make a copy of
+# the implibs to make it work correctly
+IF(RV_TARGET_WINDOWS)
+  EXTERNALPROJECT_ADD_STEP(
+    ${_target} copy_implibs
+    COMMAND ${CMAKE_COMMAND} -E copy ${_install_dir}/lib/libssl.lib ${_install_dir}/lib/ssl.lib
+    COMMAND ${CMAKE_COMMAND} -E copy ${_install_dir}/lib/libcrypto.lib ${_install_dir}/lib/crypto.lib
+    DEPENDERS configure
+  )
+ENDIF()
+
 FILE(MAKE_DIRECTORY ${_include_dir})
 
 ADD_LIBRARY(OpenSSL::Crypto SHARED IMPORTED GLOBAL)


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.
Changed the copy_implibs step for the Windows build

### Describe the reason for the change.
RV_DEPS_OPENSSL_LIB_DIR doesn't exist anymore, so the paths are wrong
### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.