### PR TITLE
[FFmpeg 6 Update] Fix issues by adding missing code

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -4531,8 +4531,6 @@ MovieFFMpegWriter::fillAudio(Movie* inMovie, double overflow, bool lastPass)
         TWK_THROW_EXC_STREAM("Error encoding audio frame: " << avErr2Str(ret));
     }
 
-    //TODO Add back the audioFrame->pts assignation
-
     while (ret >= 0)
     {
         ret = avcodec_receive_packet(audioCodecContext, track->audioPacket);
@@ -4556,7 +4554,10 @@ MovieFFMpegWriter::fillAudio(Movie* inMovie, double overflow, bool lastPass)
                 TWK_THROW_EXC_STREAM(
                     "Error while writing audio frame: " << avErr2Str(ret));
             }
+            // Update the last time sample in seconds we encoded
+            m_lastAudioTime += samplesToTime(nsamps, m_info.audioSampleRate);
         }
+        track->audioFrame->pts = track->lastEncodedAudio;
     }
 
     //TODO Previously, we had logic to flush delayed audio packets, it got remove. Is it not needed anymore?

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
@@ -358,7 +358,7 @@ class MovieFFMpegWriter : public MovieWriter
     bool                               m_canControlRequest;
     bool                               m_verbose;
     std::map<std::string,std::string>  m_parameters;
-    AVOutputFormat*                    m_avOutputFormat;
+    const AVOutputFormat*              m_avOutputFormat;
     AVFormatContext*                   m_avFormatContext;
     SampleTime                         m_audioFrameSize;
     void*                              m_audioSamples;

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
@@ -23,6 +23,7 @@ class AVFormatContext;
 class AVFrame;
 class AVOption;
 class AVOutputFormat;
+class AVPacket;
 class AVRational;
 class AVStream;
 
@@ -332,6 +333,8 @@ class MovieFFMpegWriter : public MovieWriter
     // Audio Methods
     //
 
+    void encodeAudio(AVCodecContext* audioCodecContext, AVFrame* frame, AVPacket* pkt, 
+                     AVStream* audioStream, SampleTime* nsamps, int64_t lastEncAudio);
     bool fillAudio(Movie* inMovie, double overflow, bool lastPass);
     template <typename T> void translateRVAudio(int audioChannels,
         TwkAudio::AudioBuffer* audioBuffer, double max, int offset,
@@ -341,7 +344,8 @@ class MovieFFMpegWriter : public MovieWriter
     // Video Methods
     //
 
-    void fillVideo(FrameBufferVector fbs, int trackIndex, bool lastPass);
+    void encodeVideo(AVCodecContext* ctx, AVFrame* frame, AVPacket* pkt, AVStream* stream, int lastEncVideo);
+    void fillVideo(FrameBufferVector fbs, int trackIndex, int frameIndex, bool lastPass);
     void initVideoTrack(AVStream* avStream);
 
     //


### PR DESCRIPTION
### [FFmpeg 6 Update] Fix issues by adding missing code

### Linked issues
#388

### Summarize your change.
Fixed issue with addTrack method, added back some code to fix a crash when exporting and added back some code to fix a infinite loop while decoding audio.

### Describe the reason for the change.
FFmpeg 6 update

### Describe what you have tested and on which operating system.
- [ ] Rocky Linux 8

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a