### PR TITLE
Make the shotgrid_login package installable in Open RV

### DIFF
--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -520,8 +520,7 @@ FUNCTION(rv_stage)
 
         # Cleanup
         EXECUTE_PROCESS(
-          COMMAND bash -c "rm -rf tmp raw-package.zip included-files.zip"
-          COMMAND bash -c "rm -f ${RV_STAGE_PLUGINS_PACKAGES_DIR}/rvinstall"
+          COMMAND bash -c "rm -rf tmp raw-package.zip included-files.zip ${RV_STAGE_PLUGINS_PACKAGES_DIR}/rvinstall"
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
         


### PR DESCRIPTION
### Fixes #492

### Summarize your change.

In this pull request, adjustments have been made to the rv_stage CMAKE macro. This change allows for the flexible inclusion of external directories in .rvpkg files during build time using an INCLUDE_DIR parameter. 

The changes use the `CMAKE_CURRENT_BINARY_DIR ` to copy and merge the existing .rvpkg zip file with an external directory requested by the user.

### Describe the reason for the change.

With this change, the sgtk dependency can be easily included with the shotgrid_login package during build time through the RV_STAGE macro. Including the sgtk dependency in the shotgrid_login prevents the console build error described in issue #492. 

### Describe what you have tested and on which operating system.

All tests have been conducted manually on macOS Sonoma 14.5.

### Add a list of changes, and note any that might need special attention during the review.

- [ ] Add INCLUDE_DIR parameter to RV_STAGE macro
- [ ] Add additional build step when INCLUDE_DIR parameter is included where the specified directory is merged with the existing package using the CMAKE_CURRENT_BINARY_DIR

### If possible, provide screenshots.