### PR TITLE
MacOS: Fix path to shared libraries from binary dependency list on install

### DIFF
--- a/cmake/install/pre_install_darwin.cmake
+++ b/cmake/install/pre_install_darwin.cmake
@@ -83,6 +83,7 @@ FUNCTION(after_copy_platform FILE_PATH)
     RETURN()
   ENDIF()
 
-  EXECUTE_PROCESS(COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/../../src/build/remove_absolute_rpath.py --target ${FILE_PATH} COMMAND_ERROR_IS_FATAL ANY)
+  MESSAGE(STATUS "python3 ${CMAKE_CURRENT_LIST_DIR}/../../src/build/remove_absolute_rpath.py --target ${FILE_PATH} --root ${CMAKE_SOURCE_DIR}")
+  EXECUTE_PROCESS(COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/../../src/build/remove_absolute_rpath.py --target ${FILE_PATH} --root ${CMAKE_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
 
 ENDFUNCTION()

--- a/src/build/remove_absolute_rpath.py
+++ b/src/build/remove_absolute_rpath.py
@@ -24,7 +24,7 @@ def get_object_files(target):
 
                 file_type = subprocess.check_output(["file", "-bh", path])
                 if file_type.startswith(b"Mach-O"):
-                    yield path
+                    yield str(path.absolute())
     else:
         yield target
 
@@ -32,21 +32,36 @@ def get_object_files(target):
 def get_rpaths(object_file_path):
     otool_output = subprocess.check_output(
         ["otool", "-l", object_file_path]
-    ).splitlines()
+    ).decode().splitlines()
 
     i = 0
     while i < len(otool_output):
         otool_line = otool_output[i].strip()
         i += 1
 
-        if otool_line.split()[-1] == b"LC_RPATH":
+        if otool_line == "":
+            continue
+
+        if otool_line.split()[-1] == "LC_RPATH":
             for y in range(i, i + 2):
                 rpath_line = otool_output[y].split()
 
-                if rpath_line[0] == b"path":
+                if rpath_line[0] == "path":
                     yield rpath_line[1]
                     break
 
+def get_shared_library_paths(object_file_path):
+    otool_output = subprocess.check_output(
+        ["otool", "-L", object_file_path]
+    ).decode().splitlines()
+
+    i = 0
+
+    while i < len(otool_output):
+        otool_line = otool_output[i].strip()
+        i += 1
+        if "(compatibility version" in otool_line:
+            yield otool_line.split("(compatibility")[0].strip()
 
 def delete_rpath(object_file_path, rpath):
     delete_rpath_command = [
@@ -57,29 +72,60 @@ def delete_rpath(object_file_path, rpath):
     ]
     subprocess.run(delete_rpath_command).check_returncode()
 
+def change_shared_library_path(object_file_path, old_library_path):
+    new_library_path = f"@rpath/{os.path.basename(old_library_path)}"
 
-def remove_absolute_rpath(target):
+    change_shared_library_path_command = [
+        "install_name_tool",
+        "-change",
+        old_library_path,
+        new_library_path,
+        object_file_path,
+    ]
+    subprocess.run(change_shared_library_path_command).check_returncode()
+
+    return new_library_path
+
+def fix_rpath(target, root):
     for file in get_object_files(target):
-        print(f"Found Mach-O file: {file}")
+        print(f"Fixing rpaths for {file}")
 
         for rpath in get_rpaths(file):
             output = f"\trpath: {rpath}"
 
-            if rpath.startswith(b"@") is False and rpath.startswith(b".") is False:
+            if rpath.startswith("@") is False and rpath.startswith(".") is False:
                 delete_rpath(file, rpath)
                 output += " (Deleted)"
 
             print(output)
 
+        print(f"Fixing shared library paths for {file}")
+
+        for library_path in get_shared_library_paths(file):
+            output = f"\tlibrary path: {library_path}"
+
+            shared_library_name = os.path.basename(library_path)
+            if library_path.startswith(root) or library_path == shared_library_name:
+                 new_library_path = change_shared_library_path(file, library_path)
+                 output += f" (Changed to {new_library_path})"
+
+            print(output)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--target", type=Path, help="Target to sanitize", required=True)
+    parser.add_argument("--root", type=Path, help="Root directory", required=True)
 
     args = parser.parse_args()
 
     if args.target.exists() is False:
         raise FileNotFoundError(f"Unable to locate {args.target.absolute()}")
+    if args.root.exists() is False:
+        raise FileNotFoundError(f"Unable to locate {args.root.absolute()}")
 
-    remove_absolute_rpath(args.target)
+    # fail if target is not in root
+    if args.target.resolve().relative_to(args.root.resolve()) is False:
+        raise ValueError(f"Target {args.target.absolute()} is not in root {args.root.absolute()}")
+
+    fix_rpath(str(args.target.resolve().absolute()), str(args.root.resolve().absolute()))


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

N/A

### Summarize your change.

When running the install step, make sure that there's no dependencies to files in the build directory. 

### Describe the reason for the change.

Fixes io_oiio.dylib (and libOpenImageIO.2.4.6.dylib), which contained hardcoded full paths to 
files in the build RV_DEPS area. 

### Describe what you have tested and on which operating system.

Tested on MacOS, where I built stuff using Autodesk's CI, tested on my MacBook running Sonoma.

### Add a list of changes and note any needing special attention during the review.

N/A

### If possible, could you provide screenshots

```
$ otool -L RV/RV.app/Contents/PlugIns/ImageFormats/io_oiio.dylib 
RV/RV.app/Contents/PlugIns/ImageFormats/io_oiio.dylib:
	@rpath/io_oiio.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libTwkFB.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libOpenEXR-3_1.30.dylib (compatibility version 30.0.0, current version 30.7.1)
	@rpath/libIex-3_1.30.dylib (compatibility version 30.0.0, current version 30.7.1)
	@rpath/libIlmThread-3_1.30.dylib (compatibility version 30.0.0, current version 30.7.1)
	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.2.13)
	@rpath/libOpenImageIO.2.4.dylib (compatibility version 2.4.0, current version 2.4.6)
	@rpath/libOpenImageIO_Util.2.4.dylib (compatibility version 2.4.0, current version 2.4.6)
	@rpath/libTwkUtil.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libTwkExc.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libImath-3_1.29.dylib (compatibility version 29.0.0, current version 29.4.0)
	@rpath/libboost_thread.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.23.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)

$ otool -L RV/RV.app/Contents/lib/libOpenImageIO.2.4.6.dylib 
RV/RV.app/Contents/lib/libOpenImageIO.2.4.6.dylib:
	@rpath/libOpenImageIO.2.4.dylib (compatibility version 2.4.0, current version 2.4.6)
	@rpath/libOpenImageIO_Util.2.4.dylib (compatibility version 2.4.0, current version 2.4.6)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.2.13)
	@rpath/libavcodec.58.dylib (compatibility version 58.0.0, current version 58.134.100)
	@rpath/libavformat.58.dylib (compatibility version 58.0.0, current version 58.76.100)
	@rpath/libavutil.56.dylib (compatibility version 56.0.0, current version 56.70.100)
	@rpath/libswscale.5.dylib (compatibility version 5.0.0, current version 5.9.100)
	/usr/lib/libbz2.1.0.dylib (compatibility version 1.0.0, current version 1.0.8)
	@rpath/libopenjp2.7.dylib (compatibility version 7.0.0, current version 2.5.0)
	@rpath/libOpenEXR-3_1.30.dylib (compatibility version 30.0.0, current version 30.7.1)
	@rpath/libOpenEXRCore-3_1.30.dylib (compatibility version 30.0.0, current version 30.7.1)
	@rpath/libraw_r.23.dylib (compatibility version 24.0.0, current version 24.0.0)
	@rpath/libtiff.5.dylib (compatibility version 5.0.0, current version 5.3.0)
	@rpath/libboost_thread.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libImath-3_1.29.dylib (compatibility version 29.0.0, current version 29.4.0)
	@rpath/libIlmThread-3_1.30.dylib (compatibility version 30.0.0, current version 30.7.1)
	@rpath/libIex-3_1.30.dylib (compatibility version 30.0.0, current version 30.7.1)
	@rpath/libjpeg.62.dylib (compatibility version 62.0.0, current version 62.3.0)
	@rpath/libboost_chrono.dylib (compatibility version 0.0.0, current version 0.0.0)
	@rpath/libboost_atomic.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.23.0)
```