### PR TITLE
[FFmpeg 6] Fix build issue of FFmpeg / libcrypto

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -323,6 +323,12 @@ FOREACH(
   LIST(APPEND RV_DEPS_LIST ffmpeg::${_ffmpeg_lib})
 ENDFOREACH()
 
+
+TARGET_LINK_LIBRARIES(
+  ffmpeg::avutil
+  INTERFACE OpenSSL::Crypto
+)
+
 TARGET_LINK_LIBRARIES(
   ffmpeg::swresample
   INTERFACE ffmpeg::avutil

--- a/cmake/dependencies/openssl.cmake
+++ b/cmake/dependencies/openssl.cmake
@@ -141,6 +141,12 @@ ELSE()
       ${_lib_dir}/${_ssl_lib_name}
   )
 
+  IF(RV_TARGET_WINDOWS)
+    SET(_implibpath
+        ${_lib_dir}/${CMAKE_IMPORT_LIBRARY_PREFIX}crypto${RV_DEBUG_POSTFIX}${CMAKE_IMPORT_LIBRARY_SUFFIX}
+    )
+  ENDIF()
+
   EXTERNALPROJECT_ADD(
     ${_target}
     DOWNLOAD_NAME ${_target}_${_version}.zip
@@ -171,6 +177,12 @@ ELSE()
     TARGET OpenSSL::Crypto
     PROPERTY IMPORTED_SONAME ${_crypto_lib_name}
   )
+  IF(RV_TARGET_WINDOWS)
+    SET_PROPERTY(
+      TARGET OpenSSL::Crypto
+      PROPERTY IMPORTED_IMPLIB ${_implibpath}
+    )
+  ENDIF()
   TARGET_INCLUDE_DIRECTORIES(
     OpenSSL::Crypto
     INTERFACE ${_include_dir}


### PR DESCRIPTION
### [FFmpeg 6] Fix build issue of FFmpeg / libcrypto

### Linked issues
#388 

### Summarize your change.
Fix issue with the build (specifically on Rocky Linux 9)

### Describe the reason for the change.
There were link issues for RV executable because libcrypto was not found by the linker.

### Describe what you have tested and on which operating system.
Tested the build and ran OpenRV on:

- [ ] Windows
- [ ] Rocky Linux 8 and 9
- [ ] MacOS

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a