### PR TITLE
Add a tag in the window title when not in release

### DIFF
--- a/src/plugins/rv-packages/window_title/window_title.mu
+++ b/src/plugins/rv-packages/window_title/window_title.mu
@@ -13,6 +13,8 @@ class: WindowTitle : MinorMode
 { 
     string _title;
     string _mystate;
+    string _titlePrefix;
+    bool _isRelease;
     qt.QTimer _playStopTimer;
     qt.QTimer _updateTimer;
 
@@ -41,15 +43,13 @@ class: WindowTitle : MinorMode
         if (_title != s) 
         {
             _title = s;
-            string releaseVariant = getReleaseVariant();
-            if (releaseVariant == "RELEASE")
+            if (_isRelease)
             {
                 setWindowTitle(_title);
             }
             else
             {
-                // Add the release variant as suffix.
-                setWindowTitle("(%s) %s" % (releaseVariant, _title));
+                setWindowTitle(_titlePrefix + _title);
             }
         }
     }
@@ -134,6 +134,14 @@ class: WindowTitle : MinorMode
 
         _title = "";
         _mystate = "unknown";
+
+        // Compute the title prefix.
+        _titlePrefix = getReleaseVariant();
+        _isRelease = _titlePrefix == "RELEASE";
+        if (!_isRelease)
+        {
+            _titlePrefix = "(%s) " % _titlePrefix;
+        }
 
         _playStopTimer = qt.QTimer(mainWindowWidget());
         _playStopTimer.setSingleShot(true);

--- a/src/plugins/rv-packages/window_title/window_title.mu
+++ b/src/plugins/rv-packages/window_title/window_title.mu
@@ -40,8 +40,17 @@ class: WindowTitle : MinorMode
     {
         if (_title != s) 
         {
-	    _title = s;
-	    setWindowTitle(_title);
+            _title = s;
+            string releaseVariant = getReleaseVariant();
+            if (releaseVariant == "RELEASE")
+            {
+                setWindowTitle(_title);
+            }
+            else
+            {
+                // Add the release variant as suffix.
+                setWindowTitle("(%s) %s" % (releaseVariant, _title));
+            }
         }
     }
 


### PR DESCRIPTION
### Add a tag in the window title when not in release

### Linked issues
n/a

### Summarize your change.
Based on the CMake's variable `RV_RELEASE_DESCRIPTION`, add a tag to the window title to identify if the current build is not a release build.

### Describe the reason for the change.
Display that the current build is not a release build in the window title.

### Describe what you have tested and on which operating system.
Tested on Windows and Linux

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
**_Without setting RV_RELEASE_DESCRIPTION or RV_RELEASE_DESCRIPTION=RELEASE (no file loaded)_**
![Untitled - Release](https://github.com/AcademySoftwareFoundation/OpenRV/assets/105517825/9f8e9c36-6c06-45d9-ad05-46d30e1a5569)

**_Without setting RV_RELEASE_DESCRIPTION or RV_RELEASE_DESCRIPTION=RELEASE (with a file loaded)_**
![File loaded - Release](https://github.com/AcademySoftwareFoundation/OpenRV/assets/105517825/0f1bd8e9-abe0-4aed-859a-fc996deb62d1)

_**RV_RELEASE_DESCRIPTION=PRE-RELEASE (no file loaded)**_
![Pre-release-openrv - untitled](https://github.com/AcademySoftwareFoundation/OpenRV/assets/105517825/c7d4e8ea-750e-4a61-bd23-5ca7028ea167)

_**RV_RELEASE_DESCRIPTION="Internal Beta" (with a file loaded)**_
![Internal beta](https://github.com/AcademySoftwareFoundation/OpenRV/assets/105517825/397f5ce6-5ec0-4a5d-a890-0c9b36c2b789)
