### PR TITLE
feat: SG-43395: Add Noto font so that RV can render Mandarin characters

### DIFF
--- a/src/lib/ui/TwkGLText/CMakeLists.txt
+++ b/src/lib/ui/TwkGLText/CMakeLists.txt
@@ -11,7 +11,7 @@ SET(_target
 )
 
 SET(_sources
-    GLT.cpp TwkGLText.cpp defaultFont.cpp
+    GLT.cpp TwkGLText.cpp defaultFont.cpp noto.cpp
 )
 
 FIND_PACKAGE(OpenGL REQUIRED)

--- a/src/lib/ui/TwkGLText/GLT.cpp
+++ b/src/lib/ui/TwkGLText/GLT.cpp
@@ -6,6 +6,7 @@
 //******************************************************************************
 #include <TwkGLText/TwkGLText.h>
 #include <TwkGLText/defaultFont.h>
+#include <TwkGLText/noto.h>
 #include <TwkGLText/GLT.h>
 #include <FTGL/ftgl.h>
 #include <TwkExc/TwkExcException.h>
@@ -41,7 +42,7 @@ void gltFace(const std::string& fontName, size_t fontSize)
 
     if (!face)
     {
-        face = new GLTFace(default_font, 67548); 
+        face = new GLTFace(notoFont, notoFontSize); 
         face->FaceSize(fontSize);
         cache[d] = face;
     }

--- a/src/lib/ui/TwkGLText/TwkGLText.cpp
+++ b/src/lib/ui/TwkGLText/TwkGLText.cpp
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <stl_ext/string_algo.h>
 #include <TwkGLText/defaultFont.h>
+#include <TwkGLText/noto.h>
 #include <iterator>
 #include <pthread.h>
 
@@ -147,7 +148,7 @@ Context GLtext::newContext()
     }
 
     if ((*ctx->fonts[ctx->fontName]).size() <= ctx->size) (*ctx->fonts[ctx->fontName]).resize(ctx->size+1);
-    if (!(*ctx->fonts[ctx->fontName])[ctx->size]) (*ctx->fonts[ctx->fontName])[ctx->size] = newFont(default_font, 67548);
+    if (!(*ctx->fonts[ctx->fontName])[ctx->size]) (*ctx->fonts[ctx->fontName])[ctx->size] = newFont(notoFont, notoFontSize);
     (*ctx->fonts[ctx->fontName])[ctx->size]->FaceSize(ctx->size);
     ctx->initialized = true;
 
@@ -194,7 +195,7 @@ void GLtext::init()
             (*ctx->fonts[ctx->fontName]).resize(ctx->size+1);
         }
         if (!(*ctx->fonts[ctx->fontName])[ctx->size]) {
-            (*ctx->fonts[ctx->fontName])[ctx->size] = newFont(default_font, 67548);
+            (*ctx->fonts[ctx->fontName])[ctx->size] = newFont(notoFont, notoFontSize);
             (*ctx->fonts[ctx->fontName])[ctx->size]->FaceSize(ctx->size);
         }
         ctx->initialized = true;

--- a/src/lib/ui/TwkGLText/TwkGLText/courier.h
+++ b/src/lib/ui/TwkGLText/TwkGLText/courier.h
@@ -5,8 +5,7 @@
 // 
 //******************************************************************************
 
-#ifndef __COURIER_H__
-#define __COURIER_H__
+#pragma once
 
 //
 // This font is from /usr/X11R6/lib/X11/fonts/TTF/cour.ttf
@@ -14,5 +13,3 @@
 
 extern const unsigned char courierFont[];
 const unsigned int courierFontSize = 297660;
-
-#endif    // End #ifdef __COURIER_H__

--- a/src/lib/ui/TwkGLText/TwkGLText/noto.h
+++ b/src/lib/ui/TwkGLText/TwkGLText/noto.h
@@ -5,10 +5,9 @@
 // 
 //******************************************************************************
 
-#ifndef __NOTO_H__
-#define __NOTO_H__
+#pragma once
+
+// Sourced from Noto Sans Simplified: https://fonts.google.com/noto/specimen/Noto+Sans+SC
 
 extern const unsigned char notoFont[];
 const unsigned int notoFontSize = 10560380;
-
-#endif    // End #ifdef __NOTO_H__

--- a/src/lib/ui/TwkGLText/TwkGLText/noto.h
+++ b/src/lib/ui/TwkGLText/TwkGLText/noto.h
@@ -1,0 +1,14 @@
+//******************************************************************************
+// Copyright (c) 2024 Autodesk Inc. All rights reserved.
+// 
+// SPDX-License-Identifier: Apache-2.0
+// 
+//******************************************************************************
+
+#ifndef __NOTO_H__
+#define __NOTO_H__
+
+extern const unsigned char notoFont[];
+const unsigned int notoFontSize = 10560380;
+
+#endif    // End #ifdef __NOTO_H__

--- a/src/lib/ui/TwkGLText/TwkGLText/tweakFont.h
+++ b/src/lib/ui/TwkGLText/TwkGLText/tweakFont.h
@@ -5,12 +5,9 @@
 // 
 //******************************************************************************
 
-#ifndef __TWEAKFONT_H__
-#define __TWEAKFONT_H__
+#pragma once
 
 // Nedian Medium
 
 extern const unsigned char tweakFont[];
 const unsigned int tweakFontSize = 62376;
-
-#endif    // End #ifdef __TWEAKFONT_H__


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

A new font has been added to RV's UI with the capability to render Latin and Mandarin characters.

### Describe the reason for the change.

RV uses hardcoded fonts for it's the UI. The existing fonts did not have the capability to render mandarin characters, so a new font ([Google Noto](https://fonts.google.com/noto/specimen/Noto+Sans+SC)) needed to be added to give RV the capability of rendering mandarin glyphs. 

### Describe what you have tested and on which operating system.

macOS Sonoma 14.5.

### Add a list of changes, and note any that might need special attention during the review.

A change that should be ignored is in `noto.cpp`, which contains a byte array of a `ttf` file. This is how RV consumes fonts.

### If possible, provide screenshots.

**Before:**

<img width="658" alt="Snipaste_2024-07-11_11-20-11" src="https://github.com/user-attachments/assets/6d35dcb9-f767-47fa-856c-8ca331c79ab9">

**After:**

![image](https://github.com/user-attachments/assets/b3c8fac0-04c3-4452-a34f-b7cc4878b51d)
