### PR TITLE
Remove unnecessary cmake build from rocky9 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Open RV is currently supported on the following operating systems:
 * [Windows 10 and 11](docs/build_system/config_windows.md)
 * [macOS Big Sur, Monterey and Ventura](docs/build_system/config_macos.md)
 * [Linux Centos 7](docs/build_system/config_linux_centos7.md)
+* [Linux Rocky 8](docs/build_system/config_linux_rocky8.md)
+* [Linux Rocky 9](docs/build_system/config_linux_rocky9.md)
 
 Support for other operating systems is on a best effort basis.
 

--- a/docs/build_system/config_linux_rocky9.md
+++ b/docs/build_system/config_linux_rocky9.md
@@ -46,22 +46,6 @@ Some of the RV build scripts requires extra python packages. They can be install
 python3 -m pip install -r requirements.txt
 ```
 
-## Install CMake
-
-You need CMake version 3.24+ to build RV. The dnf-installable version is not quite recent enough, you'll to build and install CMake from sources.
-
-```bash
-wget https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0.tar.gz
-tar -zxvf cmake-3.24.0.tar.gz
-cd cmake-3.24.0
-./bootstrap --parallel=32  # 32 or whatever your machine allows
-make -j 32  # 32 or whatever your machine allows
-sudo make install
-
-cmake --version  # confirm the version of your newly installed version of CMake
-cmake version 3.24.0
-```
-
 ## Install Qt
 
 Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). Logs, Android, iOS and WebAssembly are not required to build OpenRV.


### PR DESCRIPTION
### Remove unnecessary cmake build from rocky9 setup

### Linked issues
NA

### Summarize your change.
Remove unnecessary cmake build from rocky9 build system setup

### Describe the reason for the change.
Rocky Linux 9 comes with cmake version 3.26.5 which is more recent than the cmake version 3.24 built from sources that were in the build system setup instructions.

### Describe what you have tested and on which operating system.
Open RV Rocky 9 build system instructions were validated on a branch new Rocky 9 installation.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.