### PR TITLE
Issue-162: OCIO v2 configs don't work on Mac; shader compiler fail

### DIFF
--- a/cmake/dependencies/oiio.cmake
+++ b/cmake/dependencies/oiio.cmake
@@ -168,7 +168,6 @@ IF(NOT RV_TARGET_WINDOWS)
     DEPENDS ${_depends_freetype}
             jpeg-turbo::jpeg
             Tiff::Tiff
-            RV_DEPS_OCIO
             OpenEXR::OpenEXR
             RV_DEPS_OPENJPEG
             jpeg-turbo::turbojpeg
@@ -227,7 +226,6 @@ ELSE()
     DEPENDS ${_depends_freetype}
             jpeg-turbo::jpeg
             Tiff::Tiff
-            RV_DEPS_OCIO
             OpenEXR::OpenEXR
             OpenJpeg::OpenJpeg
             jpeg-turbo::turbojpeg

--- a/cmake/dependencies/webp.cmake
+++ b/cmake/dependencies/webp.cmake
@@ -27,7 +27,14 @@ SET(_download_hash
     "ef5ac6de4b800afaebeb10df9ef189b2"
 )
 
-RV_MAKE_STANDARD_LIB_NAME("webp" "${_version}" "STATIC" "d")
+IF(RV_TARGET_DARWIN
+   OR RV_TARGET_LINUX
+)
+  # WebP lib on Darwin&Linux is built without a version number.
+  RV_MAKE_STANDARD_LIB_NAME("webp" "" "STATIC" "d")
+ELSE()
+  RV_MAKE_STANDARD_LIB_NAME("webp" "${_version}" "STATIC" "d")
+ENDIF()
 
 # The '_configure_options' list gets reset and initialized in 'RV_CREATE_STANDARD_DEPS_VARIABLES'
 GET_TARGET_PROPERTY(_zlib_library ZLIB::ZLIB IMPORTED_LOCATION)

--- a/src/lib/ip/IPCore/IPCore/ShaderFunction.h
+++ b/src/lib/ip/IPCore/IPCore/ShaderFunction.h
@@ -138,6 +138,7 @@ class Function
              const std::string& doc="");
 
     static void useShadingLanguageVersion(const char*);
+    static bool isGLSLVersionLessThan150();
 
     const std::string& name() const { return m_name; }
     const std::string& callName() const { return m_callName; }

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -390,10 +390,10 @@ OCIOIPNode::evaluate(const Context& context)
         }
 
         QMutexLocker(&this->m_lock);
-        OCIO::ConstGPUProcessorRcPtr legacyGPUProcessor = processor->getOptimizedLegacyGPUProcessor(OCIO::OPTIMIZATION_NONE, lutSize);
         OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
-        shaderDesc->setLanguage(GPULanguage);
         shaderDesc->setFunctionName(shaderName.str().c_str());
+        shaderDesc->setLanguage(GPULanguage);
+        OCIO::ConstGPUProcessorRcPtr legacyGPUProcessor = processor->getOptimizedLegacyGPUProcessor(OCIO::OPTIMIZATION_DEFAULT, lutSize);
 
         // Fills the shaderDesc from the proc.
         legacyGPUProcessor->extractGpuShaderInfo(shaderDesc);


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Fixing OCIO v2 config shader compiler failures on Mac
### Linked issues
N/A

### Summarize your change.

The version comparison doesn't even check the GLSL version, maybe it should. For higher than GLSL 150, we will keep the current code. If the version is less than 150, we will use "version 120" as the header and remove the extension GL_ARB_texture header.

### Describe the reason for the change.

Mac fails to build with the current GLSL header.

### Describe what you have tested and on which operating system.

Tested on Mac Ventura 13.2.1, Rocky 8 Dbg config.

### Add a list of changes, and note any that might need special attention during the review.

Removing OCIO dep from OIIO as our OIIO config doesn't need OCIO 
Fixing byproducts for WebP on Mac and Linux for iterative builds 
Tweaking OCIO pipeline code in OCIOIPNode and setting the GPUProc as OPT_DEFAULT instead of OPT_NONE. ocioconvert uses OPT_DEFAULT for legacy 
Fixing bad GLSL Version comparison for Mac. We may need to iterate on this fix 
Fixing the Annonate Output when GLSL fails as it wasn't showing the exact GLSL that failed

### If possible, provide screenshots.

<img width="1028" alt="FixMarciNotShadedV2Mac" src="https://github.com/AcademySoftwareFoundation/OpenRV/assets/69678953/cb8a65f4-7dcd-44ea-bb3a-ca5d0ede97ba">
