### PR TITLE
Fix crash when loading a multi-files src with mixed avail

### DIFF
--- a/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
@@ -2466,6 +2466,14 @@ FileSourceIPNode::reloadMediaFromFiles()
 
     m_mediaMovies->valueContainer() = media;
 
+    // 
+    // First assume that the media files are all available (active)
+    // Note that if any of the media file associated with this FileSourceIPNode
+    // is unreachable, then setMediaActive(false) will be called.
+    // For reference : FileSourceIPNode::openMovieTask()
+    // 
+    m_mediaActive->front() = 1;
+
     //
     //  Sync media files
     //
@@ -2615,10 +2623,6 @@ FileSourceIPNode::openMovieTask(const string& filename,
         str << name() << ";;" << file << ";;" << mediaRepName();
         TwkApp::GenericStringEvent event("source-media-unavailable", graph(), str.str());
         graph()->sendEvent(event);
-    }
-    else
-    {
-        setMediaActive(true);
     }
 
     SharedMediaPointer sharedMedia(newSharedMedia(mov, true /*hasValidRange*/));


### PR DESCRIPTION
### Fix RV crash when loading a multi-files src with mixed availability 

### Linked issues

### Describe the reason for the change.

#### Problem:
A user reported some RV crashes on Windows when a session file contained file sources with unreachable media (because the media was not available locally).
We were not able to reproduce until the client informed us that the crashes were only occurring when the multiple files associated with a single file source in the RV session were not ALL available. 
That was the key that allowed me to reproduce the issue.

### Summarize your change.

#### Cause
Normally, an RVFileSource is only comprised of a single file. However, RV also supports stereoscopic images (left + right) and also having the audio file separated from the video file. The latter was the user case here.
In the scenario that was causing the crash, an RVFileSource was composed of a media file (an openEXR image) which was NOT available locally, and an audio file (a .wav) which was available locally.
This special scenario was causing RV to enter an infinite loop because this problematic scenario had never been considered:
1. RV was first trying to load the image file : it was missing so the media was flagged as inactive
2. Then the audio file was successfully loaded, so the media associated with the FileSourceIPNode was flagged as active which and was then trying to load the missing image media. 
3. Goto 1.

#### Solution
Now, at the beginning of FileSourceIPNode::reloadMediaFromFiles(), which is in charge of loading every single media belonging to the same FileSourceIPNode,  we first assume that the media files are all available (active).
Note that this was already the case but I made it explicit.
In FileSourceIPNode::openMovieTask(), we no longer set the activeness of the media to true when one media successfully load because we have no guarantee that all the media composing this FileSourceIPNode is actually available and the order could be random in the case of progressive source loading.
However, if at least one media is not available then we call setMediaActive(false) (just like before, no change).


