### PR TITLE
Enable Help Menu customization

### DIFF
--- a/src/lib/app/mu_rvui/CMakeLists.txt
+++ b/src/lib/app/mu_rvui/CMakeLists.txt
@@ -19,7 +19,6 @@ SET(_mumodules
     gltexture.mu
     wipes.mu
     inspector.mu
-    help_mode.mu
     window_mode.mu
     mode_manager.mu
     xmlrpc.mu

--- a/src/lib/app/mu_rvui/rvui.mu
+++ b/src/lib/app/mu_rvui/rvui.mu
@@ -7024,9 +7024,6 @@ global bool debugGC = false;
     use window_mode;
     s.minorModes.push_back(WindowMinorMode());
 
-    use help_mode;
-    s.minorModes.push_back(HelpMinorMode());
-
     use presentation_mode;
     s.minorModes.push_back(PresentationControlMinorMode());
 

--- a/src/plugins/rv-packages/openrv_help_menu/CMakeLists.txt
+++ b/src/plugins/rv-packages/openrv_help_menu/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (C) 2022  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+SET(_target
+    "openrv_help_menu"
+)
+
+RV_STAGE(TYPE "RVPKG" TARGET ${_target})

--- a/src/plugins/rv-packages/openrv_help_menu/PACKAGE
+++ b/src/plugins/rv-packages/openrv_help_menu/PACKAGE
@@ -1,0 +1,21 @@
+package: Open RV Help menu
+author: Autodesk, Inc.
+organization: Autodesk, Inc.
+version: 1.0
+requires: 
+rv: 2024.0.0
+openrv: 1.0.0
+optional: false
+system: true
+hidden: true
+
+modes: 
+  - file: openrv_help_menu_mode.mu
+    load: immediate
+
+description: |
+
+    <p>
+    Open RV Help menu
+    </p>
+

--- a/src/plugins/rv-packages/openrv_help_menu/openrv_help_menu_mode.mu
+++ b/src/plugins/rv-packages/openrv_help_menu/openrv_help_menu_mode.mu
@@ -3,7 +3,7 @@
 // 
 // SPDX-License-Identifier: Apache-2.0 
 //
-module: help_mode {
+module: openrv_help_menu_mode {
 use rvtypes;
 use runtime;
 use commands;
@@ -14,11 +14,11 @@ require io;
 require qt;
 
 documentation: """
-HelpMinorMode adds a Help menu and some modal event tables that
+OpenRVHelpMenuMinorMode adds a Help menu and some modal event tables that
 implement things like describe key, etc. Help minor mode should always
 appear list in the menu bar.
 """
-class: HelpMinorMode : MinorMode
+class: OpenRVHelpMenuMinorMode : MinorMode
 {
     \: showManual (void; Event ev, string env)
     {
@@ -35,29 +35,6 @@ class: HelpMinorMode : MinorMode
                 system.defaultWindowsOpen(wpath);
             }
             else openUrl("file://" + m);
-
-            /*
-            if (globalConfig.os == "DARWIN")
-            {
-                system.system("open " + m);
-            }
-            else if (globalConfig.os == "LINUX")
-            {
-                if (io.path.extension(m) == "pdf")
-                {
-                    system.system("%s %s&" % (state.config.pdfReader, m));
-                }
-                else
-                {
-                    system.system("%s %s&" % (state.config.htmlReader, m));
-                }
-            }
-            else if (globalConfig.os == "WINDOWS")
-            {
-                let wpath = regex.replace("/", m, "\\\\");
-                system.defaultWindowsOpen(wpath);
-            }
-            */
         }
         catch (...)
         {
@@ -154,18 +131,8 @@ class: HelpMinorMode : MinorMode
 
     \: inactiveState (int;) { DisabledMenuState; }
 
-    method: HelpMinorMode (HelpMinorMode;)
+    method: OpenRVHelpMenuMinorMode (OpenRVHelpMenuMinorMode;)
     {
-        string menuName = "Help";
-        if (runtime.build_os() == "DARWIN")
-        {
-            require system;
-            let major = system.getenv("RV_OS_VERSION_MAJOR"),
-                minor = system.getenv("RV_OS_VERSION_MINOR");
-
-            if (major == "10" && int(minor) < 6) menuName = "RV Help";
-        }
-
         Menu menuList = Menu {
                 {"Online Resources",    nil, nil, inactiveState},
                 {"   RV User's Manual",   opUrl(,"https://aswf-openrv.readthedocs.io/en/latest/rv-manuals/rv-user-manual/rv-user-manual-chapter-one.html"), nil},
@@ -186,26 +153,7 @@ class: HelpMinorMode : MinorMode
                 {"   Show Environment",    ~showEnv}
         };
 
-        let exec = system.getenv ("RV_APP_RV_SHORT_NAME", nil);
-        if (exec neq nil && regex.match("rvsdi", exec))
-        //
-        //  Add RV-SDI manual references to head of menu.
-        //
-        {
-            Menu newMenu;
-            for_each (item; menuList)
-            {
-                newMenu.push_back(item);
-                if (item.label == "Documentation")
-                {
-                    //newMenu.push_back (MenuItem {"   RV-SDI Manual (PDF)",  showManual(,"RV_APP_SDI_MANUAL"),      nil});
-                    newMenu.push_back (MenuItem {"   RV-SDI Manual (HTML)", showManual(,"RV_APP_SDI_MANUAL_HTML"), nil});
-                }
-            }
-            menuList = newMenu;
-        }
-
-        Menu menu = Menu {{menuName, menuList}};
+        Menu menu = Menu {{"Help", menuList}};
 
         \: bindDescribe (void; string name, EventFunc F)
         {
@@ -303,6 +251,11 @@ class: HelpMinorMode : MinorMode
                   "z",
                   9999);  // always last
     } 
+}
+
+\: createMode (Mode;)
+{
+    return OpenRVHelpMenuMinorMode();
 }
 
 }


### PR DESCRIPTION
### Enable Help Menu customization

### Linked issues
NA

### Describe the reason for the change.

This commit's intent is to allow third party applications consuming Open RV as a submodule to customize the Help menu to their liking.

### Summarize your change.

1. The Help menu has been transformed into a package with the exact same content as before.
2. Additionally, a new simple capability to the RV_STAGE(TYPE "RVPKG") macro has been added to prevent an Open RV default package from being installed : RVPKG_DO_NOT_INSTALL_LIST. By appending a package name to this list, one can prevent Open RV from installing the specified package(s).

### Describe what you have tested and on which operating system.

Tested on Mac.
