### PR TITLE
Enable hardened runtime capability on mac

### DIFF
--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -686,6 +686,7 @@ FUNCTION(rv_stage)
                    MACOSX_BUNDLE_BUNDLE_VERSION "${RV_MAJOR_VERSION}.${RV_MINOR_VERSION}.${RV_REVISION_NUMBER}"
                    MACOSX_BUNDLE_ICON_FILE "${_target}.icns"
                    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist"
+                   XCODE_ATTRIBUTE_ENABLE_HARDENED_RUNTIME YES
       )
     ELSEIF(RV_TARGET_LINUX)
       # Allow plugins that call dlopen to read app symbols


### PR DESCRIPTION
### Enable hardened runtime on mac (required for notorization)

### Linked issues
NA

### Describe the reason for the change.
We were unable to notarize the RV app on macOS because the hardened runtime capability was NOT enabled.
Enabling hardened runtime capability is a required for notarization: 
https://developer.apple.com/documentation/security/hardened_runtime?language=objc

### Summarize your change.
Enabled hardened runtime capability on the RV app.

### Describe what you have tested and on which operating system.
Make sure that the build was still successful on macOS and that the App behaved as expected.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.