### PR TITLE
Prevent missing etc directory warning

### DIFF
--- a/src/lib/app/QTBundle/QTBundle.cpp
+++ b/src/lib/app/QTBundle/QTBundle.cpp
@@ -62,7 +62,10 @@ QTBundle::init()
     m_ui = m_root;
     if (!m_scripts.cd("scripts")) cerr << "WARNING: missing scripts dir in bundle" << endl;
     if (!m_plugins.cd("plugins")) cerr << "WARNING: missing plugin dir in bundle" << endl;
-    if (!m_etc.cd("etc")) cerr << "WARNING: missing etc dir in bundle" << endl;
+
+    // Note: we do not issue a warning here for a potentially missing 'etc' dir since 
+    // it is optional and is not populated on all platforms like on Linux for example.
+    m_etc.cd("etc");
 
 #ifdef PLATFORM_LINUX
     m_homeSupport = m_home;


### PR DESCRIPTION
### Prevent missing etc directory warning

### Linked issues
NA

### Summarize your change.

Prevent missing etc directory warning on launch since the etc directory is optional.

### Describe the reason for the change.

The app/etc directory is optional and is not populated on all platforms like on Linux for example.

### Describe what you have tested and on which operating system.

Successfully tested on Linux CentOS 7.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.