### PR TITLE
Set OpenRV version to 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,10 @@
 #
 CMAKE_MINIMUM_REQUIRED(VERSION 3.24)
 
-# These variables are parsed by sphinx for the documentation.
-# One-line formatting facilitates parsing and readability.
+# These variables are parsed by sphinx for the documentation. One-line formatting facilitates parsing and readability.
 # cmake-format: off
 SET(RV_MAJOR_VERSION "2" CACHE STRING "RV's version major")
-SET(RV_MINOR_VERSION "0" CACHE STRING "RV's version minor")
+SET(RV_MINOR_VERSION "1" CACHE STRING "RV's version minor")
 SET(RV_REVISION_NUMBER "0" CACHE STRING "RV's revision number")
 SET(RV_VERSION_YEAR "2024" CACHE STRING "RV's year of release.")
 # cmake-format: on
@@ -26,17 +25,17 @@ IF(CMAKE_BUILD_TYPE
   MESSAGE(FATAL_ERROR "Invalid value for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 ENDIF()
 
-IF (NOT RV_RELEASE_DESCRIPTION)
-    IF(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-        SET(RV_RELEASE_DESCRIPTION
-            "DEVELOPMENT"
-        )
-    ELSE()
-        # as checked 'src/lib/app/RvCommon/RvApplication.cpp'
-        SET(RV_RELEASE_DESCRIPTION
-            "RELEASE"
-        )
-    ENDIF()
+IF(NOT RV_RELEASE_DESCRIPTION)
+  IF(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    SET(RV_RELEASE_DESCRIPTION
+        "DEVELOPMENT"
+    )
+  ELSE()
+    # as checked 'src/lib/app/RvCommon/RvApplication.cpp'
+    SET(RV_RELEASE_DESCRIPTION
+        "RELEASE"
+    )
+  ENDIF()
 ENDIF()
 
 SET(RV_UI_APPLICATION_NAME


### PR DESCRIPTION
### Set OpenRV version to 2.1.0

### Linked issues

NA

### Summarize your change.

Set OpenRV version to 2.1.0

### Describe the reason for the change.

This is to be able to set a minimal version baseline for upcoming support of Flow Production Tracking packages in Open RV.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.