### PR TITLE
Fix OIIO download hash

### DIFF
--- a/cmake/dependencies/oiio.cmake
+++ b/cmake/dependencies/oiio.cmake
@@ -19,10 +19,10 @@ RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_OIIO" "2.4.6.0" "make" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
 SET(_download_url
-    "https://github.com/OpenImageIO/oiio/archive/refs/tags/v${_version}.tar.gz"
+    "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v${_version}.tar.gz"
 )
 SET(_download_hash
-    "c7acc1b9a8fda04ef48f7de1feda4dae"
+    "628c588112ce8e08f31ec3417eb6828d"
 )
 
 RV_MAKE_STANDARD_LIB_NAME("OpenImageIO_Util" "2.4.6" "SHARED" "${RV_DEBUG_POSTFIX}")


### PR DESCRIPTION
### Fix OIIO download hash 

### Linked issues

### Summarize your change.

Changed the download hash for the OpenImageIO's code.
We believe this change was caused by the fact that the tagged oiio sources are now hosted by ASWF.
From:
https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.4.6.0.tar.gz
To:
https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.4.6.0.tar.gz

### Describe the reason for the change.

The OIIO download hash was changed under our feet for the exact same OpenImageIO version.

### Describe what you have tested and on which operating system.
Successfully built tested on Mac OS
