### PR TITLE
Fixing FFMpeg multiplatform build

### DIFF
--- a/cmake/dependencies/dav1d.cmake
+++ b/cmake/dependencies/dav1d.cmake
@@ -46,13 +46,17 @@ SET(_dav1d_lib
     ${_lib_dir}/${_david_lib_name}
 )
 
+# Required for configuring ffmpeg build
+SET(RV_DEPS_DAVID_LIB_DIR
+    ${_lib_dir}
+    CACHE INTERNAL ""
+)
+
 IF(RV_TARGET_WINDOWS)
   LIST(APPEND RV_FFMPEG_EXTRA_LIBPATH_OPTIONS "--extra-ldflags=-LIBPATH:${_lib_dir}")
 ELSE()
   LIST(APPEND RV_FFMPEG_EXTRA_LIBPATH_OPTIONS "--extra-ldflags=-L${_lib_dir}")
 ENDIF()
-
-LIST(APPEND RV_FFMPEG_EXTRA_LIBPATH_OPTIONS "--extra-ldflags=-ldav1d")
 
 LIST(APPEND RV_FFMPEG_EXTRA_C_OPTIONS "--extra-cflags=-I${_include_dir}")
 

--- a/cmake/dependencies/openssl.cmake
+++ b/cmake/dependencies/openssl.cmake
@@ -49,9 +49,6 @@ ELSE()
   LIST(APPEND RV_FFMPEG_EXTRA_LIBPATH_OPTIONS "--extra-ldflags=-L${_lib_dir}")
 ENDIF()
 
-LIST(APPEND RV_FFMPEG_EXTRA_LIBPATH_OPTIONS "--extra-ldflags=-lssl")
-LIST(APPEND RV_FFMPEG_EXTRA_LIBPATH_OPTIONS "--extra-ldflags=-lcrypto")
-
 LIST(APPEND RV_FFMPEG_EXTRA_C_OPTIONS "--extra-cflags=-I${_include_dir}")
 
 LIST(APPEND RV_FFMPEG_EXTERNAL_LIBS "--enable-openssl")
@@ -110,6 +107,12 @@ SET(_ssl_lib
     ${_lib_dir}/${_ssl_lib_name}
 )
 
+# Required for configuring ffmpeg build
+SET(RV_DEPS_OPENSSL_LIB_DIR
+    ${_lib_dir}
+    CACHE INTERNAL ""
+)
+
 EXTERNALPROJECT_ADD(
   ${_target}
   DOWNLOAD_NAME ${_target}_${_version}.zip
@@ -127,17 +130,6 @@ EXTERNALPROJECT_ADD(
   BUILD_BYPRODUCTS ${_crypto_lib} ${_ssl_lib}
   USES_TERMINAL_BUILD TRUE
 )
-
-# The enable-openssl config option expects the openssl names not to prefixed with lib, but our build of OpenSSL does add this prefix, so we'll make a copy of
-# the implibs to make it work correctly
-IF(RV_TARGET_WINDOWS)
-  EXTERNALPROJECT_ADD_STEP(
-    ${_target} copy_implibs
-    COMMAND ${CMAKE_COMMAND} -E copy ${_install_dir}/lib/libssl.lib ${_install_dir}/lib/ssl.lib
-    COMMAND ${CMAKE_COMMAND} -E copy ${_install_dir}/lib/libcrypto.lib ${_install_dir}/lib/crypto.lib
-    DEPENDERS configure
-  )
-ENDIF()
 
 FILE(MAKE_DIRECTORY ${_include_dir})
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.
Fixed issues with the FFMpeg build for Windows and Linux, introduced with (or, unaccounted for with) the new configurable FFMpeg system I introduced, sorry!

What I think happened is that I added library flags inside the dav1d and OpenSSL `.cmake` files, which I think were conflicting with the pkg_config files for those dependencies.

### Describe the reason for the change.
Fix the default configure step for FFMpeg, so we can actually build Open RV.

### Describe what you have tested and on which operating system.
Tested on my MacOS system. Also Windows 10 and Linux Rocky 9 machines.
### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.