### PR TITLE
Fix FFmpeg 6.0 crashes when loading 50+ clips and stressing the timeline

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -5467,19 +5467,26 @@ MovieFFMpegIO::MovieFFMpegIO(CodecFilterFunction codecFilter,
                 sdparams);
     }
 
-    if (!globalContextPool)
-    {
-        int poolSize = 500;
-        if (const char* c = getenv("TWK_MOVIEFFMPEG_CONTEXT_POOL_SIZE"))
-        {
-            poolSize = atoi(c);
-        }
-        if (poolSize > 0) globalContextPool = new ContextPool(poolSize);
-        else
-        {
-            report("Disabling mio_ffmpeg context thread pool.", true);
-        }
-    }
+    // Note : No longer using the global context pool (since FFmpeg 6.0)
+    // Rationale: The global context pool was based on the premise that a context 
+    // could be opened and closed multiple times. 
+    // However, with FFmpeg 6.0, this premise is no longer valid and was causing crashes.
+    // As per the FFmpeg 6 documentation: https://ffmpeg.org/doxygen/trunk/deprecated.html:
+    // "Opening and closing a codec context multiple times is not supported anymore – use multiple codec contexts instead."
+
+    // if (!globalContextPool)
+    // {
+    //     int poolSize = 500;
+    //     if (const char* c = getenv("TWK_MOVIEFFMPEG_CONTEXT_POOL_SIZE"))
+    //     {
+    //         int poolSize = atoi(c);
+    //     }
+    //     if (poolSize > 0) globalContextPool = new ContextPool(poolSize);
+    //     else
+    //     {
+    //         report("Disabling mio_ffmpeg context thread pool.", true);
+    //     }
+    // }
 }
 
 MovieFFMpegIO::~MovieFFMpegIO()


### PR DESCRIPTION
### 483: Fix FFmpeg 6.0 crashes when loading 50+ clips and stressing the timeline

### Linked issues
Fixes #483

### Summarize your change.
No longer using the MovieFFMpeg global context pool (since FFmpeg 6.0)

### Describe the reason for the change.
Rationale: The global context pool was based on the premise that a context could be opened and closed multiple times. 
However, with FFmpeg 6.0, this premise is no longer valid and was causing crashes.
As per the FFmpeg 6 documentation: https://ffmpeg.org/doxygen/trunk/deprecated.html:
"Opening and closing a codec context multiple times is not supported anymore – use multiple codec contexts instead."

### Describe what you have tested and on which operating system.
Successfully validated repro steps

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.