### PR TITLE
Make OpenRV buildable on Xcode 15

### DIFF
--- a/cmake/dependencies/boost.cmake
+++ b/cmake/dependencies/boost.cmake
@@ -21,13 +21,44 @@ SET(_major_minor_version
     "1_80"
 )
 
+SET(_download_hash
+    077f074743ea7b0cb49c6ed43953ae95
+)
+
+# Note: Boost 1.80 cannot be built with XCode 15 which is now the only XCode version available on macOS Sonoma without a hack. Boost 1.81 has all the fixes
+# required to be able to be built with XCode 15, however it is not VFX Platform CY2023 compliant which specifies Boost version 1.80. With the aim of making the
+# OpenRV build on macOS smoother by default, we will use Boost 1.81 if XCode 15 or more recent.
+IF(RV_TARGET_DARWIN)
+  EXECUTE_PROCESS(
+    COMMAND clang --version
+    OUTPUT_VARIABLE CLANG_FULL_VERSION_STRING
+  )
+  STRING(
+    REGEX
+    REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${CLANG_FULL_VERSION_STRING}
+  )
+  IF(CLANG_VERSION_STRING VERSION_GREATER_EQUAL 15.0)
+    MESSAGE(STATUS "Clang version ${CLANG_VERSION_STRING} is not compatible with Boost 1.80, using Boost 1.81 instead. "
+                   "Install XCode 14.3.1 if you absolutely want to use Boost version 1.80 as per VFX reference platform CY2023"
+    )
+
+    SET(_version
+        "1.81.0"
+    )
+
+    SET(_major_minor_version
+        "1_81"
+    )
+
+    SET(_download_hash
+        4bf02e84afb56dfdccd1e6aec9911f4b
+    )
+  ENDIF()
+ENDIF()
+
 STRING(REPLACE "." "_" _version_with_underscore ${_version})
 SET(_download_url
     "https://archives.boost.io/release/${_version}/source/boost_${_version_with_underscore}.tar.gz"
-)
-
-SET(_download_hash
-    077f074743ea7b0cb49c6ed43953ae95
 )
 
 # Set _base_dir for Clean-<target>

