### PR TITLE
Search for QT 5.15 to avoid confusion with users who have multiple QT…

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -46,11 +46,11 @@ if [ -z "$QT_HOME" ]; then
   echo "Searching for Qt installation..."
 
   if [[ "$OSTYPE" == "linux"* ]]; then
-    QT_HOME=$(find ~/Qt* -type d -maxdepth 4 -path '*/gcc_64' | head -n 1)
+    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/gcc_64' | head -n 1)
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    QT_HOME=$(find ~/Qt* -type d -maxdepth 4 -path '*/clang_64' | head -n 1)
+    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | head -n 1)
   elif [[ "$OSTYPE" == "msys"* ]]; then
-    QT_HOME=$(find c:/Qt* -type d -maxdepth 4 -path '*/msvc2019_64' | head -n 1)
+    QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | head -n 1)
   fi
 
   # Could not find Qt installation

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -46,17 +46,17 @@ if [ -z "$QT_HOME" ]; then
   echo "Searching for Qt installation..."
 
   if [[ "$OSTYPE" == "linux"* ]]; then
-    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/gcc_64' | head -n 1)
+    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/gcc_64' | sort -V | tail -n 1)
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/macos' | head -n 1)
+    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/macos' | sort -V | tail -n 1)
 
     # If no macos installation found, try clang_64
     if [ -z "$QT_HOME" ]; then
-      QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | head -n 1)
+      QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | sort -V | tail -n 1)
     fi
     
   elif [[ "$OSTYPE" == "msys"* ]]; then
-    QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | head -n 1)
+    QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | sort -V | tail -n 1)
   fi
 
   # Could not find Qt installation

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -48,7 +48,13 @@ if [ -z "$QT_HOME" ]; then
   if [[ "$OSTYPE" == "linux"* ]]; then
     QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/gcc_64' | head -n 1)
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | head -n 1)
+    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/macos' | head -n 1)
+
+    # If no macos installation found, try clang_64
+    if [ -z "$QT_HOME" ]; then
+      QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | head -n 1)
+    fi
+    
   elif [[ "$OSTYPE" == "msys"* ]]; then
     QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | head -n 1)
   fi


### PR DESCRIPTION
### Linked issues

No linked issues, but created based on [this](https://github.com/AcademySoftwareFoundation/OpenRV/pull/501#issuecomment-2214457140) review of PR #501 

### Summarize your change.

Ensure that Open RV searches specifically for QT 5.15.* during setup, to avoid confusion with other QT versions that the user may have downloaded.

### Describe what you have tested and on which operating system.

Tested on macOS Sonoma 14.5 and Windows 11, but testing must be done with Linux before merging.

### Add a list of changes, and note any that might need special attention during the review.

- Simple changes to rvcmds.sh