### PR TITLE
Fix reading movieprocs

### DIFF
--- a/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
@@ -2844,7 +2844,7 @@ namespace IPCore
     // Ensure file exists and is accessible by the current user before
     // continuing
     //
-    if( !TwkUtil::pathIsURL( filename ) )
+    if( !TwkUtil::pathIsURL( filename ) && TwkUtil::extension( filename ) != "movieproc" )
     {
       const auto firstFileInSeq =
           TwkUtil::firstFileInPattern( filename.c_str() );


### PR DESCRIPTION
Fix reading movieprocs

### Summarize your change.

This is a followup to https://github.com/AcademySoftwareFoundation/OpenRV/pull/281 which introduced a change to bail out from reading files early when they could not be opened.

This causes a problem with movieprocs (generated sources, blank, etc) which are seen as files whose special syntax are parsed by the MovieProcedural handler after we check this file.  The fix is to simply not perform any checking on the files when it has the 'movieproc" extension. 