### PR TITLE
Fix the OpenRV build

### DIFF
--- a/cmake/dependencies/glew.cmake
+++ b/cmake/dependencies/glew.cmake
@@ -12,15 +12,15 @@ SET(_target
 )
 
 SET(_version
-    "2.2.0"
+    "e1a80a9f12d7def202d394f46e44cfced1104bfb"
 )
 
 SET(_download_url
-    "https://github.com/nigels-com/glew/archive/refs/tags/glew-${_version}.zip"
+    "https://github.com/nigels-com/glew/archive/${_version}.zip"
 )
 
 SET(_download_hash
-    f150f61074d049ff0423b09b18cd1ef6
+    9bfc689dabeb4e305ce80b5b6f28bcf9
 )
 
 SET(_install_dir


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

N/A

### Summarize your change.

Updates GLEW to the last commit, so it can build again.

### Describe the reason for the change.

OpenRV cannot build because GLEW cannot build anymore. GLEW always pull the latest of the OpenGL registries, even if the parser is not ready. 

See https://github.com/nigels-com/glew/issues/399, caused by https://github.com/KhronosGroup/OpenGL-Registry/pull/591.

There's another PR open discussing pinning the registries so OpenRV's build doesn't get another curve ball from a dependency, see https://github.com/nigels-com/glew/pull/400

### Describe what you have tested and on which operating system.

[x] Tested that it can build on Rocky8
[ ] Tested that it can build on the other platforms

### Add a list of changes, and note any that might need special attention during the review.

By doing this change, also updated GLEW to the latest. It's mandatory to have a working build, but other things might break.

### If possible, provide screenshots.

N/A