### PR TITLE
Fix make_python.py on Apple Silicon + Sonoma 14.5

### DIFF
--- a/src/build/make_python.py
+++ b/src/build/make_python.py
@@ -124,7 +124,9 @@ def get_python_interpreter_args(python_home: str) -> List[str]:
     python_interpreters = glob.glob(
         os.path.join(python_home, python_name_pattern), recursive=True
     )
-    python_interpreters += glob.glob(os.path.join(python_home, "bin", python_name_pattern))
+    python_interpreters += glob.glob(
+        os.path.join(python_home, "bin", python_name_pattern)
+    )
 
     # sort put python# before python#-config
     python_interpreters = sorted(
@@ -164,7 +166,9 @@ def patch_python_distribution(python_home: str) -> None:
             shutil.move(failed_lib, failed_lib.replace("_failed.so", ".so"))
     if OPENSSL_OUTPUT_DIR:
         if platform.system() == "Darwin":
-            openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.dylib*"))
+            openssl_libs = glob.glob(
+                os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.dylib*")
+            )
             openssl_libs = [l for l in openssl_libs if os.path.islink(l) is False]
 
             python_openssl_libs = []
@@ -196,7 +200,9 @@ def patch_python_distribution(python_home: str) -> None:
                     subprocess.run(install_name_tool_change_args).check_returncode()
 
         elif platform.system() == "Linux":
-            openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.so*"))
+            openssl_libs = glob.glob(
+                os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.so*")
+            )
 
             for lib_path in openssl_libs:
                 print(f"Copying {lib_path} to the python home")
@@ -297,8 +303,12 @@ def test_python_distribution(python_home: str) -> None:
 
             # Specify the location of the debug python import lib (eg. python39_d.lib)
             python_include_dirs = os.path.join(tmp_python_home, "include")
-            python_lib = os.path.join(tmp_python_home, "libs", f"python{PYTHON_VERSION}_d.lib")
-            my_env["CMAKE_ARGS"] = f"-DPython_LIBRARY={python_lib} -DCMAKE_INCLUDE_PATH={python_include_dirs}"
+            python_lib = os.path.join(
+                tmp_python_home, "libs", f"python{PYTHON_VERSION}_d.lib"
+            )
+            my_env[
+                "CMAKE_ARGS"
+            ] = f"-DPython_LIBRARY={python_lib} -DCMAKE_INCLUDE_PATH={python_include_dirs}"
 
             opentimelineio_install_arg = python_interpreter_args + [
                 "-m",
@@ -440,7 +450,8 @@ def configure() -> None:
 
         if OPENSSL_OUTPUT_DIR:
             configure_args.append(f"--with-openssl={OPENSSL_OUTPUT_DIR}")
-
+            if platform.system() == "Darwin":
+                configure_args.append(f"--with-openssl-rpath={OPENSSL_OUTPUT_DIR}/lib")
 
         if VARIANT == "Release":
             configure_args.append("--enable-optimizations")
@@ -565,7 +576,6 @@ def build() -> None:
         if OPENSSL_OUTPUT_DIR:
             subprocess_env["LC_RPATH"] = os.path.join(OPENSSL_OUTPUT_DIR, "lib")
 
-
         subprocess.run(
             build_args,
             cwd=SOURCE_DIR,
@@ -683,7 +693,13 @@ if __name__ == "__main__":
 
     if platform.system() == "Windows":
         # Major and minor version of Python without dots. E.g. 3.10.3 -> 310
-        parser.add_argument("--python-version", dest="python_version", type=str, required=True, default="")
+        parser.add_argument(
+            "--python-version",
+            dest="python_version",
+            type=str,
+            required=True,
+            default="",
+        )
 
     parser.set_defaults(clean=False, configure=False, build=False, install=False)
 


### PR DESCRIPTION
### Fix make_python.py on Apple Silicon + Sonoma 14.5

### Linked issues
NA

### Summarize your change.

Fix the python3 build by specifying --with-openssl-rpath in addition to --with-openssl.

### Describe the reason for the change.

Since the merge of the Apple Silicon native build for Open RV, some users were experiencing a build break when build the RV_DEPS_PYTHON3 dependency:

This was reproduced on a Mac M1 running Sonoma 14.5 using the latest Open RV code:

```
Could not build the ssl module!
Python requires a OpenSSL 1.1.1 or newer

Executing ['make', 'install', '-j10', '-s'] from /Users/labergb/git5/rv/_build/RV_DEPS_PYTHON3/src
Traceback (most recent call last):
  File "/Users/labergb/git5/rv/OpenRV/src/build/make_python.py", line 713, in <module>
    install()
  File "/Users/labergb/git5/rv/OpenRV/src/build/make_python.py", line 646, in install
    ).check_returncode()
      ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.6/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 502, in check_returncode
    raise CalledProcessError(self.returncode, self.args, self.stdout,
subprocess.CalledProcessError: Command '['make', 'install', '-j10', '-s']' returned non-zero exit status 2.
ninja: build stopped: subcommand failed.

```

### Describe what you have tested and on which operating system.
Successfully tested on M1+macOS=14.5. Will also test on other OSes.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.