### PR TITLE
Make FFmpeg rebuild when configure options change

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Use the `rvcfg` (the common build alias) to run the configuration step. You can 
 Legal Notice: Non free FFmpeg codecs are disabled by default. Please check with your legal department whether you have the proper licenses and rights to use these codecs. 
 ASWF is not responsible for any unlicensed use of these codecs.
 
-The RV_FFMPEG_ENABLE_NON_FREE_DECODERS and RV_FFMPEG_ENABLE_NON_FREE_ENCODERS can optionally be specified at configure time to enable non free FFmpeg decoders and encoders respectively.
+The RV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE and RV_FFMPEG_NON_FREE_ENCODERS_TO_ENABLE can optionally be specified at configure time to enable non free FFmpeg decoders and encoders respectively.
 
 Example:
 ```bash


### PR DESCRIPTION
### Make FFmpeg rebuild when configure options change

### Linked issues
NA

### Summarize your change.
Make FFmpeg rebuild when configure options change
Also fixed an inconsistency with the RV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE documentation in README.md.

### Describe the reason for the change.
In a previous commit was added the capability of adding non free FFmpeg decoders+encoders at configure time.
However, there were 2 issues when re-configuring with different non free codec options after a build: the FFmpeg was not rebuilt, and if it was rebuilt, the new FFmpeg libs were not copied over the stage area.
Both of these issues are solved in this commit.

Also in this commit: An inconsistency with the RV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE/RV_FFMPEG_NON_FREE_ENCODERS_TO_ENABLE documentation in README.md was fixed. (The README.md was incorrectly documenting the previous names of the FFmpeg configure options.)

### Describe what you have tested and on which operating system.
Successfully tested on macOS by alternating between the two following FFmpeg configure options:

rvcfg
rvbuild
Launch OpenRV
Successfully validated that a clip with aac audio could NOT be loaded in OpenRV (aac audio is disabled by default)
Successfully validated that an hevc clip could NOT be loaded in OpenRV (hevc is disabled by default)

rvcfg -DRV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE="aac;hevc"
rvbuild
Launch OpenRV
Successfully validated that a clip with aac audio could be loaded in OpenRV
Successfully validated that an hevc clip could be loaded in OpenRV

rvcfg -DRV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE="aac"
rvbuild
Launch OpenRV
Successfully validated that a clip with aac audio could be loaded in OpenRV
Successfully validated that an hevc clip could NOT be loaded in OpenRV

rvcfg -DRV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE=""
rvbuild
Launch OpenRV
Successfully validated that a clip with aac audio could NOT be loaded in OpenRV
Successfully validated that an hevc clip could NOT be loaded in OpenRV

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.
