### PR TITLE
Fix OpenSSL always rebuilding on CentOS 7

### DIFF
--- a/cmake/dependencies/openssl.cmake
+++ b/cmake/dependencies/openssl.cmake
@@ -94,9 +94,7 @@ ELSE()
     LIST(APPEND _make_command --arch=${RV_OSX_EMULATION_ARCH})
   ENDIF()
 
-  IF(RV_TARGET_IS_RHEL9
-     OR RV_TARGET_IS_RHEL8
-  )
+  IF(RV_TARGET_LINUX)
     SET(_crypto_lib_name
         ${CMAKE_SHARED_LIBRARY_PREFIX}crypto${CMAKE_SHARED_LIBRARY_SUFFIX}.1.1
     )


### PR DESCRIPTION
### Fix OpenSSL always rebuilding on CentOS 7

### Linked issues
NA

### Summarize your change.

Named the OpenSSL's _crypto_lib_name+_ssl_lib_name on all Linux just like RHEL8 and RHEL9: libcrypto.so.1.1

### Describe the reason for the change.

On CentOS 7, OpenSSL was always rebuilt no matter what because of that incorrect _crypto_lib_name+_ssl_lib_name

### Describe what you have tested and on which operating system.

Test build on both my own CentOS 7 system and the Autodesk internal Jenkins