### PR TITLE
Add .rvpkg bundle support for rvpkg command line tools and UI

### DIFF
--- a/src/lib/app/RvCommon/RvPreferences.cpp
+++ b/src/lib/app/RvCommon/RvPreferences.cpp
@@ -2937,7 +2937,7 @@ RvPreferences::addPackage(bool)
     QFileDialog* fileDialog = new QFileDialog(this, 
                                               "Select rvpkg RV package files",
                                               dirname,
-                                              "rvpkg Package Files (*.zip *.rvpkg)");
+                                              "rvpkg Package Files (*.zip *.rvpkg *.rvpkgs)");
 
     QStringList files;
     if (fileDialog->exec()) files = fileDialog->selectedFiles();
@@ -2961,7 +2961,7 @@ RvPreferences::addPackage(bool)
     QStringList files = QFileDialog::getOpenFileNames(this, 
                                                       "Select rvpkg RV package files",
                                                       dirname,
-                                                      "rvpkg Package Files (*.zip *.rvpkg)",
+                                                      "rvpkg Package Files (*.zip *.rvpkg *.rvpkgs, *.rvpkgs)",
                                                       &selectedFilter,
                                                       options);
 #endif
@@ -3119,7 +3119,7 @@ RvPreferences::installDependantPackages(const QString& msg)
 {
     QMessageBox box(this);
     box.setWindowTitle(tr("Some Packages Depend on This One"));
-    box.setText(tr("Can't uninstall package because some other packages dependend on this one. Try and uninstall them first?\n\nDetails:\n") + msg);
+    box.setText(tr("Can't install package because some other packages dependend on this one. Try and install them first?\n\nDetails:\n") + msg);
 
     box.setWindowModality(Qt::WindowModal);
     QPushButton* b1 = box.addButton(tr("Abort"), QMessageBox::RejectRole);
@@ -4026,5 +4026,3 @@ RvPreferences::formatProfileChanged(int index)
 
 
 } // Rv
-
-

--- a/src/lib/app/RvPackage/RvPackage/PackageManager.h
+++ b/src/lib/app/RvPackage/RvPackage/PackageManager.h
@@ -174,6 +174,9 @@ class PackageManager
     virtual bool installPackage(Package&);
     virtual bool uninstallPackage(Package&);
 
+    virtual bool isBundle(const QString&);
+    virtual std::vector<QString> handleBundle(const QString&, const QString&);
+
     virtual ModeEntryList loadModeFile(const QString&);
     virtual void writeModeFile(const QString&, const ModeEntryList&, int version=0);
 
@@ -182,7 +185,7 @@ class PackageManager
 
     virtual bool allowLoading(Package&,bool,int d=0);
     virtual bool makeSupportDirTree(QDir& root);
-    
+
     //
     //  Override these for UI versions. The defaults use cin/cout to
     //  collect responses from the user.


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

Users can now upload multiple packages at the same time through a compressed zip file using the extension **.rvpkgs**. These **.rvpkgs** files can be uploaded using the `rvpkg -add ...` command in the shell, or directly in the UI under the `Preferences/Packages` section of the menu.

In either case, **.rvpkgs** files will be immediately unzipped into the packages they contain before each package is added to OpenRV. 

Users can also add and install these **.rvpkgs** bundles using a chain command as follows.

`rvpkg -force -install -add <destination> <location of .rvpkgs file>`

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

This change was tested on MacOS. To replicate the test, recreate the following steps.

**Creating an .rvpkgs file**

1. Find the .rvpkg files you want to bundle
2. Create a zip folder containing these .rvpkg files
3. Rename this zip file following `<name>-<version>.rvpkgs`

**Testing UI upload**

1. Launch OpenRV
2. Navigate to the `Preferences/Packages` section of the menu
3. Select `Add Packages...` 
4. Select your own **.rvpkgs** file
5. Click open
6. The packages zipped into the **.rvpkgs** file should be added directly into RV

**Testing Command Line**

1. Determine the location of your **.rvpkgs** file
2. Determine the location you want to add/install your  packages to
3. Execute either of the following commands

`rvpkg -force -install -add <destination> <location of .rvpkgs file>`
`rvpkg -add <destination> <location of .rvpkgs file>`

Note that packages are often installed to `~/Library/Application\ Support/RV/` on Mac.

### Add a list of changes, and note any that might need special attention during the review.

- [ ] Added bundle detection and handling functionality to the rvpkg main file (specifically -add and -install sections)
- [ ] Minor bug fix in RvPreferences where text indicated incorrectly that packages could not be uninstalled
- [ ] Added a multitude of utility functions to the PackageManager, compartmentalizing and globalizing unzip and bundle detection functionality