### PR TITLE
Leverage new OCIOv2 GPU Processor

### DIFF
--- a/src/lib/ip/OCIONodes/OCIO1DLUT.cpp
+++ b/src/lib/ip/OCIONodes/OCIO1DLUT.cpp
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2024  Autodesk, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <OCIONodes/OCIO1DLUT.h>
+#include <TwkExc/Exception.h>
+
+namespace IPCore
+{
+
+  OCIO1DLUT::OCIO1DLUT( OCIO::GpuShaderDescRcPtr& shaderDesc, unsigned int idx,
+                        const std::string& shaderCacheID )
+  {
+    // Get the information of the 1D LUT.
+    const char* textureName = nullptr;
+    const char* samplerName = nullptr;
+    unsigned width = 0;
+    unsigned height = 0;
+    OCIO::GpuShaderDesc::TextureType textureType =
+        OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL;
+    OCIO::Interpolation interpolation = OCIO::INTERP_BEST;
+    shaderDesc->getTexture( idx, textureName, samplerName, width, height,
+                            textureType, interpolation );
+    if( !samplerName || !*samplerName || width == 0 )
+    {
+      TWK_THROW_EXC_STREAM( "The OCIO 1D LUT texture data is corrupted" );
+    }
+    const int channelSize =
+        ( textureType == OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL ) ? 3 : 1;
+    m_samplerName = samplerName;
+    m_height = height;
+
+    m_lutfb = new TwkFB::FrameBuffer(
+        TwkFB::FrameBuffer::NormalizedCoordinates, width, height, 1 /*depth*/,
+        channelSize, TwkFB::FrameBuffer::FLOAT, nullptr /*data*/,
+        nullptr /*channelNames are optional*/, TwkFB::FrameBuffer::BOTTOMLEFT,
+        true /*deleteOnDestruction*/ );
+
+    m_lutfb->staticRef();
+    m_lutfb->setIdentifier( shaderCacheID + "|" + m_samplerName );
+
+    const float* values = nullptr;
+    shaderDesc->getTextureValues( idx, values );
+    if( !values )
+    {
+      TWK_THROW_EXC_STREAM( "The OCIO 1D LUT texture values are missing" );
+    }
+
+    memcpy( m_lutfb->pixels<float>(), values,
+            channelSize * sizeof( float ) * width * height );
+  }
+
+}  // namespace IPCore

--- a/src/lib/ip/OCIONodes/OCIO3DLUT.cpp
+++ b/src/lib/ip/OCIONodes/OCIO3DLUT.cpp
@@ -1,0 +1,49 @@
+//
+// Copyright (C) 2024  Autodesk, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <OCIONodes/OCIO3DLUT.h>
+#include <TwkExc/Exception.h>
+
+namespace IPCore
+{
+
+  OCIO3DLUT::OCIO3DLUT( OCIO::GpuShaderDescRcPtr& shaderDesc, unsigned int idx,
+                        const std::string& shaderCacheID )
+  {
+    // Get the information of the 3D LUT.
+    const char* textureName = nullptr;
+    const char* samplerName = nullptr;
+    unsigned edgelen = 0;
+    OCIO::Interpolation interpolation = OCIO::INTERP_BEST;
+    shaderDesc->get3DTexture( idx, textureName, samplerName, edgelen,
+                              interpolation );
+    if( !samplerName || !*samplerName || edgelen == 0 )
+    {
+      TWK_THROW_EXC_STREAM( "The OCIO 3D LUT texture data is corrupted" );
+    }
+    m_samplerName = samplerName;
+
+    m_lutfb = new TwkFB::FrameBuffer(
+        TwkFB::FrameBuffer::NormalizedCoordinates, edgelen, edgelen, edgelen,
+        3 /*channelSize*/, TwkFB::FrameBuffer::FLOAT, nullptr /*data*/,
+        nullptr /*channelNames are optional*/, TwkFB::FrameBuffer::BOTTOMLEFT,
+        true /*deleteOnDestruction*/ );
+
+    m_lutfb->staticRef();
+    m_lutfb->setIdentifier( shaderCacheID + "|" + m_samplerName );
+
+    const float* values = nullptr;
+    shaderDesc->get3DTextureValues( idx, values );
+    if( !values )
+    {
+      TWK_THROW_EXC_STREAM( "The OCIO 3D LUT texture values are missing" );
+    }
+
+    memcpy( m_lutfb->pixels<float>(), values,
+            3 * sizeof( float ) * edgelen * edgelen * edgelen );
+  }
+
+}  // namespace IPCore

