### PR TITLE
Enable PNG decoder on Windows

### DIFF
--- a/cmake/dependencies/patch/zlib_Prevent-invalid-inclusions-when-HAVE_-is-set-to-0.patch
+++ b/cmake/dependencies/patch/zlib_Prevent-invalid-inclusions-when-HAVE_-is-set-to-0.patch
@@ -1,0 +1,52 @@
+diff --git a/zconf.h.cmakein b/zconf.h.cmakein
+index a7f24cc..a1b359b 100644
+--- a/zconf.h.cmakein
++++ b/zconf.h.cmakein
+@@ -434,11 +434,19 @@ typedef uLong FAR uLongf;
+ #endif
+ 
+ #ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */
+-#  define Z_HAVE_UNISTD_H
++#  if ~(~HAVE_UNISTD_H + 0) == 0 && ~(~HAVE_UNISTD_H + 1) == 1
++#    define Z_HAVE_UNISTD_H
++#  elif HAVE_UNISTD_H != 0
++#    define Z_HAVE_UNISTD_H
++#  endif
+ #endif
+ 
+ #ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */
+-#  define Z_HAVE_STDARG_H
++#  if ~(~HAVE_STDARG_H + 0) == 0 && ~(~HAVE_STDARG_H + 1) == 1
++#    define Z_HAVE_STDARG_H
++#  elif HAVE_STDARG_H != 0
++#    define Z_HAVE_STDARG_H
++#  endif
+ #endif
+ 
+ #ifdef STDC
+diff --git a/zconf.h.in b/zconf.h.in
+index 5e1d68a..32f53c8 100644
+--- a/zconf.h.in
++++ b/zconf.h.in
+@@ -432,11 +432,19 @@ typedef uLong FAR uLongf;
+ #endif
+ 
+ #ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */
+-#  define Z_HAVE_UNISTD_H
++#  if ~(~HAVE_UNISTD_H + 0) == 0 && ~(~HAVE_UNISTD_H + 1) == 1
++#    define Z_HAVE_UNISTD_H
++#  elif HAVE_UNISTD_H != 0
++#    define Z_HAVE_UNISTD_H
++#  endif
+ #endif
+ 
+ #ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */
+-#  define Z_HAVE_STDARG_H
++#  if ~(~HAVE_STDARG_H + 0) == 0 && ~(~HAVE_STDARG_H + 1) == 1
++#    define Z_HAVE_STDARG_H
++#  elif HAVE_STDARG_H != 0
++#    define Z_HAVE_STDARG_H
++#  endif
+ #endif
+ 
+ #ifdef STDC


### PR DESCRIPTION
### Enable PNG decoder on Windows

### Linked issues
#447 

### Summarize your change.
Make sure that FFmpeg knows where to 

### Describe the reason for the change.
PNG movies were not able to be decoded because PNG decoder in FFmpeg was disabled due to missing ZLIB library during the build of FFmpeg. 

Since ZLIB is installed by default on MacOS and Linux, it wasn't a problem on those systems. But it means that the wrong ZLIB was used by FFmpeg (not the one compiled by OpenRV).

### Describe what you have tested and on which operating system.
- [ ] Windows only

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a