### PR TITLE
fix some custom build issues with ffmpeg

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -231,6 +231,8 @@ IF(NOT RV_FFMPEG_CONFIG_OPTIONS)
   SET(RV_FFMPEG_CONFIG_OPTIONS
       "${_disabled_decoders} ${_disabled_encoders} ${_disabled_filters} ${_disabled_parsers} ${_disabled_protocols}"
   )
+ELSE()
+  SEPARATE_ARGUMENTS(RV_FFMPEG_CONFIG_OPTIONS)
 ENDIF()
 
 LIST(REMOVE_DUPLICATES RV_FFMPEG_DEPENDS)

--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -266,7 +266,7 @@ EXTERNALPROJECT_ADD(
   SOURCE_DIR ${RV_DEPS_BASE_DIR}/${_target}/src
   ${RV_FFMPEG_PATCH_COMMAND_STEP}
   CONFIGURE_COMMAND
-    ${CMAKE_COMMAND} -E env "PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${_ffmpeg_david_cmake_lib_dir_path}/pkgconfig" ${_configure_command} --prefix=${_install_dir}
+    ${CMAKE_COMMAND} -E env "PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH}:${_ffmpeg_david_cmake_lib_dir_path}/pkgconfig" ${_configure_command} --prefix=${_install_dir}
     ${RV_FFMPEG_COMMON_CONFIG_OPTIONS} ${RV_FFMPEG_CONFIG_OPTIONS} ${RV_FFMPEG_EXTRA_C_OPTIONS} ${RV_FFMPEG_EXTRA_LIBPATH_OPTIONS} ${RV_FFMPEG_EXTERNAL_LIBS}
   BUILD_COMMAND ${_make_command} -j${_cpu_count}
   INSTALL_COMMAND ${_make_command} install


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->
n/a
### Summarize your change.

I had some difficulties building ffmpeg with custom configuration options and this is what resolved it for me. `RV_FFMPEG_CONFIG_OPTIONS` not being converted to a list was the issue. This can happen when you pass it as an option via cmake commandline like this.

```
cmake -DRV_FFMPEG_CONFIG_OPTIONS="--enable-decoder=vp9 --enable-decoder=vp8" ..
``` 

There could still be issue doing it this way. When passing an option via a commandline cmake does confusing things with escaping quotes that I don't entirely understand.  If for example if you want to add a custom build option like
`--extra-cflags="-I/include/dir1 -I/incude/dir2"` I still can't figure out how to get cmake to escape the quotes properly.

The other issues was ffmpeg not finding the install packages because the script wasn't using the `PKG_CONFIG_PATH` env var.

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

I've only tested this on centos 7 

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.