### PR TITLE
VFX2023 merge to main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,16 @@ SET(CMAKE_BUILD_TYPE
 
 MESSAGE(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
+MESSAGE("PROJECT DIR ${PROJECT_SOURCE_DIR}")
+
 # Specify our own CMake modules so we can include them right after.
 SET(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/defaults ${PROJECT_SOURCE_DIR}/cmake/dependencies ${PROJECT_SOURCE_DIR}/cmake/globals
     ${PROJECT_SOURCE_DIR}/cmake/macros
+)
+
+SET(CMAKE_OSX_DEPLOYMENT_TARGET
+    "11.0"
 )
 
 INCLUDE(rv_options) # RV's build options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,10 +88,6 @@ SET(CMAKE_MODULE_PATH
     ${PROJECT_SOURCE_DIR}/cmake/macros
 )
 
-SET(CMAKE_OSX_DEPLOYMENT_TARGET
-    "11.0"
-)
-
 INCLUDE(rv_options) # RV's build options
 INCLUDE(rv_targets) # RV's build platform definitions
 INCLUDE(rv_globals) # RV's CMake-build global variables

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Open RV](docs/images/OpenRV_icon.png)](https://github.com/AcademySoftwareFoundation/OpenRV.git)
 ---
 
-![Supported Versions](https://img.shields.io/badge/python-3.9-blue)
+![Supported Versions](https://img.shields.io/badge/python-3.10-blue)
 [![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2023-lightgrey.svg)](http://www.vfxplatform.com/)
 [![docs](https://readthedocs.org/projects/aswf-openrv/badge/?version=latest)](https://aswf-openrv.readthedocs.io/en/latest)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ---
 
 ![Supported Versions](https://img.shields.io/badge/python-3.9-blue)
-[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2022-lightgrey.svg)](http://www.vfxplatform.com/)
+[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2023-lightgrey.svg)](http://www.vfxplatform.com/)
 [![docs](https://readthedocs.org/projects/aswf-openrv/badge/?version=latest)](https://aswf-openrv.readthedocs.io/en/latest)
 
 ## Overview

--- a/cmake/dependencies/boost.cmake
+++ b/cmake/dependencies/boost.cmake
@@ -14,11 +14,11 @@ SET(_target
 
 # This version of boost resolves Python3 compatibilty issues on Big Sur and Monterey and is compatible with Python 2.7 through Python 3.10
 SET(_version
-    "1.76.0"
+    "1.80.0"
 )
 
 SET(_major_minor_version
-    "1_76"
+    "1_80"
 )
 
 STRING(REPLACE "." "_" _version_with_underscore ${_version})
@@ -27,7 +27,7 @@ SET(_download_url
 )
 
 SET(_download_hash
-    e425bf1f1d8c36a3cd464884e74f007a
+    077f074743ea7b0cb49c6ed43953ae95
 )
 
 # Set _base_dir for Clean-<target>
@@ -71,11 +71,11 @@ IF(RV_TARGET_WINDOWS)
   )
   IF(CMAKE_BUILD_TYPE MATCHES "^Debug$")
     SET(BOOST_LIBRARY_SUFFIX
-        "-vc142-mt-gd-x64-${_major_minor_version}"
+        "-vc143-mt-gd-x64-${_major_minor_version}"
     )
   ELSE()
     SET(BOOST_LIBRARY_SUFFIX
-        "-vc142-mt-x64-${_major_minor_version}"
+        "-vc143-mt-x64-${_major_minor_version}"
     )
   ENDIF()
   SET(BOOST_SHARED_LIBRARY_SUFFIX
@@ -139,7 +139,7 @@ ELSEIF(RV_TARGET_LINUX)
   )
 ELSEIF(RV_TARGET_WINDOWS)
   SET(_toolset
-      "msvc-14.2"
+      "msvc-14.3"
   )
 ELSE()
   MESSAGE(FATAL_ERROR "Unsupported (yet) target for Boost")

--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -16,15 +16,27 @@ SET(_pyside2_target
     "RV_DEPS_PYSIDE2"
 )
 
+SET(PYTHON_VERSION_MAJOR
+    3
+)
+
+SET(PYTHON_VERSION_MINOR
+    10
+)
+
+SET(PYTHON_VERSION_PATCH
+    12
+)
+
 SET(_python3_version
-    "3.10.12"
+    "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.${PYTHON_VERSION_PATCH}"
 )
 
 SET(RV_DEPS_PYTHON_VERSION_MAJOR
-    3
+    ${PYTHON_VERSION_MAJOR}
 )
 SET(RV_DEPS_PYTHON_VERSION_SHORT
-    "3.9"
+    "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
 )
 
 SET(_opentimelineio_version
@@ -65,10 +77,6 @@ SET(_source_dir
 SET(_build_dir
     ${RV_DEPS_BASE_DIR}/${_python3_target}/build
 )
-
-STRING(REPLACE "." ";" _version_list ${_python3_version})
-LIST(GET _version_list 0 _python3_version_major)
-LIST(GET _version_list 1 _python3_version_minor)
 
 IF(RV_TARGET_WINDOWS)
 
@@ -149,7 +157,7 @@ IF(RV_TARGET_WINDOWS)
     )
   ENDIF()
   SET(_python_name
-      python${_python3_version_major}${_python3_version_minor}${PYTHON3_EXTRA_WIN_LIBRARY_SUFFIX_IF_DEBUG}
+      python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}${PYTHON3_EXTRA_WIN_LIBRARY_SUFFIX_IF_DEBUG}
   )
   SET(_include_dir
       ${_install_dir}/include
@@ -175,7 +183,7 @@ IF(RV_TARGET_WINDOWS)
 
   # When building in Debug, we need the Release name also: see below for add_custom_command.
   SET(_python_release_libname
-      python${_python3_version_major}${_python3_version_minor}${CMAKE_STATIC_LIBRARY_SUFFIX}
+      python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}${CMAKE_STATIC_LIBRARY_SUFFIX}
   )
   SET(_python_release_libpath
       ${_lib_dir}/${_python_release_libname}
@@ -186,7 +194,7 @@ IF(RV_TARGET_WINDOWS)
   )
 ELSE() # Not WINDOWS
   SET(_python_name
-      python${_python3_version_major}.${_python3_version_minor}
+      python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
   )
   SET(_include_dir
       ${_install_dir}/include/${_python_name}

--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -17,7 +17,7 @@ SET(_pyside2_target
 )
 
 SET(_python3_version
-    "3.9.17"
+    "3.10.12"
 )
 
 SET(RV_DEPS_PYTHON_VERSION_MAJOR
@@ -39,7 +39,7 @@ SET(_python3_download_url
     "https://github.com/python/cpython/archive/refs/tags/v${_python3_version}.zip"
 )
 SET(_python3_download_hash
-    "c7b5d223bf9e80c766ccae7c88ff1e66"
+    "69de50b7f8e90167932f677390e0490f"
 )
 
 SET(_opentimelineio_download_url

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -29,7 +29,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
   QT_HOME="${QT_HOME:-$HOME/Qt/${QT_VERSION}/clang_64}"
 elif [[ "$OSTYPE" == "msys"* ]]; then
-  CMAKE_GENERATOR="${CMAKE_GENERATOR:-Visual Studio 16 2019}"
+  CMAKE_GENERATOR="${CMAKE_GENERATOR:-Visual Studio 17 2022}"
   QT_HOME="${QT_HOME:-c:/Qt/Qt/${QT_VERSION}/msvc2019_64}"
   WIN_PERL="${WIN_PERL:-c:/Strawberry/perl/bin}"
   CMAKE_WIN_ARCH="${CMAKE_WIN_ARCH:--A x64}"

--- a/src/bin/python/py-interp/main.cpp
+++ b/src/bin/python/py-interp/main.cpp
@@ -37,18 +37,36 @@ main(int argc, char **argv)
 #endif
 
     Py_SetProgramName( Py_DecodeLocale( argv[0], nullptr ) );
-    Py_InitializeEx( 1 );
+    // Current issue: sys.path doesn't hold the site-packages path and thus py-interp cannot import modules.
+    // This is the same as calling py-interp with -S since this disables site.py on init which is the symptom of the current issue.
+
+    // Py_InitializeEx(1);
+    // Note about Py_Initilialize:
+    // See here for issue about calling Py_Initialize and Py_Main after: https://bugs.python.org/issue34008
+    // See here for which functions are allowed to be called before Py_Initialize: https://docs.python.org/3/c-api/init.html#pre-init-safe
+    // And we can infer, based on the previous 2 links, that it also safe for Py_Main (since it calls Py_Initialize itself)
 
     static wchar_t delim = L'\0';
 
     wchar_t** w_argv = new wchar_t*[argc + 1];
     w_argv[argc] = &delim;
 
-    for (int i = 0; i < argc; ++i ){
+    for(int i = 0; i < argc; ++i)
+    {
       w_argv[i] = Py_DecodeLocale(argv[i], nullptr);
     }
 
-    PySys_SetArgvEx( argc, w_argv, 0 );
+    // PySys_SetArgvEx is deprecated in 3.11 (and using PySys_SetArgvEx without Py_Initialize crashes on make)
+    // PySys_SetArgvEx( argc, w_argv, 0 );
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+
+    PyConfig_SetArgv(&config, argc, w_argv);
+    // config.safe_path is new in 3.11
+    // config.safe_path = 0;
+
+    // Not calling Py_InitializeFromConfig(&config); since it's the same problem than Py_Initialize
+    // Argv is still passed; you can repro (cause the same problem) the current issue by calling py-interp with -S i.e.: "./py-interp -S"
 
 #ifdef PLATFORM_WINDOWS
     //

--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -193,7 +193,7 @@ def remove_broken_shortcuts(python_home: str) -> None:
             if filename not in [
                 "python",
                 "python3",
-                "python3.9",
+                "python3.10",
             ]:
                 print(f"Removing {filepath}...")
                 os.remove(filepath)

--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -99,7 +99,7 @@ def prepare() -> None:
     elif system == "Linux":
         clang_filename_suffix = "80-based-linux-Rhel7.2-gcc5.3-x86_64.7z"
     elif system == "Windows":
-        clang_filename_suffix = "80-based-windows-vs2017_64.7z"
+        clang_filename_suffix = "140-based-windows-vs2019_64.7z"
 
     download_url = LIBCLANG_URL_BASE + clang_filename_suffix
     libclang_zip = os.path.join(TEMP_DIR, "libclang.7z")
@@ -223,7 +223,7 @@ def build() -> None:
     # PySide2 v5.15.2.1 builds with errors on Windows using Visual Studio 2019.
     # We force Visual Studio 2017 here to make it build without errors.
     if platform.system() == "Windows":
-        source_widows_msvc_env("2017")
+        source_widows_msvc_env("2022")
 
         # Add Qt jom to the path to build in parallel
         jom_path = os.path.abspath(

--- a/src/build/utils.py
+++ b/src/build/utils.py
@@ -340,7 +340,7 @@ def source_widows_msvc_env(msvc_year: str) -> None:
 
     mvs_base_path = os.path.join(
         os.path.expandvars("%SystemDrive%") + os.sep,
-        "Program Files (x86)",
+        "Program Files",
         "Microsoft Visual Studio",
     )
     vcvars_path = os.path.join(


### PR DESCRIPTION
### Merge VFX2023 to main

### Linked issues
N/A

### Summarize your change.
Merging VFX2023 to main and adding a commit for fixing py-interp

### Describe the reason for the change.

RV is updating their third-party toolchains

### Describe what you have tested and on which operating system.

Mac, Windows and Linux Rocky 8 and Rocky 9

### Add a list of changes, and note any that might need special attention during the review.
- Added a commit to fix py-interp: removing Py_Initialize as it is called by Py_Main. Removing PySys_SetArgvEx as it doesn't work when removing Py_Initialize but the new PyConfig works to set Py[...]SetArgv.

### If possible, provide screenshots.