### PR TITLE
Fix Frame Rate of RVIO's exported movies

### DIFF
--- a/src/bin/imgtools/rvio/main.cpp
+++ b/src/bin/imgtools/rvio/main.cpp
@@ -1011,6 +1011,7 @@ utf8Main(int argc, char *argv[])
 
 
 #ifdef PLATFORM_DARWIN
+    QCoreApplication qapp(argc, argv);
     TwkApp::DarwinBundle bundle("RV", MAJOR_VERSION, MINOR_VERSION, REVISION_NUMBER);
 #endif
 

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -873,6 +873,15 @@ validateTimestamps(AVPacket* pkt, AVStream* stm, int64_t frameCount,
     if (pkt->duration > 0 && isAudio)
         pkt->duration =
             av_rescale_q(pkt->duration, stm->codec->time_base, stm->time_base);
+
+    // Video AVPacket's duration needs to be initialized starting with FFmpeg 4.4.3
+    // as the automatic computing of the frame duration code was removed from FFmpeg.
+    // Otherwise the exported media will have an incorrect duration (-1 frame) which
+    // will result in a slightly higher (incorrect) frame rate.
+    if (pkt->duration == 0 && !isAudio)
+    {
+        pkt->duration = av_rescale_q(1, stm->codec->time_base, stm->time_base);
+    }
 }
 
 void copyImage(AVPicture* dst, const AVPicture* src,


### PR DESCRIPTION
### Pull Request Fix Frame Rate of RVIO's exported movies

### Linked issues
NA

### Describe the reason for the change.

RVIO exported movies had a slightly higher frame rate than expected.
Note that one can export a movie either by calling the RVIO command line tool directly or by selecting the File/Export/QuicktimeMovie menu in RV.
<img width="675" alt="bad_fps" src="https://github.com/AcademySoftwareFoundation/OpenRV/assets/117092886/650c5e5b-da3a-4f46-a678-3ea25ea3d356">

### Summarize your change.

This issue was introduced when FFmpeg was updated from 4.2.1 (RV 2023) to FFmpeg 4.4.3 (RV 2024 and Open RV).
After investigation, the slightly higher frame rate was introduced by an incorrect duration stored in the movie file header. This incorrect duration was 1 frame less than the expected duration. Which led to a higher frame rate because the same number of frame was now for a lower duration.
frame rate = numberOfFrames/Duration.

Example with a 10 secs clip at 24 fps:
frame rate = (10 * 24 frames)/(10secs - 1/24 secs) = 24.1 fps

The incorrect clip duration in the movie file frame header was caused by the fact that FFmpeg no longer computes the duration of a video AVPacket when its duration is 0. This automatic duration computation code existed in FFmpeg 4.2.1 but is no longer present in FFmpeg 4.4.3.
To solve this issue, we are now computing the duration of the video AVPacket in RV prior to calling av_interleaved_write_frame()

This is the code that is now missing in action in the newer FFmpeg
FFMPEG/src/libavformat/mux.c
    /* duration field */
    if (pkt->duration == 0) {
        ff_compute_frame_duration(s, &num, &den, st, NULL, pkt);
        if (den && num) {
            pkt->duration = av_rescale(1, num * (int64_t)st->time_base.den * st->codec->ticks_per_frame, den * (int64_t)st->time_base.num);
        }
    }

### Describe what you have tested and on which operating system.

Fix was successfully tested on Mac 
The fix is not OS specific.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.
<img width="672" alt="good_fps" src="https://github.com/AcademySoftwareFoundation/OpenRV/assets/117092886/465aab11-efd6-40b7-8fb1-66bee56e0ec4">

