### PR TITLE
Fix segmentation fault if OCIO is not set

### DIFF
--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -14,6 +14,7 @@
 #include <OpenColorIO/OpenColorIO.h>
 #include <boost/functional/hash.hpp>
 #include <algorithm>
+#include <cstdlib>
 #include <regex>
 
 namespace OCIO = OCIO_NAMESPACE;
@@ -169,7 +170,13 @@ OCIOIPNode::updateConfig()
 
     m_state->display  = m_state->config->getDefaultDisplay();
     m_state->view     = m_state->config->getDefaultView(m_state->display.c_str());
-    m_state->linear   = m_state->config->getColorSpace(OCIO::ROLE_SCENE_LINEAR)->getName();
+    
+    if (getenv("OCIO")) {
+        m_state->linear   = m_state->config->getColorSpace(OCIO::ROLE_SCENE_LINEAR)->getName();
+    } else {
+        std::cerr << "ERROR: OCIO environment variable not set" << '\n';
+    }
+    
     m_state->shaderID = "";
     m_state->lutID    = "";
 

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -171,11 +171,14 @@ OCIOIPNode::updateConfig()
     m_state->display  = m_state->config->getDefaultDisplay();
     m_state->view     = m_state->config->getDefaultView(m_state->display.c_str());
     
-    if (getenv("OCIO")) {
+    if (getenv("OCIO"))
+    {
         m_state->linear   = m_state->config->getColorSpace(OCIO::ROLE_SCENE_LINEAR)->getName();
-    } else {
+    }
+    else
+    {
         m_state->linear   = "";
-        std::cerr << "ERROR: OCIO environment variable not set" << '\n';
+        std::cerr << "ERROR: OCIO environment variable not set" << std::endl;
     }
     
     m_state->shaderID = "";

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -174,6 +174,7 @@ OCIOIPNode::updateConfig()
     if (getenv("OCIO")) {
         m_state->linear   = m_state->config->getColorSpace(OCIO::ROLE_SCENE_LINEAR)->getName();
     } else {
+        m_state->linear   = "";
         std::cerr << "ERROR: OCIO environment variable not set" << '\n';
     }
     


### PR DESCRIPTION
### Fix segmentation fault if OCIO is not set

### Summarize your change.

The idea is to only call _OpenColorIO_v2_2::ColorSpace::getName()_ if the OCIO environment variable is set.

### Describe the reason for the change.

Using the new OCIOv2 system, if a user uses rvio to export a .rv session file in which some OCIO configs were applied clips, everything works as expected as long as the OCIO environment variable is detected in the terminal in which rvio is used. However, if the OCIO environment variable is not set, the tool will reach a segmentation fault. This is a regression. Using a past release of RV (i.e 2023.0.1), the tool would export the content from the .rv session file but would just not apply the OCIO changes if it couldn't find the environment variable.

### Describe what you have tested and on which operating system.

The bug was tested on MacOS.

1. Download the attached zip file containing OCIO configs from [here](https://jira.autodesk.com/browse/SG-32970)
2. Install the latest version of RV using the OCIOv2 system
3. Open a terminal and make sure the OCIO environment variable is set and points on a valid OCIO config (i.e: ../aces_1.0.3/config.ocio)
4. Launch RV, then import some clips and make sure to apply an OCIO LUT on them
5. File / Save Session As...: Save the media and context into a .rv session file
6. Close RV, then open another terminal and go into the "bin" folder of the RV installed on step 2
7. Make sure to remove the OCIO environment variable from the terminal
8. Use the rvio tool to export the content of the .rv session file saved on step 5 (i.e: ./rvio /mnt/nvme/myOCIOSession.rv -o /mnt/nvme/myExport.mov)

You should now get the same behaviour as before (i.e. the rvio tool wil export the content in that context, but without applying OCIO).

### Add a list of changes, and note any that might need special attention during the review.

- [X] Call  _OpenColorIO_v2_2::ColorSpace::getName()_ if the variable is set, output an error message otherwise.