### PR TITLE
Create Python virtual environment when Open RV/RV is being built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ cmake-*/*
 build/*
 _build/*
 _install/*
-_venv/*
+.venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ cmake-*/*
 build/*
 _build/*
 _install/*
-_virtualenv/*
+_venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ cmake-*/*
 build/*
 _build/*
 _install/*
+_virtualenv/*

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ the `_build` folder.
 
 ### Using a Python Virtual Environment
 
-Open RV automatically sets up a Python virtual environment when the user bootstraps (`rvbootstrap`), builds (`rvbuild`) or configures (`rvcfg`) their project. After each of these commands, you should see that the executing instance of the terminal is using a virtual environment with the name `_virtualenv`.
+Open RV automatically sets up a Python virtual environment when the user bootstraps (`rvbootstrap`), builds (`rvbuild`) or configures (`rvcfg`) their project. After each of these commands, you should see that the executing instance of the terminal is using a virtual environment with the name `.venv`.
 
 If this is not the case or if you would like to set up your virtual environment directly, you can run the command `rvenv`.
 

--- a/README.md
+++ b/README.md
@@ -83,15 +83,28 @@ Use the `rvsetup` common build alias to run the bootstrap step.
 
 #### Manually
 
-See the **Using a Python Virtual Environment** before running any of the commands in this section. Python packages should be installed inside of a virtual environment. 
-
 ```bash
-python3 -m pip install --upgrade -r ${RV_HOME}/requirements.txt
-```
+ python3 -m pip install --user --upgrade -r requirements.txt
+ ```
 
-Note that on Windows, use the following command instead from an MSYS2-MinGW64 shell:
-```bash
-SETUPTOOLS_USE_DISTUTILS=stdlib python3 -m pip install --upgrade -r requirements.txt
+ Note that on Windows, use the following command instead from an MSYS2-MinGW64 shell:
+ ```bash
+ SETUPTOOLS_USE_DISTUTILS=stdlib python3 -m pip install --user --upgrade -r requirements.txt
+ ```
+
+ ### Blackmagicdesign&reg; Video Output Support (Optional)
+
+ Download the Blackmagicdesign&reg; SDK to add Blackmagicdesign&reg; output capability to Open RV (optional): https://www.blackmagicdesign.com/desktopvideo_sdk<br>
+ Then set RV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH to the path of the downloaded zip file on the rvcfg line.<br>
+ Example:
+ ```bash
+ rvcfg -DRV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH='<downloads_path>/Blackmagic_DeckLink_SDK_14.1.zip'
+ ```
+
+ ### NDI&reg; Video Output Support (Optional)
+
+ Download and install the NDI&reg; SDK to add NDI&reg; output capability to Open RV (optional): https://ndi.video/<br>
+ This must be done before the `configure` step.
 ```
 
 ### Configure

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ Use the `rvsetup` common build alias to run the bootstrap step.
 
 #### Manually
 
+Please ensure that a virtual environment is running before this command is executed.
+
 ```bash
-python3 -m pip install --user --upgrade -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Note that on Windows, use the following command instead from an MSYS2-MinGW64 shell:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ pre-commit install
 To clean your build directory and restart from a clean slate, use the `rvclean` common build alias, or delete
 the `_build` folder.
 
+### Using a Python Virtual Environment
+
+Open RV automatically sets up a Python virtual environment when the user bootstraps (`rvbootstrap`), builds (`rvbuild`) or configures (`rvcfg`) their project. After each of these commands, you should see that the executing instance of the terminal is using a virtual environment with the name `_virtualenv`.
+
+If this is not the case or if you would like to set up your virtual environment directly, you can run the command `rvenv`.
+
 ### Bootstrap
 
 Before first your first Open RV build, you must install some python dependencies.
@@ -77,28 +83,16 @@ Use the `rvsetup` common build alias to run the bootstrap step.
 
 #### Manually
 
+See the **Using a Python Virtual Environment** before running any of the commands in this section. Python packages should be installed inside of a virtual environment. 
+
 ```bash
-python3 -m pip install --user --upgrade -r requirements.txt
+python3 -m pip install --upgrade -r ${RV_HOME}/requirements.txt
 ```
 
 Note that on Windows, use the following command instead from an MSYS2-MinGW64 shell:
 ```bash
-SETUPTOOLS_USE_DISTUTILS=stdlib python3 -m pip install --user --upgrade -r requirements.txt
+SETUPTOOLS_USE_DISTUTILS=stdlib python3 -m pip install --upgrade -r requirements.txt
 ```
-
-### Blackmagicdesign&reg; Video Output Support (Optional)
-
-Download the Blackmagicdesign&reg; SDK to add Blackmagicdesign&reg; output capability to Open RV (optional): https://www.blackmagicdesign.com/desktopvideo_sdk<br>
-Then set RV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH to the path of the downloaded zip file on the rvcfg line.<br>
-Example:
-```bash
-rvcfg -DRV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH='<downloads_path>/Blackmagic_DeckLink_SDK_14.1.zip'
-```
-
-### NDI&reg; Video Output Support (Optional)
-
-Download and install the NDI&reg; SDK to add NDI&reg; output capability to Open RV (optional): https://ndi.video/<br>
-This must be done before the `configure` step.
 
 ### Configure
 

--- a/README.md
+++ b/README.md
@@ -84,28 +84,27 @@ Use the `rvsetup` common build alias to run the bootstrap step.
 #### Manually
 
 ```bash
- python3 -m pip install --user --upgrade -r requirements.txt
- ```
-
- Note that on Windows, use the following command instead from an MSYS2-MinGW64 shell:
- ```bash
- SETUPTOOLS_USE_DISTUTILS=stdlib python3 -m pip install --user --upgrade -r requirements.txt
- ```
-
- ### Blackmagicdesign&reg; Video Output Support (Optional)
-
- Download the Blackmagicdesign&reg; SDK to add Blackmagicdesign&reg; output capability to Open RV (optional): https://www.blackmagicdesign.com/desktopvideo_sdk<br>
- Then set RV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH to the path of the downloaded zip file on the rvcfg line.<br>
- Example:
- ```bash
- rvcfg -DRV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH='<downloads_path>/Blackmagic_DeckLink_SDK_14.1.zip'
- ```
-
- ### NDI&reg; Video Output Support (Optional)
-
- Download and install the NDI&reg; SDK to add NDI&reg; output capability to Open RV (optional): https://ndi.video/<br>
- This must be done before the `configure` step.
+python3 -m pip install --user --upgrade -r requirements.txt
 ```
+
+Note that on Windows, use the following command instead from an MSYS2-MinGW64 shell:
+```bash
+SETUPTOOLS_USE_DISTUTILS=stdlib python3 -m pip install --user --upgrade -r requirements.txt
+```
+
+### Blackmagicdesign&reg; Video Output Support (Optional)
+
+Download the Blackmagicdesign&reg; SDK to add Blackmagicdesign&reg; output capability to Open RV (optional): https://www.blackmagicdesign.com/desktopvideo_sdk<br>
+Then set RV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH to the path of the downloaded zip file on the rvcfg line.<br>
+Example:
+```bash
+rvcfg -DRV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH='<downloads_path>/Blackmagic_DeckLink_SDK_14.1.zip'
+```
+
+### NDI&reg; Video Output Support (Optional)
+
+Download and install the NDI&reg; SDK to add NDI&reg; output capability to Open RV (optional): https://ndi.video/<br>
+This must be done before the `configure` step.
 
 ### Configure
 

--- a/docs/build_system/config_macos.md
+++ b/docs/build_system/config_macos.md
@@ -2,11 +2,13 @@
 
 ## Summary
 
-1. [Install XCode](#install-xcode)
-1. [Install Homebrew](#install-homebrew)
-1. [Install tools and build dependencies](#install-tools-and-build-dependencies)
-1. [Install the python requirements](#install-the-python-requirements)
-1. [Install Qt](#install-qt)
+- [Building Open RV on macOS](#building-open-rv-on-macos)
+  - [Summary](#summary)
+  - [Install XCode](#install-xcode)
+  - [Install Homebrew](#install-homebrew)
+  - [Install tools and build dependencies](#install-tools-and-build-dependencies)
+  - [Install the python requirements](#install-the-python-requirements)
+  - [Install Qt](#install-qt)
 
 ## Install XCode
 
@@ -39,6 +41,8 @@ Make sure `python` resolves in your terminal. In some case, depending on how the
 In that case, you can create one with this command `ln -s python3 $(dirname $(which python3))/python`.
 
 ## Install the python requirements
+
+See the **Using a Python Virtual Environment** in `README.md` in the root directory before running any of the commands in this section. Python packages should be installed inside of a virtual environment. 
 
 Some of the RV build scripts requires extra python packages. They can be installed using the requirements.txt at the root of the repository.
 

--- a/docs/build_system/config_macos.md
+++ b/docs/build_system/config_macos.md
@@ -9,6 +9,7 @@
   - [Install tools and build dependencies](#install-tools-and-build-dependencies)
   - [Install the python requirements](#install-the-python-requirements)
   - [Install Qt](#install-qt)
+  - [Allow Terminal to update or delete other applications](#allow-terminal-to-update-or-delete-other-applications)
 
 ## Install XCode
 
@@ -42,7 +43,7 @@ In that case, you can create one with this command `ln -s python3 $(dirname $(wh
 
 ## Install the python requirements
 
-See the **Using a Python Virtual Environment** in `README.md` in the root directory before running any of the commands in this section. Python packages should be installed inside of a virtual environment. 
+See the **Using a Python Virtual Environment** in `README.md` in the root directory before running any of the commands in this section. Python packages should be installed inside of a virtual environment.
 
 Some of the RV build scripts requires extra python packages. They can be installed using the requirements.txt at the root of the repository.
 

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -73,11 +73,11 @@ fi
 
 # Must be executed in a function as it changes the shell environment
 rvenv_shell() {
-  if [ -d "_venv" ]; then
-    source _venv/bin/activate
+  if [ -d ".venv" ]; then
+    source .venv/bin/activate
   else
     python3 -m venv _venv
-    source _venv/bin/activate
+    source .venv/bin/activate
   fi
 }
 

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -46,17 +46,11 @@ if [ -z "$QT_HOME" ]; then
   echo "Searching for Qt installation..."
 
   if [[ "$OSTYPE" == "linux"* ]]; then
-    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/gcc_64' | sort -V | tail -n 1)
+    QT_HOME=$(find ~/Qt* -type d -maxdepth 4 -path '*/gcc_64' | head -n 1)
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/macos' | sort -V | tail -n 1)
-
-    # If no macos installation found, try clang_64
-    if [ -z "$QT_HOME" ]; then
-      QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | sort -V | tail -n 1)
-    fi
-    
+    QT_HOME=$(find ~/Qt* -type d -maxdepth 4 -path '*/clang_64' | head -n 1)
   elif [[ "$OSTYPE" == "msys"* ]]; then
