### PR TITLE
Add P216 video output buffer format

### DIFF
--- a/src/lib/app/TwkApp/TwkApp/VideoDevice.h
+++ b/src/lib/app/TwkApp/TwkApp/VideoDevice.h
@@ -92,7 +92,11 @@ public:
         Y0CbY1Cr_8_422,         // aka yuvs or YUY2
         Y1CbY0Cr_8_422,
         YCrCb_AJA_10_422,       // v210
-        YCrCb_BM_10_422         // 
+        YCrCb_BM_10_422,        //
+
+        YCbCr_P216_16_422       // Semi-Planar, 4:2:2, 16-bit per component.
+                                // The first buffer is a 16bpp luminance buffer.
+	                            // Immediately after this is an interleaved buffer of 16bpp Cb, Cr pairs.
     };
 
     struct Resolution

--- a/src/lib/app/TwkApp/VideoDevice.cpp
+++ b/src/lib/app/TwkApp/VideoDevice.cpp
@@ -410,6 +410,7 @@ VideoDevice::pixelSizeInBytes(InternalDataFormat f)
       case Y1CbY0Cr_8_422:  return sizeof(unsigned char) * 3;
       case YCrCb_AJA_10_422:
       case YCrCb_BM_10_422: return sizeof(unsigned int);
+      case YCbCr_P216_16_422: return sizeof(unsigned short) * 2;
       default:
           abort();
     }   

--- a/src/lib/graphics/TwkGLF/GLVideoDevice.cpp
+++ b/src/lib/graphics/TwkGLF/GLVideoDevice.cpp
@@ -195,6 +195,7 @@ internalFormatFromDataFormat(VideoDevice::InternalDataFormat f)
       case VideoDevice::Y1CbY0Cr_8_422: return GL_RGB8;
       case VideoDevice::YCrCb_AJA_10_422: return GL_RGB10_A2;
       case VideoDevice::YCrCb_BM_10_422: return GL_RGB10_A2;
+      case VideoDevice::YCbCr_P216_16_422: return GL_RGB10_A2;
           
       default:
           return GL_RGBA16F_ARB;
@@ -227,7 +228,8 @@ textureFormatFromDataFormat(VideoDevice::InternalDataFormat f)
       case VideoDevice::Y0CbY1Cr_8_422:
       case VideoDevice::Y1CbY0Cr_8_422: return GLenumPair(GL_RGB, GL_UNSIGNED_BYTE);
       case VideoDevice::YCrCb_AJA_10_422:
-      case VideoDevice::YCrCb_BM_10_422: return GLenumPair(GL_RGBA, GL_UNSIGNED_INT_10_10_10_2);
+      case VideoDevice::YCrCb_BM_10_422: 
+      case VideoDevice::YCbCr_P216_16_422: return GLenumPair(GL_RGBA, GL_UNSIGNED_INT_10_10_10_2);
           
       default:
           return GLenumPair(GL_RGBA, GL_HALF_FLOAT_ARB);

--- a/src/lib/image/TwkFB/TwkFB/FastConversion.h
+++ b/src/lib/image/TwkFB/TwkFB/FastConversion.h
@@ -109,6 +109,22 @@ TWKFB_EXPORT void packedUYVY16_to_planarYUV16_MP( size_t width, size_t height, c
 TWKFB_EXPORT void packedUVYA16_to_planarYUVA16( size_t width, size_t height, const uint64_t* FASTMEMCPYRESTRICT inBuf, uint16_t* FASTMEMCPYRESTRICT outY, uint16_t* FASTMEMCPYRESTRICT outCb, uint16_t* FASTMEMCPYRESTRICT outCr, uint16_t* FASTMEMCPYRESTRICT outA, size_t strideY, size_t strideCb, size_t strideCr, size_t strideA );
 TWKFB_EXPORT void packedUVYA16_to_planarYUVA16_MP( size_t width, size_t height, const uint64_t* FASTMEMCPYRESTRICT inBuf, uint16_t* FASTMEMCPYRESTRICT outY, uint16_t* FASTMEMCPYRESTRICT outCb, uint16_t* FASTMEMCPYRESTRICT outCr, uint16_t* FASTMEMCPYRESTRICT outA, size_t strideY, size_t strideCb, size_t strideCr, size_t strideA );
 
+/// @brief Converts packed YUV-444 10-bits to semi-planar YUV-422 16-bits (P216)
+///
+/// @param width The number of pixels per row.
+/// @param height The number of rows.
+/// @param inBuf The input buffer.
+/// @param outBufY The output buffer Y.
+/// @param outBufCbCr The output buffer CbCr
+/// @param inBufStride The stride of the output buffer in bytes.
+/// @param outBufStride The stride of the input buffer in bytes.
+TWKFB_EXPORT void packedYUV444_10bits_to_P216( size_t width, size_t height, const uint32_t*FASTMEMCPYRESTRICT inBuf, 
+    uint16_t*FASTMEMCPYRESTRICT outBufY, uint16_t*FASTMEMCPYRESTRICT outBufCbC, 
+    size_t inBufStride, size_t outBufStride, bool flip );
+TWKFB_EXPORT void packedYUV444_10bits_to_P216_MP( size_t width, size_t height, const uint32_t*FASTMEMCPYRESTRICT inBuf, 
+    uint16_t*FASTMEMCPYRESTRICT outBufY, uint16_t*FASTMEMCPYRESTRICT outBufCbC, 
+    size_t inBufStride, size_t outBufStride, bool flip );
+
 /// @brief Converts packed BGRA 64-bits BE to packed ABGR 64-bits LE.
 ///
 /// @param width The number of bytes per row.


### PR DESCRIPTION
### Add P216 video output buffer format

### Linked issues
NA

### Summarize your change.

This commit adds P216 video output buffer format support to Open RV.

P216 
This is a 4:2:2 buffer in semi-planar format with full 16bpp color
precision. This is formed from two buffers in memory, the first is a 16bpp
luminance buffer and the second is a buffer of U,V pairs in memory. 

### Describe the reason for the change.

This format is the 16 bits internal buffer format representation used by the NDI SDK which will allow an upcoming version of Open RV to support the NDI SDK 6.0.0 with 10 bits support.

### Describe what you have tested and on which operating system.
Tested on macOS 

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.