### PR TITLE
Fix boost currently unavailable on boostorg.jfrog.io issue

### DIFF
--- a/cmake/dependencies/boost.cmake
+++ b/cmake/dependencies/boost.cmake
@@ -23,7 +23,7 @@ SET(_major_minor_version
 
 STRING(REPLACE "." "_" _version_with_underscore ${_version})
 SET(_download_url
-    "https://boostorg.jfrog.io/artifactory/main/release/${_version}/source/boost_${_version_with_underscore}.tar.gz"
+    "https://archives.boost.io/release/${_version}/source/boost_${_version_with_underscore}.tar.gz"
 )
 
 SET(_download_hash
@@ -32,7 +32,7 @@ SET(_download_hash
 
 # Set _base_dir for Clean-<target>
 SET(_base_dir
-  ${RV_DEPS_BASE_DIR}/${_target}
+    ${RV_DEPS_BASE_DIR}/${_target}
 )
 
 SET(_install_dir
@@ -40,7 +40,7 @@ SET(_install_dir
 )
 
 SET(${_target}_ROOT_DIR
-  ${_install_dir}
+    ${_install_dir}
 )
 
 SET(_boost_libs
@@ -283,10 +283,11 @@ ADD_CUSTOM_TARGET(
   DEPENDS ${_boost_stage_output}
 )
 
-ADD_CUSTOM_TARGET(clean-${_target}
-    COMMENT "Cleaning '${_target}' ..."
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${_base_dir}
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${RV_DEPS_BASE_DIR}/cmake/dependencies/${_target}-prefix
+ADD_CUSTOM_TARGET(
+  clean-${_target}
+  COMMENT "Cleaning '${_target}' ..."
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${_base_dir}
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${RV_DEPS_BASE_DIR}/cmake/dependencies/${_target}-prefix
 )
 
 ADD_DEPENDENCIES(dependencies ${_target}-stage-target)


### PR DESCRIPTION
### Fix boost currently unavailable on boostorg.jfrog.io issue

Now using an alternative location for the boost sources: https://archives.boost.io/release/1.80.0/source/

### Linked issues
NA

### Summarize your change.

Now using an alternative location for the boost sources: https://archives.boost.io/release/1.80.0/source/
Note that even though it is taken from a different location, it has the exact same MD5 checksum.

### Describe the reason for the change.

Since a week ago, the boost sources are no longer available from the expected location: https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz

There is an open, still unresolved, issue about this in the boost project:
https://github.com/boostorg/boost/issues/842

This causes a build break when building RV from scratch if one does not have the boost already downloaded.

### Describe what you have tested and on which operating system.
Successfully tested build on Mac.
Plus the URL checksum matches the one from the original location which is nice.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.