-    QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | sort -V | tail -n 1)
+    QT_HOME=$(find c:/Qt* -type d -maxdepth 4 -path '*/msvc2019_64' | head -n 1)
   fi
 
   # Could not find Qt installation
@@ -79,17 +73,18 @@ RV_BUILD_PARALLELISM="${RV_BUILD_PARALLELISM:-$(python3 -c 'import os; print(os.
 
 # ALIASES: Basic commands
 
-alias rvsetup="SETUPTOOLS_USE_DISTUTILS=${SETUPTOOLS_USE_DISTUTILS} python3 -m pip install --user --upgrade -r ${RV_HOME}/requirements.txt"
-alias rvcfg="cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
-alias rvcfgd="cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Debug -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
-alias rvbuildt="cmake --build ${RV_BUILD} --config Release -v --parallel=${RV_BUILD_PARALLELISM} --target "
-alias rvbuildtd="cmake --build ${RV_BUILD} --config Debug -v --parallel=${RV_BUILD_PARALLELISM} --target "
-alias rvbuild="rvbuildt main_executable"
-alias rvbuildd="rvbuildtd main_executable"
-alias rvtest="ctest --test-dir ${RV_BUILD} --extra=verbose"
-alias rvinst="cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Release"
-alias rvinstd="cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Debug"
-alias rvclean="rm -rf ${RV_BUILD}"
+alias rvenv="[ -d "_virtualenv" ] && source _virtualenv/bin/activate || (python3 -m venv _virtualenv && source _virtualenv/bin/activate)"
+alias rvsetup="rvenv && SETUPTOOLS_USE_DISTUTILS=${SETUPTOOLS_USE_DISTUTILS} python3 -m pip install --upgrade -r ${RV_HOME}/requirements.txt"
+alias rvcfg="rvenv && cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
+alias rvcfgd="rvenv && cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Debug -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
+alias rvbuildt="rvenv && cmake --build ${RV_BUILD} --config Release -v --parallel=${RV_BUILD_PARALLELISM} --target "
+alias rvbuildtd="rvenv && cmake --build ${RV_BUILD} --config Debug -v --parallel=${RV_BUILD_PARALLELISM} --target "
+alias rvbuild="rvenv && rvbuildt main_executable"
+alias rvbuildd="rvenv && rvbuildtd main_executable"
+alias rvtest="rvenv && ctest --test-dir ${RV_BUILD} --extra=verbose"
+alias rvinst="rvenv && cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Release"
+alias rvinstd="rvenv && cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Debug"
+alias rvclean="rm -rf ${RV_BUILD} && rm -rf _virtualenv"
 
 # ALIASES: Config and Build
 

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -71,6 +71,16 @@ else
   echo "Using Qt installation already set at $QT_HOME"
 fi
 
