### PR TITLE
463: Unanonymised QMutexLocker usage in OCIOIPNode.cpp

### DIFF
--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -294,7 +294,7 @@ OCIO::MatrixTransformRcPtr OCIOIPNode::getMatrixTransformXYZToRec709()
 {
     if (!m_matrix_xyz_to_rec709)
     {
-        QMutexLocker(&this->m_lock);
+        QMutexLocker lock(&this->m_lock);
         if (!m_matrix_xyz_to_rec709)
         {
             m_matrix_xyz_to_rec709 = createMatrixTransformXYZToRec709();
@@ -308,7 +308,7 @@ OCIO::MatrixTransformRcPtr OCIOIPNode::getMatrixTransformRec709ToXYZ()
 {
     if (!m_matrix_rec709_to_xyz)
     {
-        QMutexLocker(&this->m_lock);
+        QMutexLocker lock(&this->m_lock);
         if (!m_matrix_rec709_to_xyz)
         {
             m_matrix_rec709_to_xyz = createMatrixTransformXYZToRec709();
@@ -477,7 +477,7 @@ OCIOIPNode::evaluate(const Context& context)
 
             if (!m_transform)
             {
-                QMutexLocker(&this->m_lock);
+                QMutexLocker lock(&this->m_lock);
                 if (!m_transform)
                 {
                     m_transform = OCIO::GroupTransform::Create();
@@ -522,7 +522,7 @@ OCIOIPNode::evaluate(const Context& context)
 
             if (!m_transform)
             {
-                QMutexLocker(&this->m_lock);
+                QMutexLocker lock(&this->m_lock);
                 if (!m_transform)
                 {
                     m_transform = OCIO::GroupTransform::Create();
@@ -546,7 +546,7 @@ OCIOIPNode::evaluate(const Context& context)
         shaderName << "OCIO_sd_" << name() << "_" << hex << hashValue;
       }
 
-      QMutexLocker( &this->m_lock );
+      QMutexLocker lock(&this->m_lock);
       OCIO::GpuShaderDescRcPtr shaderDesc =
           OCIO::GpuShaderDesc::CreateShaderDesc();
       shaderDesc->setFunctionName( shaderName.str().c_str() );


### PR DESCRIPTION
### Linked issues
Should fix [#463](https://github.com/AcademySoftwareFoundation/OpenRV/issues/463)

### Summarize your change.
Added "lock" variable name to all anonymous QMutexLocker instances to extend their lifespan to the end of their scope. This matches the QMutexLocker usage in other parts of the app (RVConsoleWindow.cpp and QTAudioRenderer.cpp).

### Describe the reason for the change
Enabling OCIO was causing frequent crashing when reader threads were set greater than 1, in particular under MacOS Sonoma.
