### PR TITLE
Fix issue with venv on Windows

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -73,11 +73,16 @@ fi
 
 # Must be executed in a function as it changes the shell environment
 rvenv_shell() {
+  local activate_path=".venv/bin/activate"
+  if [[ "$OSTYPE" == "msys"* ]]; then
+    activate_path=".venv/Scripts/activate"
+  fi
+
   if [ -d ".venv" ]; then
-    source .venv/bin/activate
+    source "$activate_path"
   else
     python3 -m venv .venv
-    source .venv/bin/activate
+    source "$activate_path"
   fi
 }
 

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -71,10 +71,18 @@ else
   echo "Using Qt installation already set at $QT_HOME"
 fi
 
-# Must be executed in a function as it changes the shell environment
+if [[ "$(python -c 'import sys; print(sys.prefix)')" =~ ^/usr|^/mingw64 ]]; then
+  # Python from MSYS2.
+  PYTHON_FROM_MSYS2=1
+else
+  # Native Windows.
+  PYTHON_FROM_MSYS2=0
+fi
+
+# Must be executed in a function as it changes the shell environment.
 rvenv_shell() {
   local activate_path=".venv/bin/activate"
-  if [[ "$OSTYPE" == "msys"* ]]; then
+  if [[ PYTHON_FROM_MSYS2 -eq 0 ]]; then
     activate_path=".venv/Scripts/activate"
   fi
 


### PR DESCRIPTION
### Fix issue with venv on Windows

### Linked issues
n/a

### Summarize your change.
The Python virtual environment was not functioning correctly through rvcmd.sh.
### Describe the reason for the change.
Changed the path to activate the virtual environment based on the OS.

### Describe what you have tested and on which operating system.

- [x] Windows