### PR TITLE
Fix typo to include File.h in Bundle.cpp

### DIFF
--- a/src/lib/app/TwkApp/Bundle.cpp
+++ b/src/lib/app/TwkApp/Bundle.cpp
@@ -9,7 +9,7 @@
 #include <TwkApp/Bundle.h>
 #include <sstream>
 #include <boost/filesystem.hpp>
-#include <TwkUtil/file.h>
+#include <TwkUtil/File.h>
 
 namespace TwkApp {
 using namespace std;


### PR DESCRIPTION
### Linked issues

N/A

Based on this review: https://github.com/AcademySoftwareFoundation/OpenRV/pull/530#discussion_r1714530682

### Summarize your change.

Include statement in `src/lib/app/TwkApp/Bundle.cpp` has been fixed.

### Describe the reason for the change.

The include statement was trying to include a file that dosen't exist, `file.h` instead of `File.h`.

### Describe what you have tested and on which operating system.

Builds correctly on...

- MacOS 14.5 Sonoma