### PR TITLE
Make sure that LZMA is disabled when building Boost (MacOS)

### DIFF
--- a/cmake/dependencies/boost.cmake
+++ b/cmake/dependencies/boost.cmake
@@ -146,17 +146,13 @@ FOREACH(
   ENDIF()
 ENDFOREACH()
 
-SET(_boost_b2_options
-    "-s NO_LZMA=1"
-)
+LIST(APPEND _boost_b2_options "-s")
+LIST(APPEND _boost_b2_options "NO_LZMA=1")
+
 IF(RV_VERBOSE_INVOCATION)
-  SET(_boost_b2_options
-      "${_boost_b2_options} -d+2"
-  )
+  LIST(APPEND _boost_b2_options "-d+2")
 ELSE()
-  SET(_boost_b2_options
-      "${_boost_b2_options} -d+0"
-  )
+  LIST(APPEND _boost_b2_options "-d+0")
 ENDIF()
 
 IF(RV_TARGET_DARWIN)


### PR DESCRIPTION
### LZMA is not disabled for Boost

### Linked issues
n/a

### Summarize your change.
Make sure that LZMA is disabled when building Boost because OpenRV is not using it.

### Describe the reason for the change.
There is a quotation issue with how we use the NO_LZMA option for boost where it does not really disable it. 
This cause issue when OpenRV finds a LZMA that was compiled for x86_64 architecture.

### Describe what you have tested and on which operating system.

Tested the build on  Windows, Rocky Linux 8/9, MacOS Intel and ARM64.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.