+# Must be executed in a function as it changes the shell environment
+rvenv_shell() {
+  if [ -d "_venv" ]; then
+    source _venv/bin/activate
+  else
+    python3 -m venv _venv
+    source _venv/bin/activate
+  fi
+}
+
 # VARIABLES
 RV_HOME="${RV_HOME:-$SCRIPT_HOME}"
 RV_BUILD="${RV_BUILD:-${RV_HOME}/_build}"
@@ -79,7 +89,7 @@ RV_BUILD_PARALLELISM="${RV_BUILD_PARALLELISM:-$(python3 -c 'import os; print(os.
 
 # ALIASES: Basic commands
 
-alias rvenv="[ -d "_virtualenv" ] && source _virtualenv/bin/activate || (python3 -m venv _virtualenv && source _virtualenv/bin/activate)"
+alias rvenv="rvenv_shell"
 alias rvsetup="rvenv && SETUPTOOLS_USE_DISTUTILS=${SETUPTOOLS_USE_DISTUTILS} python3 -m pip install --upgrade -r ${RV_HOME}/requirements.txt"
 alias rvcfg="rvenv && cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
 alias rvcfgd="rvenv && cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Debug -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -45,19 +45,19 @@ fi
 if [ -z "$QT_HOME" ]; then
   echo "Searching for Qt installation..."
 
