### PR TITLE
AV1 codec shouldnt have threaded readers.

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -607,7 +607,7 @@ const char* slowRandomAccessCodecsArray[] = {
     "div6", "divx", "dnxhd", "dx50", "h263", "h264", "i263", "iv31", "iv32",
     "m4s2", "mp42", "mp43", "mp4s", "mp4v", "mpeg4", "mpg1", "mpg3", "mpg4",
     "pim1", "s263", "svq1", "svq3", "u263", "vc1", "vc1_vdpau", "vc1image",
-    "viv1", "wmv3", "wmv3_vdpau", "wmv3image", "xith", "xvid",
+    "viv1", "wmv3", "wmv3_vdpau", "wmv3image", "xith", "xvid", "libdav1d",
     0 };
 
 const char* supportedEncodingCodecsArray[] = {


### PR DESCRIPTION
I noticed that if you have an AV1 file, you need to set the threads to 1, to playback properly without stuttering.

e.g. compare:
rv.exe -debug playback -fps 30 -playMode 2 chimera_cars_srgb-test_mp4-libsvtav1-10bit.mp4 -rthreads 4 -play
to
rv.exe -debug playback -fps 30 -playMode 2 chimera_cars_srgb-test_mp4-libsvtav1-10bit.mp4 -rthreads 1 -play

It seems like av1 is missing from the slowRandomAccessCodecsArray array.

Changing this seems to improve things. Athough with the above debug enabled, I'm still seeing lines like:
PATTERN FAIL #15 :  3 1 2 2 2 2 3 2 1 2 // frame = 83 (83)
PATTERN FAIL #16 :  2 3 1 2 2 2 2 3 2 1 // frame = 84 (84)


Which I'm guessing is not good. But that might be something else.