### PR TITLE
Default sequences replaced when comparing media from FPTR 

### DIFF
--- a/src/lib/app/RvApp/Options.cpp
+++ b/src/lib/app/RvApp/Options.cpp
@@ -458,6 +458,8 @@ Options::Options()
     presentFormat = (char*)"";
     presentData = (char*)"";
 
+    addSourceToDefaultView = true;
+
 #ifdef PLATFORM_DARWIN
     fontSize1 = 13;
     fontSize2 = 10;
@@ -493,6 +495,7 @@ Options::parseSourceArgs(const Files& inputFiles)
             inSource = true;
             sources.resize(sources.size() + 1);
             sources.back().singleSource = true;
+            sources.back().addSourceToDefaultView = true;
 
             SourceArgs& a = sources.back();
 

--- a/src/lib/app/RvApp/RvApp/Options.h
+++ b/src/lib/app/RvApp/RvApp/Options.h
@@ -34,8 +34,8 @@ struct Options
     {
         SourceArgs() : audioOffset(0), rangeOffset(0), volume(1), fps(0),
                        pixelAspect(0), stereoRelativeOffset(0), stereoRightOffset(0),
-                       hascrop(false), hasuncrop(false), singleSource (false),
-                       noMovieAudio(false)
+                       hascrop(false), hasuncrop(false), singleSource(false),
+                       noMovieAudio(false), addSourceToDefaultView(true)
             {
                 cutIn  = (std::numeric_limits<int>::max)();
                 cutOut = (std::numeric_limits<int>::max)();
@@ -59,6 +59,7 @@ struct Options
         float        stereoRightOffset;
         int          cutIn;
         int          cutOut;
+        bool         addSourceToDefaultView;
         std::string  fcdl;
         std::string  lcdl;
         std::string  flut;
@@ -340,6 +341,8 @@ struct Options
     int          presentAudio;
     int          fontSize1;
     int          fontSize2;
+
+    bool         addSourceToDefaultView;
 
     SendExternalEventVector  sendEvents;
 };

--- a/src/lib/app/RvApp/RvGraph.cpp
+++ b/src/lib/app/RvApp/RvGraph.cpp
@@ -324,7 +324,14 @@ RvGraph::connectNewSourcesToDefaultViews()
         copy(layer->inputs().begin(), layer->inputs().end(), inputs.begin());
         copy(m_newSources.begin(), m_newSources.end(), inputs.begin()+layer->inputs().size());
         HOP_ZONE( HOP_ZONE_COLOR_12 );
-        layer->setInputs(inputs);
+
+        if (Rv::Options::sharedOptions().addSourceToDefaultView)
+        {
+            layer->setInputs(inputs);
+        } else
+        {
+            cout << "INFO: Disabled adding sources to default views" << endl;
+        }
     }
 
     m_newSources.clear();

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -609,6 +609,12 @@ void initUICommands()
                                       Return, "void",
                                       End),
 
+                         new Function(c, "setConnectNewSourcesToDefaultViews", setConnectNewSourcesToDefaultViews, None,
+                                      Return, "void",
+                                      Parameters,
+                                      new Param(c, "enable", "bool"),
+                                      End),
+
                          EndArguments);
 }
 
@@ -2333,6 +2339,12 @@ NODE_IMPLEMENTATION(rvioSetup, void)
 {
     // Note: This is no longer relevant in RV Open Source but kept to maintain
     // backward compatibility.
+}
+
+NODE_IMPLEMENTATION(setConnectNewSourcesToDefaultViews, void)
+{
+    bool enable = NODE_ARG(0, bool);
+    Rv::Options::sharedOptions().addSourceToDefaultView = enable;
 }
 
 } // Rv namespace

--- a/src/lib/app/RvCommon/RvCommon/MuUICommands.h
+++ b/src/lib/app/RvCommon/RvCommon/MuUICommands.h
@@ -88,6 +88,7 @@ NODE_DECLARATION(validateShotgunToken, Mu::Pointer);
 NODE_DECLARATION(launchTLI, void);
 NODE_DECLARATION(rvioSetup, void);
 NODE_DECLARATION(javascriptMuExport, void);
+NODE_DECLARATION(setConnectNewSourcesToDefaultViews, void);
 
 
 } // Rv

--- a/src/lib/app/TwkApp/Bundle.cpp
+++ b/src/lib/app/TwkApp/Bundle.cpp
@@ -9,7 +9,7 @@
 #include <TwkApp/Bundle.h>
 #include <sstream>
 #include <boost/filesystem.hpp>
-#include <TwkUtil/file.h>
+#include <TwkUtil/File.h>
 
 namespace TwkApp {
 using namespace std;


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

This When a user opens media from Flow Production Tracking, and then compares it to another piece of media in Flow Production Tracking, the default sequences are overwritten. Meaning, the user can no longer access the clips that they initially opened from FPTR. This can interrupt workflows.

If this change is implemented, along with another PR into OpenRV, users will have the option to enable a parameter in `Flow Production Tracking / Session Prefs` that will prevent this from happening.

This PR, paired with a PR in Commercial RV, will resolve this issue. The changes made in this PR include a command that modifies a global preference to prevent media from being overwritten while comparing media. 

### Describe the reason for the change.

User wanted to be able to compare media without overwriting the original media. 

### Describe what you have tested and on which operating system.

MacOS 14.5 Sonoma