### PR TITLE
Fix OpenTimelineIO crash at startup

### DIFF
--- a/src/build/requirements.txt
+++ b/src/build/requirements.txt
@@ -2,7 +2,7 @@
 
 pip                     # License: MIT License (MIT)
 setuptools              # License: MIT License
-OpenTimelineIO          # License: Other/Proprietary License (Modified Apache 2.0 License)
+OpenTimelineIO==0.16    # License: Other/Proprietary License (Modified Apache 2.0 License)
 PyOpenGL                # License: BSD License (BSD)
 PyOpenGL_accelerate     # License: BSD License (BSD)
 


### PR DESCRIPTION
### Fix OpenTimelineIO crash at startup

### Linked issues

Fixes #511

### Summarize your change.

Force the previous version of OpenTimelineIO to be used in Open RV (==0.16.0) to fix the crash at launch.

### Describe the reason for the change.

Open RV crashes on launch on Windows since the OpenTimelineIO python package was updated to 0.17.0
This started to occur on July 2nd, 2024. Matching the release of OpenTimelineIO version 0.17.0
Work around:
./py-interp -m pip install OpenTimelineIO==0.16

The latest version of OpenTimelineIO is normally used in Open RV, but the recently released version is causing a crash at startup. 
As an emergency fix, we will therefore force the previous version of OpenTimelineIO to be used in Open RV (==0.16.0) to fix the crash at launch until this OpenTimelineIO issue is resolved at the source.

### Describe what you have tested and on which operating system.
Successfully tested on Windows 11 and macOS.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.