-   if [[ "$OSTYPE" == "linux"* ]]; then
-     QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/gcc_64' | sort -V | tail -n 1)
-   elif [[ "$OSTYPE" == "darwin"* ]]; then
-     QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/macos' | sort -V | tail -n 1)
+  if [[ "$OSTYPE" == "linux"* ]]; then
+    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/gcc_64' | sort -V | tail -n 1)
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/macos' | sort -V | tail -n 1)
 
-     # If no macos installation found, try clang_64
-     if [ -z "$QT_HOME" ]; then
-       QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | sort -V | tail -n 1)
-     fi
+    # If no macos installation found, try clang_64
+    if [ -z "$QT_HOME" ]; then
+      QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | sort -V | tail -n 1)
+    fi
 
-   elif [[ "$OSTYPE" == "msys"* ]]; then
-     QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | sort -V | tail -n 1)
-   fi
+  elif [[ "$OSTYPE" == "msys"* ]]; then
+    QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | sort -V | tail -n 1)
+  fi
 
   # Could not find Qt installation
   if [ -z "$QT_HOME" ]; then

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -76,7 +76,7 @@ rvenv_shell() {
   if [ -d ".venv" ]; then
     source .venv/bin/activate
   else
-    python3 -m venv _venv
+    python3 -m venv .venv
     source .venv/bin/activate
   fi
 }