--- a/src/lib/ip/OCIONodes/OCIOLUT.cpp
+++ b/src/lib/ip/OCIONodes/OCIOLUT.cpp
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2024  Autodesk, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <OCIONodes/OCIOLUT.h>
+#include <TwkExc/Exception.h>
+
+namespace IPCore
+{
+
+  OCIOLUT::~OCIOLUT()
+  {
+    if( m_lutfb )
+    {
+      if( !m_lutfb->hasStaticRef() || m_lutfb->staticUnRef() )
+      {
+        delete m_lutfb;
+      }
+      m_lutfb = 0;
+    }
+  }
+
+}  // namespace IPCore

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIO1DLUT.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIO1DLUT.h
@@ -1,0 +1,42 @@
+//
+// Copyright (C) 2024  Autodesk, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <OCIONodes/OCIOLUT.h>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include <string>
+#include <vector>
+
+namespace IPCore
+{
+
+  namespace OCIO = OCIO_NAMESPACE;
+
+  // An OCIO 1D LUT representation (a GPU texture) with its associated
+  // frame buffer.
+  //
+  class OCIO1DLUT : public OCIOLUT
+  {
+   public:
+    OCIO1DLUT( OCIO::GpuShaderDescRcPtr& shaderDesc, unsigned int idx,
+               const std::string& shaderCacheID );
+    virtual ~OCIO1DLUT() {};
+
+    // Returns the LUT sampler type: sampler3D, sampler2D, or sampler1D
+    // Note: a 2D texture is needed to hold large LUTs.
+    std::string samplerType() const override
+    {
+      return m_height == 1 ? "sampler1D" : "sampler2D";
+    }
+
+   private:
+    int m_height{ 1 };
+  };
+
+}  // namespace IPCore

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIO3DLUT.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIO3DLUT.h
@@ -1,0 +1,38 @@
+//
+// Copyright (C) 2024  Autodesk, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <OCIONodes/OCIOLUT.h>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include <string>
+#include <vector>
+
+namespace IPCore
+{
+
+  namespace OCIO = OCIO_NAMESPACE;
+
+  // An OCIO 3D LUT representation (a GPU texture) with its associated
+  // frame buffer.
+  //
+  class OCIO3DLUT : public OCIOLUT
+  {
+   public:
+    OCIO3DLUT( OCIO::GpuShaderDescRcPtr& shaderDesc, unsigned int idx,
+               const std::string& shaderCacheID );
+    virtual ~OCIO3DLUT() {};
+
+    // Returns the LUT sampler type: sampler3D, sampler2D, or sampler1D
+    std::string samplerType() const override
+    {
+      return "sampler3D";
+    }
+  };
+
+}  // namespace IPCore

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
@@ -15,6 +15,8 @@
 #include <QMutex>
 #include <OpenColorIO/OpenColorIO.h>
 
