### PR TITLE
Add synchronous spdlog logger to debug crashes

### DIFF
--- a/src/lib/base/TwkUtil/FileLogger.cpp
+++ b/src/lib/base/TwkUtil/FileLogger.cpp
@@ -1,8 +1,8 @@
 //******************************************************************************
 // Copyright (c) 2023 Autodesk Inc. All rights reserved.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 //******************************************************************************
 
 #include <ostream>
@@ -13,91 +13,109 @@
 #include "TwkUtil/FileLogger.h"
 #include "TwkUtil/EnvVar.h"
 
-namespace TwkUtil {
+namespace TwkUtil
+{
 
-    static ENVVAR_STRING(evFileLogLevel, "RV_FILE_LOG_LEVEL", "debug");
-    static ENVVAR_INT(evFileLogSize, "RV_FILE_LOG_SIZE", 1024*1024*5); // Default: 5MB
-    static ENVVAR_INT(evFileLogNumFiles, "RV_FILE_LOG_NUM_FILES", 2);
-    static ENVVAR_BOOL(evFileLogSynchronous, "RV_FILE_LOG_SYNCHRONOUS", false);
+  static ENVVAR_STRING( evFileLogLevel, "RV_FILE_LOG_LEVEL", "debug" );
+  static ENVVAR_INT( evFileLogSize, "RV_FILE_LOG_SIZE",
+                     1024 * 1024 * 5 );  // Default: 5MB
+  static ENVVAR_INT( evFileLogNumFiles, "RV_FILE_LOG_NUM_FILES", 2 );
+  static ENVVAR_BOOL( evFileLogSynchronous, "RV_FILE_LOG_SYNCHRONOUS", false );
 
-    FileLogger::FileLogger()
+  FileLogger::FileLogger()
+  {
+#if defined( PLATFORM_DARWIN )
+    std::string logFilePath =
+        QDir::homePath().toStdString() + "/Library/Logs/" +
+        QCoreApplication::organizationName().toStdString() + "/";
+#else
+    std::string logFilePath =
+        QStandardPaths::writableLocation( QStandardPaths::AppDataLocation )
+            .toStdString() +
+        "/";
+#endif
+    std::cout << "INFO: File logger path: " << logFilePath << '\n';
+
+    std::string name = QCoreApplication::applicationName().toStdString();
+
+    if( evFileLogSynchronous.getValue() )
     {
-    #if defined(PLATFORM_DARWIN)
-        std::string logFilePath = QDir::homePath().toStdString() + "/Library/Logs/" + QCoreApplication::organizationName().toStdString() + "/";
-    #else
-        std::string logFilePath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() +  "/";
-    #endif
-        std::cout << "INFO: File logger path: " << logFilePath << '\n';
+      m_logger = spdlog::rotating_logger_mt(
+                     name, logFilePath.append( name + ".log" ),
+                     evFileLogSize.getValue(), evFileLogNumFiles.getValue() )
+                     .get();
 
-        std::string name = QCoreApplication::applicationName().toStdString();
-
-        if(evFileLogSynchronous.getValue())
-        {
-            m_logger = spdlog::rotating_logger_mt(
-                name,
-                logFilePath.append(name + ".log"),
-                evFileLogSize.getValue(),
-                evFileLogNumFiles.getValue()
-            ).get();
-
-            m_logger->flush_on(spdlog::level::trace);  // All message levels will be flush to disk
-        } else {
-            m_logger = spdlog::rotating_logger_mt<spdlog::async_factory>(
-                name,
-                logFilePath.append(name + ".log"),
-                evFileLogSize.getValue(),
-                evFileLogNumFiles.getValue()
-            ).get();
-        }
-
-        setLogLevel(evFileLogLevel.getValue());
-
-        m_logger->info("============ SESSION START ============");
+      m_logger->flush_on(
+          spdlog::level::trace );  // All message levels will be flush to disk
     }
-
-    FileLogger::~FileLogger() {
-        m_logger->info("============  SESSION END  ============");        
-    }
-
-    void FileLogger::logToFile(spdlog::level::level_enum lineLevel, std::string& line)
+    else
     {
-        // Remove the unecessary newline for the log file (it would 'double space' each line in the log)
-        boost::trim_right(line);
-        switch (lineLevel)
-        {
-            case spdlog::level::debug: m_logger->debug(line); break;
-            case spdlog::level::info: m_logger->info(line); break;
-            case spdlog::level::warn: m_logger->warn(line); break;
-            case spdlog::level::err: m_logger->error(line); break;
-            default: break;
-        }
+      m_logger = spdlog::rotating_logger_mt<spdlog::async_factory>(
+                     name, logFilePath.append( name + ".log" ),
+                     evFileLogSize.getValue(), evFileLogNumFiles.getValue() )
+                     .get();
     }
 
-    void FileLogger::setLogLevel(const std::string& level)
+    setLogLevel( evFileLogLevel.getValue() );
+
+    m_logger->info( "============ SESSION START ============" );
+  }
+
+  FileLogger::~FileLogger()
+  {
+    m_logger->info( "============  SESSION END  ============" );
+  }
+
+  void FileLogger::logToFile( spdlog::level::level_enum lineLevel,
+                              std::string& line )
+  {
+    // Remove the unecessary newline for the log file (it would 'double space'
+    // each line in the log)
+    boost::trim_right( line );
+    switch( lineLevel )
     {
-        if (level == "trace")
-        {
-            m_logger->set_level(spdlog::level::trace);
-        }
-        else if (level == "debug" || level == "deb")
-        {
-            m_logger->set_level(spdlog::level::debug);
-        }
-        else if (level == "info")
-        {
-            m_logger->set_level(spdlog::level::info);
-        }
-        else if (level ==  "warning" || level == "warn")
-        {
-            m_logger->set_level(spdlog::level::warn);
-        }
-        else if (level == "error")
-        {
-            m_logger->set_level(spdlog::level::err);
-        }
-        else if (level == "critical")
-        {
-            m_logger->set_level(spdlog::level::critical);
-        }
+      case spdlog::level::debug:
+        m_logger->debug( line );
+        break;
+      case spdlog::level::info:
+        m_logger->info( line );
+        break;
+      case spdlog::level::warn:
+        m_logger->warn( line );
+        break;
+      case spdlog::level::err:
+        m_logger->error( line );
+        break;
+      default:
+        break;
     }
-}
+  }
+
+  void FileLogger::setLogLevel( const std::string& level )
+  {
+    if( level == "trace" )
+    {
+      m_logger->set_level( spdlog::level::trace );
+    }
+    else if( level == "debug" || level == "deb" )
+    {
+      m_logger->set_level( spdlog::level::debug );
+    }
+    else if( level == "info" )
+    {
+      m_logger->set_level( spdlog::level::info );
+    }
+    else if( level == "warning" || level == "warn" )
+    {
+      m_logger->set_level( spdlog::level::warn );
+    }
+    else if( level == "error" )
+    {
+      m_logger->set_level( spdlog::level::err );
+    }
+    else if( level == "critical" )
+    {
+      m_logger->set_level( spdlog::level::critical );
+    }
+  }
+}  // namespace TwkUtil

