### PR TITLE
Add two color mgmt nodes to Open RV that used to be only available in RV

### DIFF
--- a/src/lib/app/RvApp/RvNodeDefinitions.cpp
+++ b/src/lib/app/RvApp/RvNodeDefinitions.cpp
@@ -493,6 +493,28 @@ void addRvNodeDefinitions(NodeManager* m)
         m->addDefinition(def);
     }
 
+    {
+        NodeDefinition* def = new NodeDefinition("SYNLinearize", 1, false,
+                                                 "sclin",
+                                                 newIPNode<OCIOIPNode>,
+                                                 "", "", emptyIcon,
+                                                 true);
+
+        def->declareProperty<StringProperty>("defaults.function", "synlinearize");
+        m->addDefinition(def);
+    }
+
+    {
+        NodeDefinition* def = new NodeDefinition("SYNDisplay", 1, false,
+                                                 "scdsp",
+                                                 newIPNode<OCIOIPNode>,
+                                                 "", "", emptyIcon,
+                                                 true);
+
+        def->declareProperty<StringProperty>("defaults.function", "syndisplay");
+        m->addDefinition(def);
+    }
+
     m->addDefinition(new NodeDefinition("RVOverlay", 1, false,
                                         "overlay",
                                         newIPNode<OverlayIPNode>,

--- a/src/lib/ip/OCIONodes/CMakeLists.txt
+++ b/src/lib/ip/OCIONodes/CMakeLists.txt
@@ -10,9 +10,13 @@ SET(_target
     "OCIONodes"
 )
 
-FIND_PACKAGE(Qt5 REQUIRED COMPONENTS Core)
+FIND_PACKAGE(
+  Qt5 REQUIRED
+  COMPONENTS Core
+)
 
-FILE(GLOB _sources *.c*)
+FILE(GLOB _sources *.cpp)
+
 ADD_LIBRARY(
   ${_target} STATIC
   ${_sources}
@@ -25,8 +29,8 @@ TARGET_INCLUDE_DIRECTORIES(
 
 TARGET_LINK_LIBRARIES(
   ${_target}
-  PUBLIC IPCore TwkFB
-  PRIVATE ocio::ocio TwkUtil Qt5::Core
+  PUBLIC IPCore TwkFB ocio::ocio
+  PRIVATE TwkUtil Qt5::Core
 )
 
 IF(RV_TARGET_WINDOWS)

--- a/src/lib/ip/OCIONodes/ConfigIOProxy.cpp
+++ b/src/lib/ip/OCIONodes/ConfigIOProxy.cpp
@@ -1,0 +1,71 @@
+//
+// Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <OCIONodes/ConfigIOProxy.h>
+#include <TwkExc/Exception.h>
+#include <IPCore/IPNode.h>
+
+namespace IPCore {
+
+const std::string ConfigIOProxy::USE_IN_TRANSFORM_DATA_PROPERTY = "OCIOIPNode.inTransform.data.icc";
+
+std::string ConfigIOProxy::getConfigData() const
+{
+    std::ostringstream os;
+    OCIO::Config::CreateRaw()->serialize(os);
+    return os.str();
+}
+
+std::vector<uint8_t> ConfigIOProxy::getLutData(
+        const char * filepath) const
+{
+    std::vector<uint8_t> buffer;
+
+    // Load color transform from memory
+    if (std::string(filepath).find(ConfigIOProxy::USE_IN_TRANSFORM_DATA_PROPERTY)!=std::string::npos)
+    {
+        const TwkContainer::ByteProperty* inTransformData = m_node->property<TwkContainer::ByteProperty>("inTransform.data");
+        if (!inTransformData)
+        {
+            std::ostringstream os;
+            os << "Could not read property inTransform.data from : " << m_node->name();
+            TWK_THROW_EXC_STREAM(os.str().c_str());
+        }
+        const char* data     = static_cast<const char*>(inTransformData->rawData());
+        const size_t dataSize = inTransformData->size(); // don't assume null terminated (ICC is not text)
+        buffer.resize(dataSize);
+        std::memcpy(buffer.data(), data, dataSize);
+    }
+    // Load color transform from file
+    else
+    {
+        std::ifstream fstream(
+            filepath, 
+            std::ios_base::in | std::ios_base::binary | std::ios::ate
+        );
+        if (fstream.fail())
+        {
+            std::ostringstream os;
+            os << "Could not read LUT file : " << filepath;
+            TWK_THROW_EXC_STREAM(os.str().c_str());
+        }
+
+        const auto eofPosition = static_cast<std::streamoff>(fstream.tellg());
+        buffer.resize(eofPosition);
+        fstream.seekg(0, std::ios::beg);
+        fstream.read(reinterpret_cast<char*>(buffer.data()), eofPosition);
+    }
+
+    return buffer;
+}
+
+std::string ConfigIOProxy::getFastLutFileHash(const char * filename) const
+{
+    return std::string(filename);
+}
+
+
+} // IPCore

--- a/src/lib/ip/OCIONodes/OCIONodes/ConfigIOProxy.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/ConfigIOProxy.h
@@ -1,0 +1,48 @@
+//
+// Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include <string>
+#include <vector>
+
+namespace IPCore {
+
+class IPNode;
+
+namespace OCIO = OCIO_NAMESPACE;
+
+// An OCIO::ConfigIOProxy interface implementation class that is required by OCIOv2
+// to instantiate a color transfrom from memory (and not from an actual file).
+//
+class ConfigIOProxy : public OCIO::ConfigIOProxy
+{
+    public:
+
+    ConfigIOProxy(const IPNode* node) : m_node(node) {};
+    virtual ~ConfigIOProxy() {};
+
+    // Virtual LUT filepath to indicate that the color transform needs to be 
+    // initialized from memory using the inTransform.data ByteProperty from the
+    // IPNode. Otherwise the LUT is read from the filepath specified.
+    static const std::string USE_IN_TRANSFORM_DATA_PROPERTY;
+
+    //
+    // OCIO::ConfigIOProxy interface implementation
+    //
+    std::string getConfigData() const override;
+    std::vector<uint8_t> getLutData(const char * filepath) const override;
+    std::string getFastLutFileHash(const char * filename) const override;
+
+    private:
+
+    const IPNode* m_node;
+};
+
+} // IPCore
+

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
@@ -5,12 +5,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // 
 //******************************************************************************
-#ifndef __IPGraph__OCIOIPNode__h__
-#define __IPGraph__OCIOIPNode__h__
+
+#pragma once
+
 #include <IPCore/IPImage.h>
 #include <IPCore/IPNode.h>
 #include <TwkFB/FrameBuffer.h>
+
 #include <QMutex>
+#include <OpenColorIO/OpenColorIO.h>
 
 namespace IPCore {
 
@@ -21,6 +24,8 @@ namespace IPCore {
 ///
 
 struct OCIOState;
+
+namespace OCIO = OCIO_NAMESPACE;
 
 class OCIOIPNode : public IPNode
 {
@@ -43,22 +48,35 @@ class OCIOIPNode : public IPNode
     virtual void propertyChanged(const Property*);
 
     void updateConfig();
+    bool useRawConfig() const {return m_useRawConfig;}
 
   protected:
     void updateContext();
-    
+
+    OCIO::MatrixTransformRcPtr createMatrixTransformXYZToRec709() const;
+    OCIO::MatrixTransformRcPtr getMatrixTransformXYZToRec709();
+    OCIO::MatrixTransformRcPtr getMatrixTransformRec709ToXYZ();
+
   private:
-    IntProperty*    m_activeProperty;
-    IntProperty*    m_lutSize;
-    StringProperty* m_configDescription;
-    StringProperty* m_configWorkingDir;
-    FrameBuffer*    m_lutfb;
+
+    IntProperty*    m_activeProperty{nullptr};
+    IntProperty*    m_lutSize{nullptr};
+    StringProperty* m_configDescription{nullptr};
+    StringProperty* m_configWorkingDir{nullptr};
+    FrameBuffer*    m_lutfb{nullptr};
     std::string     m_lutSamplerName;
-    FrameBuffer*    m_prelutfb;
-    OCIOState*      m_state;
+    FrameBuffer*    m_prelutfb{nullptr};
+    OCIOState*      m_state{nullptr};
     mutable QMutex  m_lock;
+    bool            m_useRawConfig{false};
+
+    // synlinearize/syndisplay functions
+    StringProperty* m_inTransformURL{nullptr};
+    ByteProperty*   m_inTransformData{nullptr};
+    StringProperty* m_outTransformURL{nullptr};
+    OCIO::GroupTransformRcPtr m_transform;
+    OCIO::MatrixTransformRcPtr m_matrix_xyz_to_rec709;
+    OCIO::MatrixTransformRcPtr m_matrix_rec709_to_xyz;
 };
 
-} // Rv
-
-#endif // __IPGraph__OCIOIPNode__h__
+} // IPCore


### PR DESCRIPTION
### Add two color mgmt nodes to Open RV that used to be only available in RV

### Linked issues
NA

### Describe the reason for the change.

A little bit of context is required here: missing until this commit in Open RV, the commercial version of RV had two special color management related nodes that some users were leveraging:

1. SYNLinearize: this node could be used to include some media file's embedded color transforms into RV's color management pipeline.
2. SYNDisplay: this node could be used to include an ICC monitor profile file into RV's color management pipeline.

However, these two nodes were implemented using an Autodesk's internally developed color management library.
With the aim of adding these two nodes to Open RV without having to open source this internally developed library, it was decided to replace their implementation with OCIOv2.
This is exactly what this commit contains.

### Summarize your change.

Note that with the aim of preventing our existing users from having to modify their existing scripts to leverage these two color management related nodes, we have maintained the exact same interface that was available in the commercial RV to leverage those nodes: this includes their node names (SYNLinearize, SYNDisplay) and their associated parameters. 

Two nodes were added to the RV nodes definitions:

- SYNLinearize
- SYNDisplay

Both nodes are instantiated using the same already existing OCIOIPNode, but with new specific functions: synlinearize and syndisplay. 

The original implementation of those nodes did not require an OCIO config to be specified by the client. 
With the aim of allowing existing users to leverage those nodes without an OCIO config, the OCIOIPNode now supports built-in OCIO config which takes into effect automatically when the OCIO environment variable hasn't been set by the user.

For the SYNLinearize node, the input transform can be specified in two ways: via a url or via a data array. When the input transform is specified via a data array, then you will notice that we store the data array in a temporary file before passing it to OCIOv2 as it is not currently trivial to make OCIOv2 load a color transform from memory. There is the OCIOv2's ConfigIOProxy that can be used for that purpose, however it proved to be a bit overkill for our needs, since we only wanted to overload the color transform, not having to allocate a special config.

### Describe what you have tested and on which operating system.
Already Tested on Mac OS. But will also test on all platforms.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

Note that to test those nodes, one can create an .rvrc.mu file in their home directory (do not forget the dot . at the beginning) with the following content:

[rvrc.mu.zip](https://github.com/AcademySoftwareFoundation/OpenRV/files/13603419/rvrc.mu.zip)
