### PR TITLE
Remove libDevil from Notice.txt

### DIFF
--- a/Notice.txt
+++ b/Notice.txt
@@ -966,11 +966,7 @@ We are required to state that
 
 Libaio
 
-libaio is licensed under the GNU Lesser General Public License v.2.1, which can be found at https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html.   
-
-libDevil 1.6.8
-
-libDevil is licensed under the GNU Lesser General Public License v.2.1, which can be found at https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html.   
+libaio is licensed under the GNU Lesser General Public License v.2.1, which can be found at https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html.    
 
 Libexif
 


### PR DESCRIPTION
### Remove libDevil from Notice.txt

### Describe the reason for the change.

The libDevil mention is no longer required in Notice.txt since the library has been removed [here](https://github.com/AcademySoftwareFoundation/OpenRV/pull/550).