### PR TITLE
Update macOS build setup doc to allow Terminal to update other apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git submodule update --init --recursive
 Open RV is currently supported on the following operating systems:
 
 * [Windows 10 and 11](docs/build_system/config_windows.md)
-* [macOS Big Sur, Monterey and Ventura](docs/build_system/config_macos.md)
+* [macOS](docs/build_system/config_macos.md)
 * [Linux Centos 7](docs/build_system/config_linux_centos7.md)
 * [Linux Rocky 8](docs/build_system/config_linux_rocky8.md)
 * [Linux Rocky 9](docs/build_system/config_linux_rocky9.md)

--- a/docs/build_system/config_macos.md
+++ b/docs/build_system/config_macos.md
@@ -54,3 +54,8 @@ Download the last version of Qt 5.15.x that you can get using the online install
 WARNING: If you fetch Qt from another source, make sure to build it with SSL support, that it contains everything required to build PySide2, and that the file structure is similar to the official package.
 
 Note: Qt5 from homebrew is known to not work well with OpenRV.
+
+## Allow Terminal to update or delete other applications
+
+From the macOS System Settings/Privacy & Security/App Management, allow Terminal to update or delete other applications.
+


### PR DESCRIPTION
### Update macOS build setup doc to allow Terminal to update other apps

### Linked issues
NA

### Summarize your change.

Update macOS build setup to allow Terminal to update or delete other applications

### Describe the reason for the change.

Now required starting with macOS 14.5 

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.