+#include <memory>
+
 namespace IPCore {
 
 /// Provides 3D and Channel OCIOs for DisplayIPNode and ColorIPNode
@@ -26,6 +28,11 @@ namespace IPCore {
 struct OCIOState;
 
 namespace OCIO = OCIO_NAMESPACE;
+
+class OCIO1DLUT;
+using OCIO1DLUTPtr = std::shared_ptr<OCIO1DLUT>;
+class OCIO3DLUT;
+using OCIO3DLUTPtr = std::shared_ptr<OCIO3DLUT>;
 
 class OCIOIPNode : public IPNode
 {
@@ -60,12 +67,10 @@ class OCIOIPNode : public IPNode
   private:
 
     IntProperty*    m_activeProperty{nullptr};
-    IntProperty*    m_lutSize{nullptr};
     StringProperty* m_configDescription{nullptr};
     StringProperty* m_configWorkingDir{nullptr};
-    FrameBuffer*    m_lutfb{nullptr};
-    std::string     m_lutSamplerName;
-    FrameBuffer*    m_prelutfb{nullptr};
+    std::vector<OCIO1DLUTPtr> m_1DLUTs;
+    std::vector<OCIO3DLUTPtr> m_3DLUTs;
     OCIOState*      m_state{nullptr};
     mutable QMutex  m_lock;
     bool            m_useRawConfig{false};

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIOLUT.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIOLUT.h
@@ -1,0 +1,45 @@
+//
+// Copyright (C) 2024  Autodesk, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <TwkFB/FrameBuffer.h>
+
+#include <string>
+
+namespace IPCore
+{
+
+  // An OCIO LUT base representation (a GPU texture) with its associated frame
+  // buffer.
+  //
+  class OCIOLUT
+  {
+   public:
+    // Returns the LUT sampler name
+    std::string samplerName() const
+    {
+      return m_samplerName;
+    };
+
+    // Returns the LUT sampler type: sampler3D, sampler2D, or sampler1D
+    virtual std::string samplerType() const = 0;
+
+    // Returns the FrameBuffer associated with the LUT containing the LUT values
+    TwkFB::FrameBuffer* lutfb() const
+    {
+      return m_lutfb;
+    }
+
+   protected:
+    OCIOLUT() {};
+    virtual ~OCIOLUT();
+
+    TwkFB::FrameBuffer* m_lutfb{ nullptr };
+    std::string m_samplerName;
+  };
+
+}  // namespace IPCore


### PR DESCRIPTION
### Leverage new OCIOv2 GPU Processor

### Linked issues
Fixes #365

### Describe the reason for the change.
Even though Open RV was recently upgraded to OCIOv2, it was only using the legacy GPU processor implementation of OCIOv2 which is less accurate and more limited than the new OCIOv2 GPU processor implementation. 
This commit leverages the new OCIOv2 GPU processor implementation in Open RV.
 
### Summarize your change.
Prior to this commit, only the legacy OCIOv2 GPU processor was used (OCIO::getOptimizedLegacyGPUProcessor).
In this commit, the new OCIOv2 GPU processor implementation is now used by default.
With the aim of maintaining backward compatibility of results, I have added a new environment variable which can be optionally defined to tell OCIO to use the legacy GPU processor implementation: 
`export RV_OCIO_USE_LEGACY_GPU_PROCESSOR=1`

The main change is that we are now calling OCIO::getOptimizedGPUProcessor() instead of OCIO::getOptimizedLegacyGPUProcessor() and that we have to handle the possibility of having an arbitrary number of 1D LUT(s) and 3D LUT(s). Prior to this commit, only 1x optional 3D LUT could be handled.
This is why I decided to model the 1D LUTs and the 3D LUTs in their own classes to hide the OCIO calls to fetch their values since that they translate to different OCIOv2 calls. This way the OCIOIPNode::evaluate() code ended up not being too much impacted by it. It is long enough as it is.

### Describe what you have tested and on which operating system.
Built and Tested on Mac, RockyLinux9, and Windows.
Using this OCIOv2 config: studio-config-v2.0.0_aces-v1.3_ocio-v2.2.ocio.

### Add a list of changes, and note any that might need special attention during the review.
Also fixed in this commit: Fixed a crash in RV when the provided OCIO config did not contain the OCIO::ROLE_SCENE_LINEAR color space (this was unlikely to occur with production OCIO configs but it happened during my tests using a very customized OCIO config).

### If possible, provide screenshots.
<img width="989" alt="ocio_display_menu" src="https://github.com/AcademySoftwareFoundation/OpenRV/assets/117092886/ee15b136-75fb-4f3d-a4cf-279a2ae70ea0">

