### PR TITLE
Prevent the schedule workflow from running in fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   rocky-linux:
+    if : ${{ github.repository_owner == 'AcademySoftwareFoundation' }}
     name: 'Rocky Linux ${{ matrix.rocky-version }} ${{ matrix.vfx-platform }}
       <qt=${{ matrix.qt-version }},
        python=${{ matrix.python-version }},
@@ -219,6 +220,7 @@ jobs:
           cmake --install _build --prefix $(pwd)/_install --config ${{ matrix.build-type }}
 
   macos:
+    if : ${{ github.repository_owner == 'AcademySoftwareFoundation' }}
     name: '${{ matrix.os }} ${{ matrix.arch-type }} ${{ matrix.vfx-platform }}
       <qt=${{ matrix.qt-version }},
        python=${{ matrix.python-version }},
@@ -397,6 +399,7 @@ jobs:
           cmake --install _build --prefix $(pwd)/_install --config ${{ matrix.build-type }}
 
   windows:
+    if : ${{ github.repository_owner == 'AcademySoftwareFoundation' }}
     name: 'Windows ${{ matrix.vfx-platform }}
       <${{ matrix.os }}
        msvc=${{ matrix.msvc-component }},


### PR DESCRIPTION
### Prevent the schedule workflow from running in fork

### Linked issues
n/a

### Summarize your change.
Prevent the run of workflow is the repository owner is not ASWF. The new if conditon should prevent the workflow to be schedule and run on forks.

### Describe the reason for the change.
The schedule workflow is executing in forks as well.

### Describe what you have tested and on which operating system.
n/a