### PR TITLE
Fix download_name for python3

### DIFF
--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -195,7 +195,7 @@ SET(_requirements_install_command
 
 EXTERNALPROJECT_ADD(
   ${_python3_target}
-  DOWNLOAD_NAME ${_python3_target}_${_version}.zip
+  DOWNLOAD_NAME ${_python3_target}_${_python3_version}.zip
   DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
   SOURCE_DIR ${_source_dir}


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.
Updates `DOWNLOAD_NAME` to use `_python3_version` as `_version` isn't declared in this file.

### Describe the reason for the change.
The downloaded package ended up with the wrong version string. In initial testing this was was the version from OpenSSL.

### Describe what you have tested and on which operating system.
Tested that it builds in a virtual machine for Centos 7

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.