### PR TITLE
Fix doc wrt Open RV prefs and log location

### DIFF
--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-fifteen.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-fifteen.md
@@ -4,9 +4,9 @@ Each RV user has a Preferences file where her personal rv settings are stored. M
 
 | Platform | Location |
 | --- | --- |
-| macOS | $HOME/Library/Preferences/com.autodesk.OpenRV.plist |
-| Linux | $HOME/.config/Autodesk/OpenRV.conf |
-| Windows 7 | ~$HOME/AppData/Roaming/Autodesk/OpenRV.ini |
+| macOS | $HOME/Library/Preferences/com.aswf.OpenRV.plist |
+| Linux | $HOME/.config/ASWF/OpenRV.conf |
+| Windows 7 | ~$HOME/AppData/Roaming/ASWF/OpenRV.ini |
 
 Initial values of preferences can be overridden on a site-wide or show-wide basis by setting the environment variable RV_PREFS_OVERRIDE_PATH to point to one or more directories that contain files of the name and type listed in the above table. For example, if you have your RV.conf file under $HOME/Documents/ you can set RV_PREFS_OVERRIDE_PATH=$HOME/Documents. Each of these overriding preferences file can provide default values for one or more preferences. A value from one of these overriding files will override the users's preference only if the user's preferences file has no value for this preference yet.In the simplest case, if you want to provide overriding initial values for all preferences, you should
 

--- a/docs/rv-manuals/rv-user-manual/rv-user-manual-chapter-three.md
+++ b/docs/rv-manuals/rv-user-manual/rv-user-manual-chapter-three.md
@@ -85,9 +85,9 @@ You can also access the logs at the following locations:
 
 | OS | Logs location |
 | --- | --- |
-| Linux | ~/.local/share/Autodesk/RV/RV.log |
-| macOS | ~/Library/Logs/Autodesk/RV.log |
-| Windows | %AppData%\Roaming\Autodesk\RV\RV.log |
+| Linux | ~/.local/share/ASWF/OpenRV/OpenRV.log |
+| macOS | ~/Library/Logs/ASWF/OpenRV.log |
+| Windows | %AppData%\Roaming\ASWF\OpenRV\OpenRV.log |
 
 These logs contain anything that is written in the RV Console.
 


### PR DESCRIPTION
### Fix doc wrt Open RV prefs and log location

### Linked issues

NA

### Summarize your change.

Fix incorrect documentation with respect to the Open RV preferencess and log location.

### Describe the reason for the change.

The documentation for the Open RV preferences and log file locations was incorrectly referencing Autodesk.
It is actually under ASWF (Academy Software Foundation)

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.