### PR TITLE
Fix Adding MXF files is slower than MOV

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -688,6 +688,15 @@ codecHasSlowAccess(string name)
     return false;
 };
 
+bool
+isMP4format(AVFormatContext* avFormatContext)
+{
+    return avFormatContext!=nullptr 
+            && avFormatContext->iformat!=nullptr 
+            && avFormatContext->iformat->name!=nullptr  
+            && strstr(avFormatContext->iformat->name, "mp4") != nullptr;
+}
+
 int64_t
 findBestTS(int64_t goalTS, double frameDur, VideoTrack* track, bool finalPacket)
 {
@@ -1395,7 +1404,7 @@ MovieFFMpegReader::snagColr(AVCodecContext* videoCodecContext,
     //
 
     void* fileHandle;
-    if (mp4v2Utils::readFile(m_filename,fileHandle))
+    if (isMP4format(m_avFormatContext) && mp4v2Utils::readFile(m_filename,fileHandle))
     {
         int streamIndex = track->number;
         mp4v2Utils::getColrType(fileHandle, streamIndex, track->colrType);


### PR DESCRIPTION
### Fix Adding MXF files is slower than MOV

### Linked issues
NA

### Describe the reason for the change.

Note that this issue was fixed and released in commercial RV 2023.0.1 and RV 2022.3.3.
It was even successfully validated by the user who reported this issue.
It was missing from Open RV. This PR makes sure to include it.

### Summarize your change.

#### Problem:
An RV user recently changed their workflow to use .mxf containers instead of .mov and they were observing that loading say 200x .mxf files takes 2x-3x the time it took them to load 200x .mov files with pretty much the same content (DNXHD).

I used XCode/Instruments to see if I couldn't find any obvious bottleneck and I was able to find that the extra time was spent trying to load the COLR MP4 atom in an .mxf file which is NOT an MP4 file using the MP4V2 Open Source MP4 utility library.
So the extra time was spent scanning the whole file and asserting that the COLR MP4 atom could not be found.

It doesn't make any sense to parse an .mxf file to get this MP4 atom since an .mxf file is NOT an MP4 container.

#### Solution
Adding a simple isMP4file() routine to make sure that the media file is an MP4 before trying to read the MP4 COLR atom.

Before Fix:
Time to add 200x rainbow_8bit.mov =    8 secs
Time to add 200x rainbow_8bit.mxf =   14 secs

Time to add 200x rainbow_10bit.mov =    8 secs
Time to add 200x rainbow_12bit.mxf =   23 secs

Afer Fix:
Time to add 200x rainbow_8bit.mov =    8 secs
Time to add 200x rainbow_8bit.mxf =   10 secs

Time to add 200x rainbow_10bit.mov =    8 secs
Time to add 200x rainbow_12bit.mxf =   12 secs

Note that even with the fix, loading the 8 bits mxf file is slightly slower than loading the 8 bits mov file equivalent.
However, I checked it with the XCode/Instrument performance profiling tool and the different is within the FFmpeg routine avformat_find_stream_info() and NOT with our own code.

### Describe what you have tested and on which operating system.

The fix was successfully tested on all platforms.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.