### PR TITLE
Display the new error log only when debugging Mu

### DIFF
--- a/src/lib/app/PyTwkApp/PyMuSymbolType.cpp
+++ b/src/lib/app/PyTwkApp/PyMuSymbolType.cpp
@@ -388,10 +388,14 @@ namespace TwkApp
       str << ", ";
       str << exc.what();
 
-      // Printing the error using cerr right away because the exception string does not get 
-      // displayed. The issue is that PyErr_Occurred does not return true and the printing is 
-      // skipped in PyStateFunc::state().
-      cerr << "ERROR: " << str.str() << endl;
+      if (muContext()->debugging())
+      {
+        // Printing the error using cerr right away because the exception string does not get 
+        // displayed. The issue is that PyErr_Occurred does not return true and the printing is 
+        // skipped in PyStateFunc::state().
+        cerr << "ERROR: " << str.str() << endl;
+      }
+      
 
       PyErr_SetString( PyExc_Exception, str.str().c_str() );
       return NULL;


### PR DESCRIPTION
### Display the new error log only when debugging Mu

### Linked issues
n/a

### Summarize your change.
Display the new error log (recently added) only when debugging Mu.

### Describe the reason for the change.
Don't want to show the log to the user if the user is not debugging Mu.

### Describe what you have tested and on which operating system.

- [ ] Windows

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a