### PR TITLE
Fix issue with OTIO in debug on Windows

### DIFF
--- a/cmake/dependencies/ocio.cmake
+++ b/cmake/dependencies/ocio.cmake
@@ -197,6 +197,13 @@ ELSE() # Windows
       ""
   )
   STRING(REPLACE "." "" PYTHON_VERSION_SHORT_NO_DOT ${RV_DEPS_PYTHON_VERSION_SHORT})
+  
+  # Windows only.
+  # Because of an issue in Debug with minizip-ng finding ZLIB at two locations,
+  # ZLIB_LIBRARY and ZLIB_INCLUDE_DIR is used for both Release and Debug. 
+  # ZLIB_ROOT is not enough to fix the issue.
+  GET_TARGET_PROPERTY(_zlib_library ZLIB::ZLIB IMPORTED_IMPLIB)
+  GET_TARGET_PROPERTY(_zlib_include_dir ZLIB::ZLIB INTERFACE_INCLUDE_DIRECTORIES)
 
   LIST(
     APPEND
@@ -206,7 +213,8 @@ ELSE() # Windows
     "-DOCIO_VERBOSE=ON"
     "-DCMAKE_INSTALL_PREFIX=${_install_dir}"
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-    "-DZLIB_ROOT=${RV_DEPS_ZLIB_ROOT_DIR}"
+    "-DZLIB_LIBRARY=${_zlib_library}"
+    "-DZLIB_INCLUDE_DIR=${_zlib_include_dir}"
     # Using the expat build with /MD to match the CRT.
     "-Dexpat_DIR=${_vcpkg_path}/packages/expat_x64-windows-static-md/share/expat"
     "-DImath_DIR=${RV_DEPS_IMATH_ROOT_DIR}/lib/cmake/Imath"
@@ -361,8 +369,8 @@ IF(RV_TARGET_WINDOWS)
       TARGET ${_target}
       POST_BUILD
       COMMENT "Rename PyOpenColorIO.py to PyOpenColorIO_d.py in '${_rv_stage_lib_site_package_dir}' and '${_ocio_stage_plugins_python_dir}."
-      COMMAND ${CMAKE_COMMAND} -E rename ${_rv_stage_lib_site_package_dir}/PyOpenColorIO.pyd ${_rv_stage_lib_site_package_dir}/PyOpenColorIO_d.pyd
-      COMMAND ${CMAKE_COMMAND} -E rename ${_pyocio_lib} ${_ocio_stage_plugins_python_dir}/PyOpenColorIO_d.pyd
+      COMMAND ${CMAKE_COMMAND} -E copy ${_rv_stage_lib_site_package_dir}/PyOpenColorIO.pyd ${_rv_stage_lib_site_package_dir}/PyOpenColorIO_d.pyd
+      COMMAND ${CMAKE_COMMAND} -E copy ${_pyocio_lib} ${_ocio_stage_plugins_python_dir}/PyOpenColorIO_d.pyd
     )
   ENDIF()
 ENDIF()

--- a/cmake/dependencies/openssl.cmake
+++ b/cmake/dependencies/openssl.cmake
@@ -141,6 +141,16 @@ ELSE()
       ${_lib_dir}/${_ssl_lib_name}
   )
 
+  IF(RV_TARGET_WINDOWS)
+    SET(_implibpath_crypto
+        ${_lib_dir}/${CMAKE_IMPORT_LIBRARY_PREFIX}crypto${CMAKE_IMPORT_LIBRARY_SUFFIX}
+    )
+
+    SET(_implibpath_ssl
+        ${_lib_dir}/${CMAKE_IMPORT_LIBRARY_PREFIX}ssl${CMAKE_IMPORT_LIBRARY_SUFFIX}
+    )
+  ENDIF()
+
   EXTERNALPROJECT_ADD(
     ${_target}
     DOWNLOAD_NAME ${_target}_${_version}.zip
@@ -171,6 +181,12 @@ ELSE()
     TARGET OpenSSL::Crypto
     PROPERTY IMPORTED_SONAME ${_crypto_lib_name}
   )
+  IF(RV_TARGET_WINDOWS)
+    SET_PROPERTY(
+      TARGET OpenSSL::Crypto
+      PROPERTY IMPORTED_IMPLIB ${_implibpath_crypto}
+    )
+  ENDIF()
   TARGET_INCLUDE_DIRECTORIES(
     OpenSSL::Crypto
     INTERFACE ${_include_dir}
@@ -187,6 +203,12 @@ ELSE()
     TARGET OpenSSL::SSL
     PROPERTY IMPORTED_SONAME ${_ssl_lib_name}
   )
+  IF(RV_TARGET_WINDOWS)
+    SET_PROPERTY(
+      TARGET OpenSSL::SSL
+      PROPERTY IMPORTED_IMPLIB ${_implibpath_ssl}
+    )
+  ENDIF()
   TARGET_INCLUDE_DIRECTORIES(
     OpenSSL::SSL
     INTERFACE ${_include_dir}

--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -121,6 +121,8 @@ ENDIF()
 IF(RV_TARGET_WINDOWS)
   LIST(APPEND _python3_make_command "--opentimelineio-source-dir")
   LIST(APPEND _python3_make_command ${rv_deps_opentimelineio_SOURCE_DIR})
+  LIST(APPEND _python3_make_command "--python-version")
+  LIST(APPEND _python3_make_command "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
 ENDIF()
 
 IF(${RV_OSX_EMULATION})


### PR DESCRIPTION
### Fix issue with OTIO in debug on Windows

### Linked issues
n/a

### Summarize your change.
- [x] Fix issue with `OTIO` in debug on Windows by specifying the library file and includes directly to CMake.
- [x] Fix an issue in debug on Windows where `ZLIB (release)` was found in MinGW system files **and** where `ZLIB` was found in RV_DEPS_ZLIB (debug). Both were linked and it was causing issue with `minizip-ng`. I think it is an issue with `minizip-ng`, but the fix makes sure that we only linked to the right one.
- [x] Sets `IMPORTED_IMPLIB` for `SSL` and `Crypto` target on Windows
- [x] Use `CMake` instead of the configure script and make for PCRE2 (Windows only).

### Describe the reason for the change.
Long standing instability with OTIO in debug on Windows. I always had issues building OpenRV in debug on Windows due to OTIO. This PR makes the debug build more stable, and I can build OpenRV in debug straight from a fresh cloned repository.

### Describe what you have tested and on which operating system.
- [x] Windows

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a