### PR TITLE
Update config_linux_rocky9.md based on a clean Rocky 9 install

### DIFF
--- a/docs/build_system/config_linux_rocky9.md
+++ b/docs/build_system/config_linux_rocky9.md
@@ -32,7 +32,15 @@ sudo dnf config-manager --set-disabled devel
 
 ### GLU
 
-You may or may not have libGLU on your system depending on your graphics driver setup.  To know you can check if you have the lib /usr/lib64/libGLU.so.1.  If it's there you can skip this step, there's nothing further to do in this section.  If not, you can install the graphics drivers for your system. As as last resort, you can install a software (mesa) libGLU version, but you may not have ideal performance with this option.  To do so:
+You may or may not have libGLU on your system depending on your graphics driver setup. 
+
+Check for the existance of the following files:
+
+* `/usr/lib64/libGLU.so.1`
+* `/usr/lib64/libGLU.so`
+* `/usr/include/GL/glu.h`
+
+If `libGLU.so.1` is present but `libGLU.so` is not, create a symlink between them with `sudo ln -s /usr/lib64/libGLU.so.1 /usr/lib64/libGLU.so`. If `/usr/include/GL/glu.h` is missing, install `mesa-libGLU-devel` to get this required header file. If libGLU is missing entirely, you can install the graphics drivers for your system. As as last resort, you can install a software (mesa) libGLU version, but you may not have ideal performance with this option:
 
 ```bash
 sudo dnf install mesa-libGLU mesa-libGLU-devel
@@ -48,6 +56,6 @@ python3 -m pip install -r requirements.txt
 
 ## Install Qt
 
-Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). Logs, Android, iOS and WebAssembly are not required to build OpenRV.
+Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). During Qt Setup's Select Components phase, check the "Archive" box on the right side of the window then click on "Filter" to see Qt 5.15.x options. Logs, Android, iOS and WebAssembly are not required to build OpenRV. Make sure to note the destination of the Qt install, as you will have to set the `QT_HOME` environment variable to this location's build dir.
 
 WARNING: If you fetch Qt from another source, make sure to build it with SSL support, that it contains everything required to build PySide2, and that the file structure is similar to the official package.


### PR DESCRIPTION
### Summarize your change.

With a clean(ish) install of Rocky Linux 9.4, I ran through the build instructions and updated where they fell short. It's clean(ish) because I had installed Maya 2024, MtoA, and the Deadline Cloud submitters.

### Describe the reason for the change.

Following the original instructions still results in missing libraries and errors. I referenced additional information I found in #6 or discovered the proper solution to get past it, and updated the documentation. 

### Describe what you have tested and on which operating system.

Rocky Linux 9.4

### Add a list of changes, and note any that might need special attention during the review.

>  Make sure to note the destination of the Qt install, as you will have to set the `QT_HOME` environment variable to this location's build dir.

This is actually an oversimplification, but I'm unsure if the problem is my fault. The online qt installer built Qt into `/opt/Qt/5.15.2/gcc_64` (the dir might not actually be `gcc_64`). Setting `QT_HOME` to `/opt/Qt/5.15.2/gcc_64` resolves the initial build errors, but encounters new ones where it seemingly ignores the set `QT_HOME` and tries to find the directories `/opt/Qt/5.15.2/resources` and `/opt/Qt/5.15.2/translations`. Renaming `/opt/Qt/5.15.2/gcc_64` to `/opt/Qt/5.15.2` and setting `QT_HOME` to the same resolved the issue.

### If possible, provide screenshots.

IN THE END IT BUILT!

![image](https://github.com/user-attachments/assets/6cba624a-ec16-4311-bcc4-7d7957150c77)