### PR TITLE
Fix “Streaming” Movie Media from Online Sources documentation

### DIFF
--- a/docs/rv-manuals/rv-user-manual/rv-user-manual-chapter-thirteen.md
+++ b/docs/rv-manuals/rv-user-manual/rv-user-manual-chapter-thirteen.md
@@ -10,12 +10,11 @@ The reference manual has documentation about the networking protocol and how to 
 
 While it's possible to create connections across the internet, it's a little tricky, see [13.1.4](#1314-networking-across-the-internet) .
 
-**WARNING** : Care should be taken with RV networking. Once a connection is established to a client application (RV or any other client) all scripting commands (including "system(...)") are allowed and executed with the user id and permissions of the local RV user. Local connections (from a client application running on the same machine as RV), are not authenticated and the user is not required to confirm connection. Remote connections must be explicitly allowed by the user, but the identity of the remote user can not be confirmed. Also note that traffic over RV network connections is generally not encrypted.
+**Warning:** Care should be taken with RV networking. Once a connection is established to a client application (RV or any other client) all scripting commands (including "system(...)") are allowed and executed with the user id and permissions of the local RV user. Local connections (from a client application running on the same machine as RV), are not authenticated and the user is not required to confirm connection. Remote connections must be explicitly allowed by the user, but the identity of the remote user can not be confirmed. Also note that traffic over RV network connections is generally not encrypted.
 
 Use of RV Remote Sync is at your own risk. Although we may recommend preferred configurations, we cannot guarantee that any configuration will be secure or that your use of RV Remote Sync will not introduce vulnerabilities into your systems. If you do not wish to accept this risk, please do not use RV Remote Sync.
 
-### 13.1 The Network Dialog
-
+## 13.1 The Network Dialog
 
 Before you can use any of RV's networking features, you have to tell RV to begin listening for connections. There are two ways to do this: from the command line using the -network flag or interactively using the the Network dialog via the RV → Networking... menu item.
 
@@ -23,15 +22,13 @@ The network dialog box has three pages: Configuration for setting up your identi
 
 ![60_se_rv_networking.jpg](../../images/rv-user-manual-60-rv-cx-se-rv-networking-60.jpg)  
 
-Figure 13.1:
+Figure 13.1: RV Network Dialog
 
-RV Network Dialog
-
-#### 13.1.1 Configuration
+### 13.1.1 Configuration
 
 The configuration requires two pieces of information: your identity (which appears at the other end of the connection) and a port number. Unless your systems administrator requires RV to use a different port you should leave the default value for the port number. Networking must be stopped in order to change the configuration.
 
-#### 13.1.2 Starting a Connection
+### 13.1.2 Starting a Connection
 
 To start networking and have RV accept connection just hit the Start Network button. Once running, the status indicator in the bottom left-hand corner of the dialog will show you the network status and the number of active connections (which starts out as 0).
 
@@ -41,11 +38,9 @@ Using the Connect... button will show another dialog asking for the host name of
 
 ![61_network_connect.jpg](../../images/rv-user-manual-61-rv-cx-network-connect-61.jpg)  
 
-Figure 13.2:
+Figure 13.2: Network Dialog Starting a Connection
 
-Network Dialog Starting a Connection
-
-#### 13.1.3 Contacts and Permissions
+### 13.1.3 Contacts and Permissions
 
 If networking is on, and a connection is initiated by another party, RV will ask whether or not you want the connection to occur. At that point you have three choices: accept the connection but ask for permission next time, always accept connection from the user/program that's asking, or deny the connection.
 
@@ -59,11 +54,9 @@ There is also a pop-up menu which lets you delete an existing contact or initiat
 
 ![62_network_contacts.jpg](../../images/rv-user-manual-62-rv-cx-network-contacts-62.jpg)  
 
-Figure 13.3:
+Figure 13.3: Network Contacts Page
 
-Network Contacts Page
-
-#### 13.1.4 Networking Across the Internet
+### 13.1.4 Networking Across the Internet
 
 It's possible to connect to a remote RV across the internet in a peer-to-peer fashion, but special care needs to be taken. We recommend one of two methods: using ssh tunneling or using a VPN.
 
@@ -71,8 +64,7 @@ SSH tunnelling is well known in the IT community. Since there is no standard fir
 
 Using a VPN is no different than a local area network once it has been established: you need to know the IP address or name of the host with which you want to connect. If you do not have a VPN in common with the remote participant, you can create one using [Hamachi](https://secure.logmein.com/products/hamachi/vpn.asp) . The service is free for non-commercial use. See their website for more details.
 
-### 13.2 Synchronizing Multiple RVs
-
+## 13.2 Synchronizing Multiple RVs
 
 Once a connection has been established between two RVs, you can synchronize them.
 
@@ -82,11 +74,9 @@ Usually it's a good idea to have all participants looking at the similar media, 
 
 ![63_rv_rv-cxx98-release_grabSync.png](../../images/rv-user-manual-63-rv-cxx98-release-grabSync-63.png)  
 
-Figure 13.4:
+Figure 13.4: Sync Mode Showing Remote User's Cursor
 
-Sync Mode Showing Remote User's Cursor
-
-#### 13.2.1 Using Sync
+### 13.2.1 Using Sync
 
 You can control which aspects of RV are transmitted to and received from remote RV's from the Sync menu. The menu is divided into to two main sections: things you can send and things you have agreed to receive. By default, sync mode will accept anything it gets, but will only send certain types of operations. So if one of the participants decides to send more than the default state the remote RVs will automatically use it.
 
@@ -94,9 +84,7 @@ Sync mode will always send frame changes and playback options like the current f
 
 ![64_ase_grabSyncMenu.png](../../images/rv-user-manual-64-rv-cx-ase-grabSyncMenu-64.png)  
 
-Figure 13.5:
-
-Sync Mode Menu
+Figure 13.5: Sync Mode Menu
 
 | Event Group             | What Gets Sync'ed                                                                                                                                                                                                                 |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -109,16 +97,13 @@ Sync Mode Menu
 | Audio Settings          | Soundtrack and per-source audio volume, balance, cross-over, etc. Things found under the Audio menu.                                                                                                                              |
 | Default                 | Frame changes, FPS, realtime and play all frames playback mode settings, in and out points. These are always sync'ed.                                                                                                             |
 
-Table 13.1:
+Table 13.1: Sync Mode Sending and Receiving Events
 
-Sync Mode Sending and Receiving Events
-
-### 13.3 “Streaming” Movie Media from Online Sources
+## 13.3 “Streaming” Movie Media from Online Sources
 
 Media “paths” provided to RV may be URLs that link to online media. These may be provided via the command line, in RVSession Files, or through scripting. This functionality should be considered “Beta” and there are several caveats you should be aware of:
 
-*   At the moment “https” (SSL) URLs are only supported on OSX. On Linux/Windows URLs must be “http”.
-*   The “media from online” workflow is a worst-case for RV's caching system, which generally assumes that the media can be accessed at arbitrary locations. In general, it's probably best to use Region Caching, with a large cache size, and allow the media to cache before playback begins. For media that is low-bandwidth, or for particularly low-latency connections, it may work well to use a large Lookahead Cache.
-*   The URL needs to end in “.mov” or “.mp4” or some other extension that the MIO_FFMPEG plugin will recognize.
-*   Audio may be a problem, since it is generally decoded and cached by a separate thread in RV. It may be best to turn on the “Cache All Audio” preference.
-*   The movie should be created with the "faststart" property (for RVIO this means adding the "-outparams of:movflags=faststart" command-line options).
+* The “media from online” workflow is a worst-case for RV's caching system, which generally assumes that the media can be accessed at arbitrary locations. In general, it's probably best to use Region Caching, with a large cache size, and allow the media to cache before playback begins. For media that is low-bandwidth, or for particularly low-latency connections, it may work well to use a large Lookahead Cache.
+* The URL needs to end in “.mov” or “.mp4” or some other extension that the MIO_FFMPEG plugin will recognize.
+* Audio may be a problem, since it is generally decoded and cached by a separate thread in RV. It may be best to turn on the “Cache All Audio” preference.
+* The movie should be created with the "faststart" property (for RVIO this means adding the "-outparams of:movflags=faststart" command-line options).


### PR DESCRIPTION
### Linked issues
None.

### Summarize your change.
Documentation erroneously stated in [chapter thirteen of the user manual](https://aswf-openrv.readthedocs.io/en/latest/rv-manuals/rv-user-manual/rv-user-manual-chapter-thirteen.html#streaming-movie-media-from-online-sources) that HTTPS in media paths was only supported on macOS. This is wrong, since Linux and Windows also support this.

Also took care of some markdown and other formatting issues.

### Describe the reason for the change.
Improve documentation accuracy.