### PR TITLE
Modified to allow arbitrary metadata to show up in RV.

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -840,7 +840,7 @@ isMetadataField(string check)
 
 
 bool
-ignoreMetadataField(string check)
+ignoreMetadataField(const string& check)
 {
     for (const char** p = ignoreMetadataFieldsArray; *p; p++)
     {
@@ -1252,6 +1252,14 @@ MovieFFMpegReader::openAVCodec(int index, AVCodecContext** avCodecContext)
         cout << "ERROR: MovieFFMpeg: Unsupported codec_id '" <<
             avStream->codecpar->codec_id << "' in " << m_filename << endl;
         return false;
+    }
+
+    if (avCodec->name == "libdav1d"){
+        const AVCodec *avCodec1 = avcodec_find_decoder_by_name("av1_nvdec");
+        if (avCodec1){
+            cerr << "WARNING: Using av1_nvdec codec rather than Dav1d\n";
+            avCodec = avCodec1; 
+        }
     }
 
     *avCodecContext = avcodec_alloc_context3(avCodec);
@@ -5492,26 +5500,19 @@ MovieFFMpegIO::MovieFFMpegIO(CodecFilterFunction codecFilter,
                 sdparams);
     }
 
-    // Note : No longer using the global context pool (since FFmpeg 6.0)
-    // Rationale: The global context pool was based on the premise that a context 
-    // could be opened and closed multiple times. 
-    // However, with FFmpeg 6.0, this premise is no longer valid and was causing crashes.
-    // As per the FFmpeg 6 documentation: https://ffmpeg.org/doxygen/trunk/deprecated.html:
-    // "Opening and closing a codec context multiple times is not supported anymore – use multiple codec contexts instead."
-
-    // if (!globalContextPool)
-    // {
-    //     int poolSize = 500;
-    //     if (const char* c = getenv("TWK_MOVIEFFMPEG_CONTEXT_POOL_SIZE"))
-    //     {
-    //         int poolSize = atoi(c);
-    //     }
-    //     if (poolSize > 0) globalContextPool = new ContextPool(poolSize);
-    //     else
-    //     {
-    //         report("Disabling mio_ffmpeg context thread pool.", true);
-    //     }
-    // }
+    if (!globalContextPool)
+    {
+        int poolSize = 500;
+        if (const char* c = getenv("TWK_MOVIEFFMPEG_CONTEXT_POOL_SIZE"))
+        {
+            poolSize = atoi(c);
+        }
+        if (poolSize > 0) globalContextPool = new ContextPool(poolSize);
+        else
+        {
+            report("Disabling mio_ffmpeg context thread pool.", true);
+        }
+    }
 }
 
 MovieFFMpegIO::~MovieFFMpegIO()

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -617,6 +617,12 @@ const char* metadataFieldsArray[] = {
     "lyrics", "network", "rotate", "show", "synopsis", "title", "track", "year",
     0 };
 
+const char* ignoreMetadataFieldsArray[] = { 
+    "major_brand", "minor_version","compatible_brands", "handler_name",
+    "vendor_id", "language",
+    "duration", // We ignore it here, since its explicitly added elsewhere.
+    0};
+
 //----------------------------------------------------------------------
 //
 // Static Helpers
@@ -826,6 +832,17 @@ bool
 isMetadataField(string check)
 {
     for (const char** p = metadataFieldsArray; *p; p++)
+    {
+        if (*p == check) return true;
+    }
+    return false;
+}
+
+
+bool
+ignoreMetadataField(string check)
+{
+    for (const char** p = ignoreMetadataFieldsArray; *p; p++)
     {
         if (*p == check) return true;
     }
@@ -1382,13 +1399,21 @@ MovieFFMpegReader::snagMetadata(AVDictionary* dict, string source,
     AVDictionaryEntry *tag = 0;
     while ((tag = av_dict_get(dict, "", tag, AV_DICT_IGNORE_SUFFIX)))
     {
-        string key = tag->key;
+        // We force the key to lower case, since the mkv file format has all its
+        // metadata in uppercase, and mov and mp4 are in lowercase.
+        string lckey = tag->key;
+        for( int i = 0; i < lckey.length(); i++ ) lckey[i] = tolower( lckey[i] );
+
+        // Then we make a version of the key with first letter caps for display only.
+        string key = lckey;
         key[0] = toupper(key[0]);
+
         ostringstream attrKey, attrValue;
         attrKey << source << "/" << key;
         attrValue << tag->value;
         DBL (DB_METADATA, attrKey.str() << ": " << attrValue.str());
-        if (filter && !(isMetadataField(string(tag->key)))) continue;
+        if( filter && ignoreMetadataField( string( lckey ) ) ) continue;
+
         fb->newAttribute(attrKey.str(), attrValue.str());
     }
 }


### PR DESCRIPTION
MKV in particular allows arbitrary key/value metadata pairs. The previous code only allowed a known list of parameters to be passed through to RV. This version has a list of parameters that should NOT be passed through.

### Describe what you have tested and on which operating system.
I've tested loading mov and mkv files on windows.

Below is an example of getting a field called "samfield" to show up in the info display.

<img width="385" alt="image" src="https://github.com/AcademySoftwareFoundation/OpenRV/assets/3487976/b1fc7fb6-a42b-4a33-85e1-983c0f4ad1c0">

This metadata was added using the following ffmpeg command:
```
ffmpeg -i chimera_cars_srgb-test_mov-mjpeg.mov -metadata samfield=samtest -c copy chimera_cars_srgb-test_mov-mjpeg.mkv
```
