### PR TITLE
Unblock 10 bits Rendering/DisplayOutputFormat option on Mac

### DIFF
--- a/src/lib/app/RvCommon/RvPreferences.cpp
+++ b/src/lib/app/RvCommon/RvPreferences.cpp
@@ -691,14 +691,6 @@ RvPreferences::update()
 
     m_ui.displayOutputCombo->setCurrentIndex(dindex);
 
-#ifdef PLATFORM_DARWIN
-    //
-    //  Remove the 10 bit option on os x
-    //  can't figure out how to disable it
-    //
-    if (m_ui.displayOutputCombo->count() > 2) m_ui.displayOutputCombo->removeItem(2);
-#endif
-
     settings.endGroup();
 
     //----------------------------------------------------------------------


### PR DESCRIPTION

[GradientBW_10bit.dpx.zip](https://github.com/AcademySoftwareFoundation/OpenRV/files/13746108/GradientBW_10bit.dpx.zip)
### Unblock 10 bits Rendering/DisplayOutputFormat option on Mac in RV Prefs

### Linked issues
NA

### Describe the reason for the change.
13 years ago, the 10 bits Rendering/DisplayOutputFormat option had blocked on Mac only in the RV Prefs
There is no reason for blocking the 10 bits rendering option anymore.

I was able to successfully exercise the 10 bits rendering on a Mac without any issue. 

This change is safe: Note that the 10 bits rendering display output format is NOT the default display output format so the current commit will NOT impact the behaviour of existing clients.

### Summarize your change.

Now leaving the 10 bits rendering display output option on Mac just like on Windows+Linux.

### Describe what you have tested and on which operating system.
I was able to successfully exercise the 10 bits rendering on a Mac without any issue.
I used the gradient file in attachment and with the 10 bits rendering option I had no banding (remember to change the DPX format setting in the RV Prefs to 10 [bits).]

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.
<img width="770" alt="rv_rendering_10_bits_prefs" src="https://github.com/AcademySoftwareFoundation/OpenRV/assets/117092886/cf9ddeda-1942-4cf3-a69a-b000110c7c15">
