### PR TITLE
Fixes the default path to Qt on Windows

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -30,7 +30,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   QT_HOME="${QT_HOME:-$HOME/Qt/${QT_VERSION}/clang_64}"
 elif [[ "$OSTYPE" == "msys"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Visual Studio 17 2022}"
-  QT_HOME="${QT_HOME:-c:/Qt/Qt/${QT_VERSION}/msvc2019_64}"
+  QT_HOME="${QT_HOME:-c:/Qt/${QT_VERSION}/msvc2019_64}"
   WIN_PERL="${WIN_PERL:-c:/Strawberry/perl/bin}"
   CMAKE_WIN_ARCH="${CMAKE_WIN_ARCH:--A x64}"
   SETUPTOOLS_USE_DISTUTILS=stdlib


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

#355 

### Summarize your change.

Fixes the path to the default Qt 5.15.2 location on Windows.

### Describe the reason for the change.

The path is invalid, there's an extra Qt folder that is not there by default.

### Describe what you have tested and on which operating system.

Windows.

### Add a list of changes, and note any that might need special attention during the review.

N/A

### If possible, provide screenshots.

N/A