### PR TITLE
Automatically set QT_HOME variable if it is not already set

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -21,67 +21,44 @@ if [[ $SOURCED == 0 ]]; then
   exit 1
 fi
 
-QT_VERSION="${QT_VERSION:-5.15.2}"
-
 # Linux
 if [[ "$OSTYPE" == "linux"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
-
-  # Searching for a Qt installation path if it has not already been set
-  if [ -z "$QT_HOME" ]; then
-    echo "Searching for Qt installation..."
-    QT_HOME=$(mdfind -name Qt | grep gcc_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
-    if [ -z "$QT_HOME" ]; then
-      echo "Could not find Qt installation. Please set QT_HOME to the correct path in .bashrc or .zshrc."
-      exit 1
-    else 
-      echo "Found Qt installation at $QT_HOME"
-    fi
-  else 
-    echo "Using Qt installation set at $QT_HOME"
-  fi
+  QT_REGEX=$(mdfind -name Qt | grep gcc_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
 
 # MacOS
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
-
-  # Searching for a Qt installation path if it has not already been set
-  if [ -z "$QT_HOME" ]; then
-    echo "Searching for Qt installation..."
-    QT_HOME=$(mdfind -name Qt | grep clang_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
-    if [ -z "$QT_HOME" ]; then
-      echo "Could not find Qt installation. Please set QT_HOME to the correct path in .bashrc or .zshrc."
-      exit 1
-    else 
-      echo "Found Qt installation at $QT_HOME"
-    fi
-  else 
-    echo "Using Qt installation set at $QT_HOME"
-  fi
+  QT_REGEX=$(mdfind -name Qt | grep clang_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
 
 # Windows
 elif [[ "$OSTYPE" == "msys"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Visual Studio 17 2022}"
-
-  # Searching for a Qt installation path if it has not already been set
-  if [ -z "$QT_HOME" ]; then
-    echo "Searching for Qt installation..."
-    QT_HOME=$(find c:/Qt -name 'qmake.exe' | grep msvc2019_64 | head -n 1 | sed 's|/bin/qmake.exe||') # Assuming use of msvc2019_64
-    if [ -z "$QT_HOME" ]; then
-      echo "Could not find Qt installation. Please set QT_HOME to the correct path in your environment variables."
-    else 
-      echo "Found Qt installation at $QT_HOME"
-    fi
-  else 
-    echo "Using Qt installation set at $QT_HOME"
-  fi
-
+  QT_REGEX=$(find c:/Qt -name 'qmake.exe' | grep msvc2019_64 | head -n 1 | sed 's|/bin/qmake.exe||') # Assuming use of msvc2019_64
   WIN_PERL="${WIN_PERL:-c:/Strawberry/perl/bin}"
   CMAKE_WIN_ARCH="${CMAKE_WIN_ARCH:--A x64}"
   SETUPTOOLS_USE_DISTUTILS=stdlib
+
 else
   echo "OS does not seem to be linux, darwin or msys. Exiting."
   exit 1
+fi
+
+# Searching for a Qt installation path if it has not already been set
+if [ -z "$QT_HOME" ]; then
+  echo "Searching for Qt installation..."
+  QT_HOME="$QT_REGEX"
+
+  # Could not find Qt installation
+  if [ -z "$QT_HOME" ]; then
+    echo "Could not find Qt installation. Please set QT_HOME to the correct path in your environment variables."
+  else 
+    echo "Found Qt installation at $QT_HOME"
+  fi
+
+# Qt installation path already set
+else 
+  echo "Using Qt installation already set at $QT_HOME"
 fi
 
 # VARIABLES

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -22,15 +22,57 @@ if [[ $SOURCED == 0 ]]; then
 fi
 
 QT_VERSION="${QT_VERSION:-5.15.2}"
+
+# Linux
 if [[ "$OSTYPE" == "linux"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
-  QT_HOME="${QT_HOME:-$HOME/Qt/${QT_VERSION}/gcc_64}"
+
+  # Searching for a Qt installation path if it has not already been set
+  if [ -z "$QT_HOME" ]; then
+    QT_HOME=$(mdfind -name Qt | grep gcc_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
+    if [ -z "$QT_HOME" ]; then
+      echo "Could not find Qt installation. Please set QT_HOME to the correct path in .bashrc or .zshrc."
+      exit 1
+    else 
+      echo "Found Qt installation at $QT_HOME"
+    fi
+  else 
+    echo "Using Qt installation set at $QT_HOME"
+  fi
+
+# MacOS
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
-  QT_HOME="${QT_HOME:-$HOME/Qt/${QT_VERSION}/clang_64}"
+
+  # Searching for a Qt installation path if it has not already been set
+  if [ -z "$QT_HOME" ]; then
+    QT_HOME=$(mdfind -name Qt | grep clang_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
+    if [ -z "$QT_HOME" ]; then
+      echo "Could not find Qt installation. Please set QT_HOME to the correct path in .bashrc or .zshrc."
+      exit 1
+    else 
+      echo "Found Qt installation at $QT_HOME"
+    fi
+  else 
+    echo "Using Qt installation set at $QT_HOME"
+  fi
+
+# Windows
 elif [[ "$OSTYPE" == "msys"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Visual Studio 17 2022}"
-  QT_HOME="${QT_HOME:-c:/Qt/${QT_VERSION}/msvc2019_64}"
+
+  # Searching for a Qt installation path if it has not already been set
+  if [ -z "$QT_HOME" ]; then
+    QT_HOME=$(find c:/Qt -name 'qmake.exe' | grep msvc2019_64 | head -n 1 | sed 's|/bin/qmake.exe||') # Assuming use of msvc2019_64
+    if [ -z "$QT_HOME" ]; then
+      echo "Could not find Qt installation. Please set QT_HOME to the correct path in your environment variables."
+    else 
+      echo "Found Qt installation at $QT_HOME"
+    fi
+  else 
+    echo "Using Qt installation set at $QT_HOME"
+  fi
+
   WIN_PERL="${WIN_PERL:-c:/Strawberry/perl/bin}"
   CMAKE_WIN_ARCH="${CMAKE_WIN_ARCH:--A x64}"
   SETUPTOOLS_USE_DISTUTILS=stdlib

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -24,17 +24,14 @@ fi
 # Linux
 if [[ "$OSTYPE" == "linux"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
-  QT_REGEX=$(mdfind -name Qt | grep gcc_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
 
 # MacOS
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
-  QT_REGEX=$(mdfind -name Qt | grep clang_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
 
 # Windows
 elif [[ "$OSTYPE" == "msys"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Visual Studio 17 2022}"
-  QT_REGEX=$(find c:/Qt -name 'qmake.exe' | grep msvc2019_64 | head -n 1 | sed 's|/bin/qmake.exe||') # Assuming use of msvc2019_64
   WIN_PERL="${WIN_PERL:-c:/Strawberry/perl/bin}"
   CMAKE_WIN_ARCH="${CMAKE_WIN_ARCH:--A x64}"
   SETUPTOOLS_USE_DISTUTILS=stdlib
@@ -47,7 +44,14 @@ fi
 # Searching for a Qt installation path if it has not already been set
 if [ -z "$QT_HOME" ]; then
   echo "Searching for Qt installation..."
-  QT_HOME="$QT_REGEX"
+
+  if [[ "$OSTYPE" == "linux"* ]]; then
+    QT_HOME=$(find ~/Qt* -type d -maxdepth 4 -path '*/gcc_64' | head -n 1)
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    QT_HOME=$(find ~/Qt* -type d -maxdepth 4 -path '*/clang_64' | head -n 1)
+  elif [[ "$OSTYPE" == "msys"* ]]; then
+    QT_HOME=$(find c:/Qt* -type d -maxdepth 4 -path '*/msvc2019_64' | head -n 1)
+  fi
 
   # Could not find Qt installation
   if [ -z "$QT_HOME" ]; then

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -29,6 +29,7 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 
   # Searching for a Qt installation path if it has not already been set
   if [ -z "$QT_HOME" ]; then
+    echo "Searching for Qt installation..."
     QT_HOME=$(mdfind -name Qt | grep gcc_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
     if [ -z "$QT_HOME" ]; then
       echo "Could not find Qt installation. Please set QT_HOME to the correct path in .bashrc or .zshrc."
@@ -46,6 +47,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 
   # Searching for a Qt installation path if it has not already been set
   if [ -z "$QT_HOME" ]; then
+    echo "Searching for Qt installation..."
     QT_HOME=$(mdfind -name Qt | grep clang_64 | head -n 1 | sed 's|\(.*clang_64\).*|\1|')
     if [ -z "$QT_HOME" ]; then
       echo "Could not find Qt installation. Please set QT_HOME to the correct path in .bashrc or .zshrc."
@@ -63,6 +65,7 @@ elif [[ "$OSTYPE" == "msys"* ]]; then
 
   # Searching for a Qt installation path if it has not already been set
   if [ -z "$QT_HOME" ]; then
+    echo "Searching for Qt installation..."
     QT_HOME=$(find c:/Qt -name 'qmake.exe' | grep msvc2019_64 | head -n 1 | sed 's|/bin/qmake.exe||') # Assuming use of msvc2019_64
     if [ -z "$QT_HOME" ]; then
       echo "Could not find Qt installation. Please set QT_HOME to the correct path in your environment variables."


### PR DESCRIPTION
### Linked issues

#502 

### Summarize your change.

When RV is built, we now search for QT_HOME (the QT installation location), rather than assuming it. 

### Describe the reason for the change.

Some customers have reported having issues with QT_HOME not being set correctly due to the static assumption we have made about the installation location of QT.

### Describe what you have tested and on which operating system.

QT_HOME is set properly, regardless of QT installation location, for macOS Sonoma 14.5 and Windows 11. L 

### Add a list of changes, and note any that might need special attention during the review.