### PR TITLE
VFX2023: Updating the documentation

### DIFF
--- a/docs/build_system/config_windows.md
+++ b/docs/build_system/config_windows.md
@@ -109,10 +109,10 @@ Symptoms of using Windows' (and not mingw64) CMake:
 
 ### NOTE: Before starting a build
 
-Ensure that:
-- Your codebase is fully updated to the latest version (or the version you want to use) via a command like `git pull`.
-- Fix all conflicts due to updating the code
-- Revisit any modified files to ensure they aren't using old code that changed during the update such as when the visual studio version changes
+To maximize your chances of successfully building RV, you must:
+- Fully update your code base to the latest version (or the version you want to use) with a command like `git pull`.
+- Fix all conflicts due to updating the code.
+- Revisit all modified files to ensure they aren't using old code that changed during the update such as when the Visual Studio version changes.
 
 ### NOTE: Path Length
 

--- a/docs/build_system/config_windows.md
+++ b/docs/build_system/config_windows.md
@@ -11,15 +11,13 @@
 
 ## 1. Install Microsoft Visual Studio
 
-Install Microsoft Visual Studio 2017 & 2019.
+Install Microsoft Visual Studio 2022.
 
-Any edition of Microsoft Visual Studio 2019 should do, even the Microsoft Visual Studio 2019 Community Edition. Download it from the Microsoft [older downloads page](https://visualstudio.microsoft.com/vs/older-downloads/).
+Any edition of Microsoft Visual Studio 2022 should do, even the Microsoft Visual Studio 2022 Community Edition. Download it from the Microsoft [older downloads page](https://visualstudio.microsoft.com/vs/older-downloads/).
 
 Make sure to select the "Desktop development with C++" and the latest SDK for Windows 10 or Windows 11 features when installing Microsoft Visual Studio.
 
 You select the Windows SDK based on the target Windows version you plan on running the compiled application on.
-
-Note: The current version of PySide2 required by RV (5.15.2.1) cannot be built with Microsoft Visual Studio 2019 : it can only be built with Microsoft Visual Studio 2017. Therefore, Microsoft Visual Studio 2017 needs to be installed as well.
 
 ## 2. Install Qt
 
@@ -39,9 +37,9 @@ Download and install the 64-bit version of [Strawberry Perl](https://strawberryp
 
 Download and install the latest [MSYS2](https://www.msys2.org/).
 
-Note that RV is NOT a mingw64 build. It is a Microscoft Visual Studio 2019 build.
+Note that RV is NOT a mingw64 build. It is a Microscoft Visual Studio 2022 build.
 
-RV is built with Microsoft Visual Studio 2019 via the cmake "Visual Studio 16 2019" generator.
+RV is built with Microsoft Visual Studio 2022 via the cmake "Visual Studio 17 2022" generator.
 
 msys2 is only used for convenience as it comes with a package manager with utility packages required for the RV build such as cmake, git, flex, bison, nasm, unzip, zip, etc.
 
@@ -107,6 +105,14 @@ If you have your own install of CMake on your computer, your PATH will need to p
 Symptoms of using Windows' (and not mingw64) CMake:
 - During the build, Python scripts such as quoteFile.py, make_openssl.py and make_python.py fail: either they don't work or they aren't found.
 - `build.ninja not found` during the build of a dependency. (cmake/dependencies) Reason: CMake in ExternalProject_Add *configured* the Project with the Visual Studio Generator whereas OpenRV's ExternalProject_Add build command expects that Ninja will be used.
+
+
+### NOTE: Before starting a build
+
+Ensure that:
+- Your codebase is fully updated to the latest version (or the version you want to use) via a command like `git pull`.
+- Fix all conflicts due to updating the code
+- Revisit any modified files to ensure they aren't using old code that changed during the update such as when the visual studio version changes
 
 ### NOTE: Path Length
 

--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -223,8 +223,6 @@ def build() -> None:
     # PySide2 v5.15.2.1 builds with errors on Windows using Visual Studio 2019.
     # We force Visual Studio 2017 here to make it build without errors.
     if platform.system() == "Windows":
-        source_widows_msvc_env("2022")
-
         # Add Qt jom to the path to build in parallel
         jom_path = os.path.abspath(
             os.path.join(QT_OUTPUT_DIR, "..", "..", "Tools", "QtCreator", "bin", "jom")


### PR DESCRIPTION
### Updating the documentation and removing sourcing 2022

### Summarize your change.

Updating install Visual Studio instructions to build on Windows

### Describe the reason for the change.

Documentation points to VS2019 & 2017.

### Describe what you have tested and on which operating system.

Build machines: RHEL7 and Rocky9, Windows, Mac

### Add a list of changes, and note any that might need special attention during the review.
- Make_pyside: removing source call to 2022 since only 2022 needs to be installed on build machines.

### If possible, provide screenshots.