### PR TITLE
Fix Apple Pro Res playback performance issue

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -3429,8 +3429,12 @@ MovieFFMpegReader::decodeImageAtFrame(int inframe, VideoTrack* track)
     // Optimization: We will not seek if the last decoded frame is
     // within a Group Of Picture (GOP) size distance.
     // Note that videoCodecContext->gop_size is 0 for intra-frame compression
+    // Note that we also check for inter-frame compression codecs (m_info.slowRandomAccess)
+    // since we cannot blindly rely on videoCodecContext->gop_size because it is 
+    // initialized by default by FFmpeg with a default value of 12 even for intra-frame
+    // compression codecs (such as Apple Pro Res for example).
     const int nearFrameThreshold =
-        ( videoCodecContext->gop_size != 0 ) ? videoCodecContext->gop_size : 1;
+        ( m_info.slowRandomAccess && videoCodecContext->gop_size != 0 ) ? videoCodecContext->gop_size : 1;
     if (track->lastDecodedVideo == -1 ||
         track->lastDecodedVideo >= inframe ||
         track->lastDecodedVideo <  ( inframe - nearFrameThreshold ) )


### PR DESCRIPTION
### 404: Fix Apple Pro Res playback performance issue

### Linked issues
Fixes #404 

### Summarize your change.

## Problem: 
Playback performances of Apple Pro Res media is negatively impacted when increasing the the number of reader threads

## Cause:
A check was made in the FFmpeg decoding operation executed by a reader thread (MovieFFMpegReader) to limit the number of seekToFrame() for inter-frame codecs. To detect an inter-frame codec, the code was relying on the FFmpeg's AVCodecContext->gop_size where 0 meant intra-frame only codec. However it turns out that we cannot blindly rely on AVCodecContext->gop_size because it is initialized by default by FFmpeg with a default value of 12 even for intra-frame compression codecs (such as Apple Pro Res for example). 
This resulted in each reader thread decoding extra frames it didn't need to reach the one it needed to decode. 
The result was correct but the amount of work was proportional to the number of reader threads set in the RV Preferences.
With 2 reader threads, each frame was "only" decoded twice which was not really noticeable.
With 8 reader threads, each frame ended up being decoded 8x times !

## Solution:
Now checking that a codec is actually an inter-frame codec before limiting the seekToFrame() operation in the reader thread decoding (MovieFFMpegReader).

### Describe what you have tested and on which operating system.
Successfully tested fix on Mac

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.