### PR TITLE
Fix Color Inspector on large images with RV_SOURCE_TILING

### DIFF
--- a/src/lib/ip/IPCore/IPImage.cpp
+++ b/src/lib/ip/IPCore/IPImage.cpp
@@ -71,6 +71,8 @@ IPImage::init()
     cropEndX                     = 0;
     cropEndY                     = 0;
     supportReversedOrderBlending = true;
+    width                        = 0;
+    height                       = 0;
 }
 
 IPImage::IPImage(const IPNode* n) : node(n) { init(); }
@@ -743,12 +745,17 @@ IPImage::computeMatricesRecursive(const InternalGLMatricesContext& baseContext)
 
     if (!isNoBuffer()) 
     {
-        float imageAspect = (float)width / height;
-        if (isCropped)
+        float imageAspect = 1.0f;
+        if (width!=0 && height!=0)
         {
-            imageAspect *= (float)(cropEndX - cropStartX) * (float)height
-                           / (float)((cropEndY - cropStartY) * width);
+            imageAspect = (float)width / height;
+            if (isCropped && cropStartY!=cropEndY)
+            {
+                imageAspect *= (float)(cropEndX - cropStartX) * (float)height
+                            / (float)((cropEndY - cropStartY) * width);
+            }
         }
+
         Mat44f T;
         T.makeTranslation(Vec3f(-imageAspect / 2.0f, -0.5f, 0.f));
 


### PR DESCRIPTION
### Fix Color Inspector on large images with RV_SOURCE_TILING

### Linked issues
NA

### Describe the reason for the change.

Note that this issue was fixed and released in commercial RV 2023.0.2.
It was even successfully validated by the user who reported this issue.
It was missing from Open RV. This PR makes sure to include it.

#### Problem
An RV user reported that the Color Inspector (F5) was not showing with large images when in RV_SOURCE_TILING was enabled.
What we mean by large: The large sample image that the RV user provided us was 2000x200000 (notice the large vertical size).

#### Context
When RV_SOURCE_TILING is NOT enabled (the default), then the rendering of such a large image is done in one GPU tile and the GPU has a maximum texture size which is typically 16384 for modern GPUs. Which means that the rendering of such a large image is scaled down to fit into the maximum GPU texture size which means that we lose precision and the image appears blurry.  A special mechanism in RV exists to make the rendering of such a large image accurate: by splitting the source to be rendered into tiles where each tile fits into a maximum GPU texture size. This mechanism takes effect when the RV_SOURCE_TILING environment variable is set to 1.

#### Cause
The exceptions which leads to the Color Inspector (F5) not showing with large images with RV_SOURCE_TILING enabled was caused by the RenderQuery::imageFrameRatio() method which was trying to find the rendered image using a strict name comparison. Rendered images have slightly different names, and most functions use a tokenize comparison but the tokenize comparison was missing from RenderQuery::imageFrameRatio().

### Summarize your change.

#### Solution
Added the missing tokenize comparison in RenderQuery::imageFrameRatio().
Note that this PR has only an impact on RV when RV_SOURCE_TILING is enabled because RenderQuery::imageFrameRatio() is only used when RV_SOURCE_TILING is enabled.
To give you an idea of where a tokenize comparison is important:
The rendered image's name might be:
sourceGroup000000_source/tile_x0_y1.0//20480 (where 20480 is extra information)
Whereas the requested rendered image to be found might be 
sourceGroup000000_source/tile_x0_y1.0

Since that the same tokenize comparison was done in different methods, I added a helper method to prevent the code duplication: sourceHasMatchingTokens().

### Describe what you have tested and on which operating system.
Already tested on all platforms.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.