--- a/src/lib/base/TwkUtil/FileLogger.cpp
+++ b/src/lib/base/TwkUtil/FileLogger.cpp
@@ -54,6 +54,8 @@ namespace TwkUtil
                      name, logFilePath.append( name + ".log" ),
                      evFileLogSize.getValue(), evFileLogNumFiles.getValue() )
                      .get();
+      m_logger->flush_on(
+          spdlog::level::err );
     }
 
     setLogLevel( evFileLogLevel.getValue() );

--- a/src/lib/base/TwkUtil/FileLogger.cpp
+++ b/src/lib/base/TwkUtil/FileLogger.cpp
@@ -5,13 +5,13 @@
 //
 //******************************************************************************
 
-#include <ostream>
+#include <TwkUtil/FileLogger.h>
+#include <TwkUtil/EnvVar.h>
 #include <QtCore/QtCore>
+#include <spdlog/async.h>
+#include <spdlog/sinks/rotating_file_sink.h>
 #include <boost/algorithm/string.hpp>
-#include "spdlog/async.h"
-#include "spdlog/sinks/rotating_file_sink.h"
-#include "TwkUtil/FileLogger.h"
-#include "TwkUtil/EnvVar.h"
+#include <ostream>
 
 namespace TwkUtil
 {

--- a/src/lib/base/TwkUtil/TwkUtil/FileLogger.h
+++ b/src/lib/base/TwkUtil/TwkUtil/FileLogger.h
@@ -8,9 +8,9 @@
 #ifndef _TwkUtilLog_h_
 #define _TwkUtilLog_h_
 
+#include <TwkUtil/dll_defs.h>
+#include <spdlog/logger.h>
 #include <string>
-#include "spdlog/logger.h"
-#include "TwkUtil/dll_defs.h"
 
 namespace TwkUtil
 {

--- a/src/lib/base/TwkUtil/TwkUtil/FileLogger.h
+++ b/src/lib/base/TwkUtil/TwkUtil/FileLogger.h
@@ -1,8 +1,8 @@
 //******************************************************************************
 // Copyright (c) 2023 Autodesk Inc. All rights reserved.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
-// 
+//
 //******************************************************************************
 
 #ifndef _TwkUtilLog_h_
@@ -12,21 +12,23 @@
 #include "spdlog/logger.h"
 #include "TwkUtil/dll_defs.h"
 
-namespace TwkUtil {
-
-class TWKUTIL_EXPORT FileLogger
+namespace TwkUtil
 {
-public:
+
+  class TWKUTIL_EXPORT FileLogger
+  {
+   public:
     FileLogger();
     ~FileLogger();
 
-    void logToFile(spdlog::level::level_enum lineLevel, std::string& line);
-private:
-    spdlog::logger*             m_logger;
+    void logToFile( spdlog::level::level_enum lineLevel, std::string& line );
 
-    void setLogLevel(const std::string& level);
-};
+   private:
+    spdlog::logger* m_logger;
 
-}
+    void setLogLevel( const std::string& level );
+  };
+
+}  // namespace TwkUtil
 
 #endif

--- a/src/lib/base/TwkUtil/TwkUtil/FileLogger.h
+++ b/src/lib/base/TwkUtil/TwkUtil/FileLogger.h
@@ -8,12 +8,9 @@
 #ifndef _TwkUtilLog_h_
 #define _TwkUtilLog_h_
 
-#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
-
-#include <TwkUtil/dll_defs.h>
-#include <spdlog/logger.h>
 #include <string>
-#include <iostream>
+#include "spdlog/logger.h"
+#include "TwkUtil/dll_defs.h"
 
 namespace TwkUtil {
 


### PR DESCRIPTION
### Add synchronous spdlog logger to debug crashes

### Summarize your change.

A synchronous version of the spdlog logger can now be used to get some logs to debug RV on crashes.

### Describe the reason for the change.

With the async nature of the logger, the logger file was empty if a crash occurred since the content of the logger's buffer didn't had the time to flush its content to disk.

### Describe what you have tested and on which operating system.

The feature was tested on MacOS.

Using commercial RV (so that you can have access to the Python Console):

1. Change `static ENVVAR_BOOL(evFileLogSynchronous, "RV_FILE_LOG_SYNCHRONOUS", false);` to `static ENVVAR_BOOL(evFileLogSynchronous, "RV_FILE_LOG_SYNCHRONOUS", true);`
2. Rebuild and lauch RV
3. Select _Tools/ShotGrid Python Console_ in the menu bar
4. Enter the following code snippet:
```
import rv.commands as rvc
rvc.crash()
```
5. Execute it
6. Open the file logger, and should have logs instead of nothing

### Add a list of changes, and note any that might need special attention during the review.

- [X] Add a synchronous spdlog logger that can be triggered by making `evFileLogSynchronous` true.
- [X] Add an "INFO: File logger path:" to help to user find the logs
- [X] Remove macro redefinition of SPDLOG_ACTIVE_LEVEL
- [X] Run clang-format 