### PR TITLE
Fix potential RV crash when using wipes on Default Stack

### DIFF
--- a/src/lib/ip/IPBaseNodes/SwitchIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/SwitchIPNode.cpp
@@ -14,7 +14,6 @@
 #include <TwkMath/Function.h>
 #include <TwkFB/FrameBuffer.h>
 #include <TwkFB/Operations.h>
-#include <TwkUtil/EnvVar.h>
 #include <stl_ext/stl_ext_algo.h>
 #include <iostream>
 
@@ -23,10 +22,7 @@ using namespace TwkContainer;
 using namespace TwkMath;
 using namespace TwkFB;
 using namespace TwkAudio;
-using namespace TwkUtil;
 using namespace std;
-
-static ENVVAR_BOOL( evForceNoIntermediateForSwitchNodes, "RV_FORCE_NO_INTERMEDIATE_FOR_SWITCH_NODES", true );
 
 SwitchIPNode::SwitchIPNode(const std::string& name,
                            const NodeDefinition* def,
@@ -381,8 +377,6 @@ SwitchIPNode::evaluate(const Context& context)
                                 IPImage::BlendRenderType,
                                 width,
                                 height);
-
-    root->noIntermediate = evForceNoIntermediateForSwitchNodes.getValue();
 
     try
     {


### PR DESCRIPTION
### Fix potential RV crash when using wipes on Default Stack

### Linked issues
NA

### Describe the reason for the change.

Bringing a fix to Open RV which was originally done in RV 2023.0.1 but which was not copied over to Open RV unfortunately. My bad.

### Summarize your change.

Note that this fix is in fact reverting a fix that was done in RV 2023.0.0.
(OTIO : Zooming out of the default output bounds does not reveal media.)
The problem with the fix we did in RV 2023 on SwitchIPNode is that we cannot always prevent RV from using intermediate render. Which is why it needs to be reverted and another solution needs to be applied to solve the original OTIO issue.

### Describe what you have tested and on which operating system.

Validated the fix on Mac and built successfully on all platforms

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.