### PR TITLE
Fix issue install step tries to delete rpath multiple times (MacOS ARM64)

### DIFF
--- a/src/build/remove_absolute_rpath.py
+++ b/src/build/remove_absolute_rpath.py
@@ -109,11 +109,14 @@ def fix_rpath(target, root):
             logging.info(f"Skipping {file} because numpy")
             return
 
+        # Prevent delete the same rpath multiple time (e.g. MacOS fat binary).
+        deletedRPATH = []
         for rpath in get_rpaths(file):
             output = f"\trpath: {rpath}"
 
-            if rpath.startswith("@") is False and rpath.startswith(".") is False:
+            if rpath.startswith("@") is False and rpath.startswith(".") is False and not rpath in deletedRPATH:
                 delete_rpath(file, rpath)
+                deletedRPATH.append(rpath)
                 output += " (Deleted)"
 
             logging.info(output)


### PR DESCRIPTION
### Fix issue where it tries to delete rpath multiple times

### Linked issues
n/a

### Summarize your change.
Fix an issue during the install step where it tries to delete a RPATH multiple time due to a universal library.
Keep a list of deleted rpath for a specific file and do not delete the same RPATH multiple time.

### Describe the reason for the change.
Install step was failing on MacOS ARM64

### Describe what you have tested and on which operating system.
- [x] MacOS ARM64

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.