### PR TITLE
Update dav1d version to 1.4.3

### DIFF
--- a/cmake/dependencies/dav1d.cmake
+++ b/cmake/dependencies/dav1d.cmake
@@ -12,14 +12,14 @@ SET(_target
 )
 
 SET(_version
-    "1.0.0"
+    "1.4.3"
 )
 
 SET(_download_url
     "https://github.com/videolan/dav1d/archive/refs/tags/${_version}.zip"
 )
 SET(_download_hash
-    "425282a997804984c5c115aacb005ab4"
+    "2c62106fda87a69122dc8709243a34e8"
 )
 
 SET(_install_dir


### PR DESCRIPTION
### Pull Request Update dav1d version to 1.4.3

### Summarize your change.

Update the version library from 1.0.0 to 1.4.3.

### Describe the reason for the change.

Sam Richards (Disney) asked at the last Open RV TSC if we could update the libdav1d component from 1.0 to latest 1.4.3 which has better performances according to him.

### Describe what you have tested and on which operating system.

The build step has been tested on all three platforms.