### PR TITLE
Fix examples in doc not working because of outdated syntax

### DIFF
--- a/docs/rv-manuals/rv-mu-programming.md
+++ b/docs/rv-manuals/rv-mu-programming.md
@@ -2,6 +2,8 @@
 
 ## 1. Overview ‌ ‌
 
+You can use Python3 in RV in conjunction with Mu or in place of it. It's even possible to call Python commands from Mu and vice versa. Python is a full peer to Mu as far as RV is concerned. So in answer to the question: which language should I use to customize RV? At this point, we recommend using Python.
+
 Mu is principally targeted towards computer graphics applications. The original (usable) version appeared at Tweak Films around 2001-2002. Over the years its syntax and runtime has been refactored and evolved from a simple shading language to a nearly full featured general language. However, Mu is still probably best suited for computer graphics than other computing tasks.
 
 The following discussion is mostly a result of experience in the feature film special effects industry (which I’ll call film). One could argue that computing tasks for film are extreme in many cases and that achievements and trends there tend to trickle down into related CG disciplines (like games and television post production). Indeed, over a short period of time the distinction between these CG disciplines has blurred.

--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-four.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-four.md
@@ -1,6 +1,6 @@
 # Chapter 4 - Python
 
-You can use Python3 in RV in conjunction with Mu or in place of it. It's even possible to call Python commands from Mu and vice versa. Python is a full peer to Mu as far as RV is concerned. So in answer to the question: which language should I use to customize RV? The answer is whichever you like. At this point we recommend using Python. There are some slight differences that need to be noted when translating code between the two languages: In Python the modules names required by RV are the same as in Mu. As of this writing, these are commands, extra_commands, rvtypes, and rvui. However, the Python modules all live in the rv package. This package is in-memory and only available at RV's runtime. You can access these commands via writing your own custom MinorMode package. So while in Mu, you can:
+You can use Python3 in RV in conjunction with Mu or in place of it. It's even possible to call Python commands from Mu and vice versa. Python is a full peer to Mu as far as RV is concerned. So in answer to the question: which language should I use to customize RV? At this point, we recommend using Python. There are some slight differences that need to be noted when translating code between the two languages: In Python the modules names required by RV are the same as in Mu. As of this writing, these are commands, extra_commands, rvtypes, and rvui. However, the Python modules all live in the rv package. This package is in-memory and only available at RV's runtime. You can access these commands via writing your own custom MinorMode package. So while in Mu, you can:
 
 ```
  use commands 
@@ -135,7 +135,7 @@ let pyModule = python.PyImport_Import ("os");
 
 python.PyObject pyMethod = python.PyObject_GetAttr (pyModule, "getcwd");
 
-string result = to_string(python.PyObject_CallObject (pyMethod, PyTuple_New(0)));
+string result = to_string(python.PyObject_CallObject (pyMethod, python.PyTuple_New(0)));
 
 print("result: %s\n" % result); // Prints "result: /var/tmp" 
 ```
@@ -198,12 +198,13 @@ Table 4.1:Mu-Python Value Conversion
 You can use PySide2 to make Qt interface components (RV is a Qt Application). Below is a simple pyside example using RV's py-interp.
 
 ```python
-#!/Applications/RV64.app/Contents/MacOS/py-interp
+#!/Applications/RV.app/Contents/MacOS/py-interp
 
-# Import PySide classes
+# Import PySide2 classes
 import sys
-from PySide.QtCore import *
-from PySide.QtGui import *
+from PySide2.QtCore import *
+from PySide2.QtGui import *
+from PySide2.QtWidgets import *
 
 # Create a Qt application.
 # IMPORTANT: RV's py-interp contains an instance of QApplication;
@@ -213,10 +214,10 @@ if app == None:
     app = QApplication(sys.argv)
 
 # Display the file path of the app.
-print app.applicationFilePath()
+print(f"{app.applicationFilePath()}")
 
 # Create a Label and show it.
-label = QLabel("Using RV's PySide")
+label = QLabel("Using RV's PySide2")
 label.show()
 
 # Enter Qt application main loop.


### PR DESCRIPTION
### Fix examples in doc not working because of outdated syntax

### Linked issues

### Describe the reason for the change.

A user reported that the fourth chapter of the RV reference manual contained examples that were using outdated syntax and therefore could not be executed.

### Summarize your change.

I have tested all the examples in the fourth chapter of the RV reference manual and two of them had outdated syntax which was corrected in this commit.

Additionally, a note was added to the Mu documentation to inform the user that the recommended RV scripting language is Python (not Mu).

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.