### PR TITLE
Fix crashes on CentOS7 by tweaking the error handling of libpng

### DIFF
--- a/cmake/dependencies/png.cmake
+++ b/cmake/dependencies/png.cmake
@@ -63,7 +63,7 @@ RV_COPY_LIB_BIN_FOLDERS()
 
 ADD_DEPENDENCIES(dependencies ${_target}-stage-target)
 
-ADD_LIBRARY(PNG::PNG STATIC IMPORTED GLOBAL)
+ADD_LIBRARY(PNG::PNG SHARED IMPORTED GLOBAL)
 ADD_DEPENDENCIES(PNG::PNG ${_target})
 IF(NOT RV_TARGET_WINDOWS)
   SET_PROPERTY(
@@ -75,7 +75,9 @@ IF(NOT RV_TARGET_WINDOWS)
     PROPERTY IMPORTED_SONAME ${_libname}
   )
 ELSE()
-  # PNG lib is a STATIC hence our lib & imp lib is a .lib
+  # An import library (.lib) file is often used to resolve references to 
+  # functions and variables in a DLL, enabling the linker to generate code 
+  # for loading the DLL and calling its functions at runtime.
   SET_PROPERTY(
     TARGET PNG::PNG
     PROPERTY IMPORTED_LOCATION "${_implibpath}"


### PR DESCRIPTION
### Fix crashes on CentOS by tweaking the error handling of libpng

### Linked issues
Fixes #420

### Summarize your change.
Modified the custom error handler to support the jmpbuf address instead of relying on libpng to save the address.
It should make sure that the calling convention are similar.

### Describe the reason for the change.
OpenRV was crashing (CentOS7) when opening images sequence of PNGs that had incomplete PNG.

### Describe what you have tested and on which operating system.

- [ ] Rocky Linux 8
- [ ] CentOS 7
- [ ] Windows (todo)
- [ ] MacOS (todo)

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.