### PR TITLE
Create a different build folder for debug

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -84,7 +84,9 @@ rvenv_shell() {
 # VARIABLES
 RV_HOME="${RV_HOME:-$SCRIPT_HOME}"
 RV_BUILD="${RV_BUILD:-${RV_HOME}/_build}"
+RV_BUILD_DEBUG="${RV_BUILD_DEBUG:-${RV_HOME}/_build_debug}"
 RV_INST="${RV_INST:-${RV_HOME}/_install}"
+RV_INST_DEBUG="${RV_INST_DEBUG:-${RV_HOME}/_install_debug}"
 RV_BUILD_PARALLELISM="${RV_BUILD_PARALLELISM:-$(python3 -c 'import os; print(os.cpu_count())')}"
 
 # ALIASES: Basic commands
@@ -92,15 +94,17 @@ RV_BUILD_PARALLELISM="${RV_BUILD_PARALLELISM:-$(python3 -c 'import os; print(os.
 alias rvenv="rvenv_shell"
 alias rvsetup="rvenv && SETUPTOOLS_USE_DISTUTILS=${SETUPTOOLS_USE_DISTUTILS} python3 -m pip install --upgrade -r ${RV_HOME}/requirements.txt"
 alias rvcfg="rvenv && cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Release -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
-alias rvcfgd="rvenv && cmake -B ${RV_BUILD} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Debug -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
+alias rvcfgd="rvenv && cmake -B ${RV_BUILD_DEBUG} -G \"${CMAKE_GENERATOR}\" ${CMAKE_WIN_ARCH} -DCMAKE_BUILD_TYPE=Debug -DRV_DEPS_QT5_LOCATION=${QT_HOME} -DRV_DEPS_WIN_PERL_ROOT=${WIN_PERL}"
 alias rvbuildt="rvenv && cmake --build ${RV_BUILD} --config Release -v --parallel=${RV_BUILD_PARALLELISM} --target "
-alias rvbuildtd="rvenv && cmake --build ${RV_BUILD} --config Debug -v --parallel=${RV_BUILD_PARALLELISM} --target "
+alias rvbuildtd="rvenv && cmake --build ${RV_BUILD_DEBUG} --config Debug -v --parallel=${RV_BUILD_PARALLELISM} --target "
 alias rvbuild="rvenv && rvbuildt main_executable"
 alias rvbuildd="rvenv && rvbuildtd main_executable"
 alias rvtest="rvenv && ctest --test-dir ${RV_BUILD} --extra-verbose"
+alias rvtestd="rvenv && ctest --test-dir ${RV_BUILD_DEBUG} --extra-verbose"
 alias rvinst="rvenv && cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Release"
-alias rvinstd="rvenv && cmake --install ${RV_BUILD} --prefix ${RV_INST} --config Debug"
+alias rvinstd="rvenv && cmake --install ${RV_BUILD_DEBUG} --prefix ${RV_INST_DEBUG} --config Debug"
 alias rvclean="rm -rf ${RV_BUILD} && rm -rf .venv"
+alias rvcleand="rm -rf ${RV_BUILD_DEBUG} && rm -rf .venv"
 
 # ALIASES: Config and Build
 


### PR DESCRIPTION
### Create a different build folder for debug

### Linked issues
n/a

### Summarize your change.
Create a debug folder when building in debug. (`_build_debug` vs `_build`)

### Describe the reason for the change.
It can cause problem if someone switch between built type (having mixed of debug and release).

### Describe what you have tested and on which operating system.

- [x] Rocky Linux 8