### PR TITLE
Add environment variable that allows users to disable loading video output plugins

### DIFF
--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -715,8 +715,13 @@ RvApplication::newSessionFromFiles(const StringVector& files)
                 cerr << "ERROR: DesktopVideoModule failed" << endl;
         }
 
-        // Load audio/video output plugins
-        loadOutputPlugins("TWK_OUTPUT_PLUGIN_PATH");
+        if (!getenv("RV_SKIP_LOADING_VIDEO_OUTPUT_PLUGINS")) {
+
+            // Load audio/video output plugins
+            loadOutputPlugins("TWK_OUTPUT_PLUGIN_PATH");
+        } else {
+            cout << "WARNING: Skipping loading of video output plugins" << endl;
+        }
     }
 
     doc->session()->graph().setPhysicalDevices(videoModules());


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

Add a simple environment variable check to see if the user would like to load video output plugins.

### Describe the reason for the change.

These are heavy plugins and actually slow dow the time it takes for RV to boot. If the user so chooses, they should have the option to disable them from being loaded.

### Describe what you have tested and on which operating system.

Tested on MacOS 14.5, disabling these plugins increased loading speed by about 20% when opening a piece of media with Open RV/ 

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.