### PR TITLE
Fixed CentOS 7 install guide is missing some packages

### DIFF
--- a/docs/build_system/config_linux_centos7.md
+++ b/docs/build_system/config_linux_centos7.md
@@ -35,7 +35,7 @@ scl enable devtoolset-9 $SHELL
 Most of the build requirements can be installed using the following command:
 
 ```bash
-sudo yum install alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex glew-devel libXcomposite libXi-devel libaio-devel libffi-devel ncurses-devel libtool libxkbcommon openssl-devel patch pulseaudio-libs pulseaudio-libs-glib2 mesa-libOSMesa mesa-libOSMesa-devel ocl-icd opencl-headers python3 python3-devel qt5-qtbase-devel readline-devel sqlite-devel tcl-devel tk-devel yasm zlib-devel ninja-build meson tcsh
+sudo yum install alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex glew-devel libXcomposite libXi-devel libaio-devel libffi-devel ncurses-devel libtool libxkbcommon openssl-devel patch pulseaudio-libs pulseaudio-libs-glib2 mesa-libOSMesa mesa-libOSMesa-devel ocl-icd opencl-headers python3 python3-devel qt5-qtbase-devel readline-devel sqlite-devel tcl-devel tk-devel yasm zlib-devel ninja-build meson tcsh 
 ```
 
 ### Install the python requirements

--- a/docs/build_system/config_linux_centos7.md
+++ b/docs/build_system/config_linux_centos7.md
@@ -35,7 +35,7 @@ scl enable devtoolset-9 $SHELL
 Most of the build requirements can be installed using the following command:
 
 ```bash
-sudo yum install alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex glew-devel libXcomposite libXi-devel libaio-devel libffi-devel ncurses-devel libtool libxkbcommon openssl-devel patch pulseaudio-libs pulseaudio-libs-glib2 mesa-libOSMesa mesa-libOSMesa-devel ocl-icd opencl-headers python3 python3-devel qt5-qtbase-devel readline-devel sqlite-devel tcl-devel tk-devel yasm zlib-devel
+sudo yum install alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex glew-devel libXcomposite libXi-devel libaio-devel libffi-devel ncurses-devel libtool libxkbcommon openssl-devel patch pulseaudio-libs pulseaudio-libs-glib2 mesa-libOSMesa mesa-libOSMesa-devel ocl-icd opencl-headers python3 python3-devel qt5-qtbase-devel readline-devel sqlite-devel tcl-devel tk-devel yasm zlib-devel ninja-build meson tcsh
 ```
 
 ### Install the python requirements


### PR DESCRIPTION
### Linked issues
https://github.com/AcademySoftwareFoundation/OpenRV/issues/581

### Summarize your change.
added installation for ninja-build, meson, and tcsh packages

### Describe the reason for the change.
Need the packages to run OpenRV

### Describe what you have tested and on which operating system.
MacOS