@@ -100,7 +100,7 @@ alias rvbuildd="rvenv && rvbuildtd main_executable"
 alias rvtest="rvenv && ctest --test-dir ${RV_BUILD} --extra=verbose"
 alias rvinst="rvenv && cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Release"
 alias rvinstd="rvenv && cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Debug"
-alias rvclean="rm -rf ${RV_BUILD} && rm -rf _virtualenv"
+alias rvclean="rm -rf ${RV_BUILD} && rm -rf .venv"
 
 # ALIASES: Config and Build
 

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -97,7 +97,7 @@ alias rvbuildt="rvenv && cmake --build ${RV_BUILD} --config Release -v --paralle
 alias rvbuildtd="rvenv && cmake --build ${RV_BUILD} --config Debug -v --parallel=${RV_BUILD_PARALLELISM} --target "
 alias rvbuild="rvenv && rvbuildt main_executable"
 alias rvbuildd="rvenv && rvbuildtd main_executable"
-alias rvtest="rvenv && ctest --test-dir ${RV_BUILD} --extra=verbose"
+alias rvtest="rvenv && ctest --test-dir ${RV_BUILD} --extra-verbose"
 alias rvinst="rvenv && cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Release"
 alias rvinstd="rvenv && cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Debug"
 alias rvclean="rm -rf ${RV_BUILD} && rm -rf .venv"

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -45,13 +45,19 @@ fi
 if [ -z "$QT_HOME" ]; then
   echo "Searching for Qt installation..."
 
-  if [[ "$OSTYPE" == "linux"* ]]; then
-    QT_HOME=$(find ~/Qt* -type d -maxdepth 4 -path '*/gcc_64' | head -n 1)
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-    QT_HOME=$(find ~/Qt* -type d -maxdepth 4 -path '*/clang_64' | head -n 1)
-  elif [[ "$OSTYPE" == "msys"* ]]; then
-    QT_HOME=$(find c:/Qt* -type d -maxdepth 4 -path '*/msvc2019_64' | head -n 1)
-  fi
+   if [[ "$OSTYPE" == "linux"* ]]; then
+     QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/gcc_64' | sort -V | tail -n 1)
+   elif [[ "$OSTYPE" == "darwin"* ]]; then
+     QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/macos' | sort -V | tail -n 1)
+
+     # If no macos installation found, try clang_64
+     if [ -z "$QT_HOME" ]; then
+       QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | sort -V | tail -n 1)
+     fi
+
+   elif [[ "$OSTYPE" == "msys"* ]]; then
+     QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | sort -V | tail -n 1)
+   fi
 
   # Could not find Qt installation
   if [ -z "$QT_HOME" ]; then


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

The Python version included with MacOS Sonoma 14.5 adopted [PEP 668](https://peps.python.org/pep-0668/), which is meant to prevent conflicts between system level Python packages with project specific Python packages, like what is included in `requirements.txt`. 

This means that the user will encounter an error when attempting to install Python requirements unless they use the tag `--break-system-packages` tag. By using a virtual environment, system-level conflicts are avoided and the user has a safer build of Open RV. 

### Describe what you have tested and on which operating system.

Mac OS Sonoma 14.5 and Windows 11.

### If possible, provide screenshots.

PEP 668 error without a virtual environment, triggered by running `rvbuild`.

![image](https://github.com/user-attachments/assets/c164a106-dff8-49f7-b2b9-690f46fc280e)