### PR TITLE
Fix rotation metadata loading incorrectly with FFMPEG 6

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -1491,7 +1491,7 @@ MovieFFMpegReader::snagOrientation(VideoTrack* track)
     rotation = (rotEntry) ? atoi(rotEntry->value) : 0;
 
     // If rotation metadata not in metadata, try to get it from side data
-    if (rotation == 0 && videoStream->nb_side_data > 0) {
+    if (!rotEntry && videoStream->nb_side_data > 0) {
         double sideRotation = 0;
         for (int i = 0; i < videoStream->nb_side_data; ++i) {
             const AVPacketSideData *sd = &videoStream->side_data[i];

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -1499,7 +1499,7 @@ MovieFFMpegReader::snagOrientation(VideoTrack* track)
                 sideRotation = av_display_rotation_get((int32_t *)sd->data);
             }
         }
-        rotation = (int)sideRotation;
+        rotation = std::lround(sideRotation);
     }
 
     bool rotate = false;


### PR DESCRIPTION
### Linked issues #496

### Summarize your change.

Added an additional check to another metadata field when loading movie clips to ensure that rotation metadata is captured correctly.

### Describe the reason for the change.

In FFmpeg 6.0, rotation metadata can be loaded incorrectly without this check.

### Describe what you have tested and on which operating system.

macOS Sonoma 14.5

### Add a list of changes, and note any that might need special attention during the review.

- Added an additional check to the `side_data` field when movies are loaded in to RV
- Covered additional cases of negative rotation metadata, as this was not covered already

### If possible, provide screenshots.

![Roatate-Metadata-Missing](https://github.com/AcademySoftwareFoundation/OpenRV/assets/85132405/39992046-02f3-46d8-9926-25b5cf361d51)