### PR TITLE
Fix OCIOv2 build break when RV_VFX_PLATFORM=CY2024

### DIFF
--- a/src/lib/ip/OCIONodes/OCIO1DLUT.cpp
+++ b/src/lib/ip/OCIONodes/OCIO1DLUT.cpp
@@ -21,8 +21,16 @@ namespace IPCore
     OCIO::GpuShaderDesc::TextureType textureType =
         OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL;
     OCIO::Interpolation interpolation = OCIO::INTERP_BEST;
+#if defined( RV_VFX_CY2023 )
+    // Older (pre OCIOv2 2.3.x) getTexture() function signature
     shaderDesc->getTexture( idx, textureName, samplerName, width, height,
                             textureType, interpolation );
+#else
+    OCIO::GpuShaderDesc::TextureDimensions _textureDim = 
+        OCIO::GpuShaderDesc::TextureDimensions::TEXTURE_1D;
+    shaderDesc->getTexture( idx, textureName, samplerName, width, height,
+                            textureType, _textureDim, interpolation );
+#endif
     if( !samplerName || !*samplerName || width == 0 )
     {
       TWK_THROW_EXC_STREAM( "The OCIO 1D LUT texture data is corrupted" );


### PR DESCRIPTION
### 412: Fix OCIOv2 build break when RV_VFX_PLATFORM=CY2024

### Linked issues

Fixes #412

### Summarize your change.

Fix OCIOv2 build break when RV_VFX_PLATFORM=CY2024

### Describe the reason for the change.

The OCIO::GpuShaderDesc::getTexture() function signature changes in OCIOv2 2.3.x.
Note that OCIOv2 2.3.x is not used by default. It is only used when RV_VFX_PLATFORM=CY2024 because the VFX Platform CY2024 is a work in progress.
There is an extra OCIO::GpuShaderDesc::TextureDimensions parameter that is returned.
We do not need it so this is why I have prefixed it with an underscore to mimic the python convention of unused variables.
 
### Describe what you have tested and on which operating system.

Successfully built on Mac + Windows

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.