### PR TITLE
433: Fix Playback stopping when RV is completely overlapped on macOS

### DIFF
--- a/src/lib/app/RvCommon/QTGLVideoDevice.cpp
+++ b/src/lib/app/RvCommon/QTGLVideoDevice.cpp
@@ -97,6 +97,21 @@ QTGLVideoDevice::redrawImmediately() const
     {
         if (m_view->isVisible()) 
         {
+#ifdef PLATFORM_DARWIN
+            // Make sure that the QGLWidget gets redrawn by updateGL() even
+            // when completely overlapped by another window.
+            // Note that on macOS, Qt correctly detects when the QGLWidget
+            // is completely overlapped by another window and in which case
+            // resets the Qt::WA_Mapped attribute. This will prevent the 
+            // GLView::paintGL() operation from being called by 
+            // m_view->updateGL(), which will result in automatically 
+            // interrupting any video playback that might be in progress while
+            // the RV window is completely overlapped.
+            // This is an undesirable behaviour during a review session, 
+            // especially if an external video output device is used.
+            m_view->setAttribute(Qt::WA_Mapped);
+#endif
+
             m_view->updateGL();
         }
         else 


### PR DESCRIPTION
### 433: Fix Playback stopping when RV is completely overlapped on macOS

### Linked issues
Fixes #433

### Summarize your change.
Make sure that the QGLWidget gets redrawn by updateGL() even when completely overlapped by another window.

### Describe the reason for the change.
On macOS, Qt correctly detects when the QGLWidget is completely overlapped by another window and in which case resets the Qt::WA_Mapped attribute. This prevents the GLView::paintGL() operation from being called by m_view->updateGL(), which will result in automatically interrupting any video playback that might be in progress while the RV window is completely overlapped.
This is an undesirable behaviour during a review session, especially if an external video output device is used.

### Describe what you have tested and on which operating system.
Tested on macOS Sonoma 14.0

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.