### PR TITLE
VFX2023: Updating third party components for CY2023

### DIFF
--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -192,7 +192,7 @@ def remove_broken_shortcuts(python_home: str) -> None:
             if filename not in [
                 "python",
                 "python3",
-                "python3.9",
+                "python3.10",
             ]:
                 print(f"Removing {filepath}...")
                 os.remove(filepath)


### PR DESCRIPTION
### Fix VFX2023 build for Mac and Linux due to old Python version

### Linked issues
N/A

### Summarize your change.

Changing python3.9 to python3.10 in make_pyside.py so the python EXE is copied

### Describe the reason for the change.
The build is broken for Mac and Linux since make_pyside.py cannot find Python

### Describe what you have tested and on which operating system.

Mac Ventura and Linux Rocky 8

### Add a list of changes, and note any that might need special attention during the review.
- Fixing code line with old python version. I'll create a story to investigate improving this code since it wasn't revisited since movign to CMake and creating the OpenRV repo.

### If possible, provide screenshots.