### PR TITLE
RVPaint fix segment edge intersection when path has variable widths

### DIFF
--- a/src/lib/geometry/TwkPaint/TwkPaint/Path.h
+++ b/src/lib/geometry/TwkPaint/TwkPaint/Path.h
@@ -45,6 +45,8 @@ class Path
     {
         Point points[4];
         Color colors[4];
+        Vec vpn;
+        float w0;
         bool none;
     };
     


### PR DESCRIPTION
This fixes an issue when using the annotation tools and having strokes with variable widths.

Variable widths happen when you use a stylus/wacom tablet with pen pressure. When widths can vary, it is possible for the widths of the stroke be just right so that the extruded edges become nearly parallel. This case currently isn't being handled. This creates "spikes" on your brush stroke that can seemly appear at random.

## Example Of The Spikes Occurring

https://github.com/AcademySoftwareFoundation/OpenRV/assets/814966/b7f1dd3f-1eee-4d62-97ec-add94ac12e11

## Isolated Case
Here is a minimal isolated case of the issue happening [spike_isolated.rv.](https://github.com/AcademySoftwareFoundation/OpenRV/files/14950061/spike_isolated.rv.zip)

![image](https://github.com/AcademySoftwareFoundation/OpenRV/assets/814966/81f53ac9-2775-439d-b3e7-493e1b0ddf1f)

I also graphed the polygons in desmos so its easier to see
https://www.desmos.com/calculator/gxmkrpdr2o

The issue occurs when the point of intersection is calculated between line segments AB and CD.
![image](https://github.com/AcademySoftwareFoundation/OpenRV/assets/814966/a6963e34-5377-45a9-a33d-dc64e0416e84)

As we can see the two lines are is nearly parallel. 
![image](https://github.com/AcademySoftwareFoundation/OpenRV/assets/814966/55ebb6e0-5099-41ff-9a20-c4180924615f)

When intersection point is calculated, away we go!
![image](https://github.com/AcademySoftwareFoundation/OpenRV/assets/814966/033dfef3-c2d5-4cf1-8cf1-cb6864c0b3a1)

## The Solution

To fix this issue, I changed the code to perform the intersection as if the line has a constant width. This was the simplest thing I could think of. The spikes never seem to happen with constant width strokes. 
