### PR TITLE
Use all cpu cores when building OpenRV

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -43,14 +43,15 @@ fi
 RV_HOME="${RV_HOME:-$SCRIPT_HOME}"
 RV_BUILD="${RV_BUILD:-${RV_HOME}/_build}"
 RV_INST="${RV_INST:-${RV_HOME}/_install}"
+RV_BUILD_PARALLELISM="${RV_BUILD_PARALLELISM:-$(python3 -c 'import os; print(os.cpu_count())')}"
 
 # ALIASES: Basic commands
 
 alias rvsetup="python3 -m pip install --user --upgrade -r ${RV_HOME}/requirements.txt"
 alias rvcfg="cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
 alias rvcfgd="cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Debug -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
-alias rvbuildt="cmake --build ${RV_BUILD} --config Release -v --parallel=8 --target "
-alias rvbuildtd="cmake --build ${RV_BUILD} --config Debug -v --parallel=8 --target "
+alias rvbuildt="cmake --build ${RV_BUILD} --config Release -v --parallel=${RV_BUILD_PARALLELISM} --target "
+alias rvbuildtd="cmake --build ${RV_BUILD} --config Debug -v --parallel=${RV_BUILD_PARALLELISM} --target "
 alias rvbuild="rvbuildt main_executable"
 alias rvbuildd="rvbuildtd main_executable"
 alias rvtest="ctest --test-dir ${RV_BUILD} --extra=verbose"
@@ -69,8 +70,9 @@ alias rvbootstrapd="rvsetup && rvmkd"
 
 echo "Please ensure you have installed any required dependencies from doc/build_system/config_[os]"
 echo
-echo "CMake parameters:" 
+echo "CMake parameters:"
 
+echo "RV_BUILD_PARALLELISM is $RV_BUILD_PARALLELISM"
 echo "RV_HOME is $RV_HOME"
 echo "RV_BUILD is $RV_BUILD"
 echo "RV_INST is $RV_INST"
@@ -78,7 +80,7 @@ echo "CMAKE_GENERATOR is $CMAKE_GENERATOR"
 echo "QT_HOME is $QT_HOME"
 if [[ "$OSTYPE" == "msys"* ]]; then echo "WIN_PERL is $WIN_PERL"; fi
 
-echo "To override any of them do unset [name]; export [name]=value; source $SCRIPT" 
+echo "To override any of them do unset [name]; export [name]=value; source $SCRIPT"
 echo
 echo "If this is your first time building RV try rvbootstrap (release) or rvbootstrapd (debug)"
 echo "To build quickly after bootstraping try rvmk (release) or rvmkd (debug)"


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

N/A

### Summarize your change.

It uses python to get the current core count to decide how many build tasks should run in parallel.

As for the other variables, someone can set RV_BUILD_PARALLELISM before loading rvcmds.sh to override the value.

### Describe the reason for the change.

The previous number was hardcoded to 8. On my computer, the number should be 10 (M1 Pro). It allows us to build slightly faster by allowing 25% more parallelism. 

### Describe what you have tested and on which operating system.

Tested on MacOS.

### Add a list of changes, and note any that might need special attention during the review.

N/A

### If possible, provide screenshots.

```
# geffrak @ ADSKGV4VL2YQGP in ~/code/git/github.com/org-geffrak/OpenRV on git:fast-build o [16:38:32] 
$ source rvcmds.sh
Please ensure you have installed any required dependencies from doc/build_system/config_[os]

CMake parameters:
RV_BUILD_PARALLELISM is 10
RV_HOME is /Users/geffrak/code/git/github.com/org-geffrak/OpenRV
RV_BUILD is /Users/geffrak/code/git/github.com/org-geffrak/OpenRV/_build
RV_INST is /Users/geffrak/code/git/github.com/org-geffrak/OpenRV/_install
CMAKE_GENERATOR is Ninja
QT_HOME is /Users/geffrak/Qt/5.15.14/macos
To override any of them do unset [name]; export [name]=value; source rvcmds.sh

If this is your first time building RV try rvbootstrap (release) or rvbootstrapd (debug)
To build quickly after bootstraping try rvmk (release) or rvmkd (debug)
```

```
# geffrak @ ADSKGV4VL2YQGP in ~/code/git/github.com/org-geffrak/OpenRV on git:fast-build o [16:39:16] 
$ rvbuild
Change Dir: '/Users/geffrak/code/git/github.com/org-geffrak/OpenRV/_build'

Run Build Command(s): /opt/homebrew/bin/ninja -v -j 10 main_executable
[...]
```