--- a/cmake/dependencies/boost.cmake
+++ b/cmake/dependencies/boost.cmake
@@ -30,7 +30,7 @@ SET(_download_hash
 # OpenRV build on macOS smoother by default, we will use Boost 1.81 if XCode 15 or more recent.
 IF(RV_TARGET_DARWIN)
   EXECUTE_PROCESS(
-    COMMAND clang --version
+    COMMAND xcrun clang --version
     OUTPUT_VARIABLE CLANG_FULL_VERSION_STRING
   )
   STRING(

--- a/cmake/dependencies/zlib.cmake
+++ b/cmake/dependencies/zlib.cmake
@@ -26,9 +26,10 @@ SET(_install_dir
     ${RV_DEPS_BASE_DIR}/${_target}/install
 )
 
-# This file is pretty close to being ready to use the Standrd macros: (create_lib_bin especially but maybe rv_make_std_lib). One problem is debug names for Libs which is different but there's ways to fix this.
-SET(RV_DEPS_ZLIB_ROOT_DIR 
-  ${_install_dir}
+# This file is pretty close to being ready to use the Standrd macros: (create_lib_bin especially but maybe rv_make_std_lib). One problem is debug names for Libs
+# which is different but there's ways to fix this.
+SET(RV_DEPS_ZLIB_ROOT_DIR
+    ${_install_dir}
 )
 
 SET(_include_dir
@@ -103,12 +104,11 @@ IF(RV_TARGET_WINDOWS)
   LIST(APPEND _zlib_byproducts ${_implibpath})
 ENDIF()
 
-# The patch comes from the ZLIB port in Vcpkg repository.
-# The name of the patch is kept as is. See https://github.com/microsoft/vcpkg/tree/master/ports/zlib
+# The patch comes from the ZLIB port in Vcpkg repository. The name of the patch is kept as is. See https://github.com/microsoft/vcpkg/tree/master/ports/zlib
 # Description: Fix unistd.h being incorrectly required when imported from a project defining HAVE_UNISTD_H=0
-SET(_patch_command 
-    patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/zconf.h.cmakein_prevent_invalid_inclusions.patch
-    && patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/zconf.h.in_prevent_invalid_inclusions.patch
+SET(_patch_command
+    patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/zconf.h.cmakein_prevent_invalid_inclusions.patch && patch -p1 <
+    ${CMAKE_CURRENT_SOURCE_DIR}/patch/zconf.h.in_prevent_invalid_inclusions.patch
 )
 
 EXTERNALPROJECT_ADD(
@@ -154,6 +154,18 @@ IF(RV_TARGET_WINDOWS)
   ADD_CUSTOM_TARGET(
     ${_target}-stage-target ALL
     DEPENDS ${RV_STAGE_BIN_DIR}/${_libname}
+  )
+ELSEIF(RV_TARGET_DARWIN)
+  ADD_CUSTOM_COMMAND(
+    COMMENT "Installing ${_target}'s libs into ${RV_STAGE_LIB_DIR}"
+    OUTPUT ${RV_STAGE_LIB_DIR}/${_libname}
+    COMMAND ${CMAKE_INSTALL_NAME_TOOL} -id "@rpath/${_libname}" "${_lib_dir}/${_libname}"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${_lib_dir} ${RV_STAGE_LIB_DIR}
+    DEPENDS ${_target}
+  )
+  ADD_CUSTOM_TARGET(
+    ${_target}-stage-target ALL
+    DEPENDS ${RV_STAGE_LIB_DIR}/${_libname}
   )
 ELSE()
   ADD_CUSTOM_COMMAND(

--- a/docs/build_system/config_macos.md
+++ b/docs/build_system/config_macos.md
@@ -15,6 +15,12 @@ Note that using an XCode version more recent than 14.3.1 will result in an FFmpe
 
 `xcode-select -p` should return `/Applications/Xcode.app/Contents/Developer`. If it's not the case, run `sudo xcode-select -s /Applications/Xcode.app`
 
+Note that XCode 15 is not compatible with Boost 1.80. If XCode 15 is installed, RV will automatically default to using Boost 1.81 instead. 
+Install XCode 14.3.1 if you absolutely want to use Boost version 1.80 as per VFX reference platform CY2023.
+
+Please reference [this workaround](https://forums.developer.apple.com/forums/thread/734709) to use XCode 14.3.1 on Sonoma, as it is no longer 
+compatible by default.
+
 ## Install Homebrew
 
 Homebrew is the one stop shop providing all the build requirements. You can install it following the instructions on the [Homebrew page](https://brew.sh).

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -47,7 +47,7 @@ RV_BUILD_PARALLELISM="${RV_BUILD_PARALLELISM:-$(python3 -c 'import os; print(os.
 
 # ALIASES: Basic commands
 
-alias rvsetup="SETUPTOOLS_USE_DISTUTILS=${SETUPTOOLS_USE_DISTUTILS} python3 -m pip install --user --upgrade -r ${RV_HOME}/requirements.txt --break-system-packages"
+alias rvsetup="SETUPTOOLS_USE_DISTUTILS=${SETUPTOOLS_USE_DISTUTILS} python3 -m pip install --user --upgrade -r ${RV_HOME}/requirements.txt"
 alias rvcfg="cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
 alias rvcfgd="cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Debug -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
 alias rvbuildt="cmake --build ${RV_BUILD} --config Release -v --parallel=${RV_BUILD_PARALLELISM} --target "

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -47,7 +47,7 @@ RV_BUILD_PARALLELISM="${RV_BUILD_PARALLELISM:-$(python3 -c 'import os; print(os.
 
 # ALIASES: Basic commands
 
-alias rvsetup="SETUPTOOLS_USE_DISTUTILS=${SETUPTOOLS_USE_DISTUTILS} python3 -m pip install --user --upgrade -r ${RV_HOME}/requirements.txt"
+alias rvsetup="SETUPTOOLS_USE_DISTUTILS=${SETUPTOOLS_USE_DISTUTILS} python3 -m pip install --user --upgrade -r ${RV_HOME}/requirements.txt --break-system-packages"
 alias rvcfg="cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
 alias rvcfgd="cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Debug -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
 alias rvbuildt="cmake --build ${RV_BUILD} --config Release -v --parallel=${RV_BUILD_PARALLELISM} --target "

--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -86,16 +86,11 @@ def prepare() -> None:
     system = platform.system()
     if system == "Darwin":
         clang_version_search = re.search(
-            "version (\d+)\.(\d+)",
+            "version (\d+)\.(\d+)\.(\d+)",
             os.popen("clang --version").read(),
         )
-        clang_version_str = "".join(clang_version_search.groups())
-        clang_version_int = int(clang_version_str)
-
-        if clang_version_int <= 120:
-            clang_filename_suffix = clang_version_str + "-based-mac.7z"
-        else:
-            clang_filename_suffix = clang_version_str + "-based-macos-universal.7z"
+        clang_version_str = ".".join(clang_version_search.groups())
+        clang_filename_suffix = clang_version_str + "-based-macos-universal.7z"
     elif system == "Linux":
         clang_filename_suffix = "80-based-linux-Rhel7.2-gcc5.3-x86_64.7z"
     elif system == "Windows":

--- a/src/lib/geometry/TwkPaint/TwkPaint/Path.h
+++ b/src/lib/geometry/TwkPaint/TwkPaint/Path.h
@@ -45,6 +45,8 @@ class Path
     {
         Point points[4];
         Color colors[4];
+        Vec vpn;
+        float w0;
         bool none;
     };
     


### PR DESCRIPTION
### Linked issues

Fixes #278

### Summarize your change.

OpenRV will now default to using Boost 1.81 if the user has Xcode 15 or greater. Otherwise, OpenRV will default to using Boost 1.80, which is compliant with CY 2023 and works with Xcode 14.3.1. This also is outlined for the user in changes to documentation. 

### Describe the reason for the change.

Xcode 14.3.1 is deprecated on macOS Sonoma in favour of Xcode 15 and up, which means users on Sonoma or later will not be able to build OpenRV without this change.

### Describe what you have tested and on which operating system.

A complete build of OpenRV using `rvbootstrap` on macOS Sonoma and Xcode 15.

### Add a list of changes, and note any that might need special attention during the review.

- [ ] CMake automatically uses Boost 1.80 if the Clang version provided by Xcode is less than 15