### PR TITLE
Fix OTIO tests

### DIFF
--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -281,7 +281,7 @@ def _get_global_transform(tl):
     # that can contain all clips
     def find_display_bounds(tl):
         display_bounds = None
-        for clip in tl.clip_if():
+        for clip in tl.find_clips():
             try:
                 bounds = clip.media_reference.available_image_bounds
                 if bounds:

--- a/src/plugins/rv-packages/otio_reader/otio_writer.py
+++ b/src/plugins/rv-packages/otio_reader/otio_writer.py
@@ -396,8 +396,8 @@ def _create_transition(rv_trx, *args, **kwargs):
     :param node_name: `str`
     :return: `otio.schema.Transition`
     """
-    pre_item = kwargs.get("pre_item")
-    pre_item = kwargs.get("post_item")
+    pre_item = kwargs.get("pre_item")[0]
+    post_item = kwargs.get("post_item")
 
     transition_type = TRANSITION_TYPE_MAP.get(
         commands.nodeType(rv_trx), otio.schema.TransitionTypes.Custom
@@ -438,12 +438,12 @@ def _create_transition(rv_trx, *args, **kwargs):
         rate=fps,
     )
 
-    if pre_item.source_range:
+    if pre_item.source_range is not None:
         if not is_same_media(out_source, pre_item):
             return None
         pre_item.source_range = pre_item.source_range.duration_extended_by(in_offset)
 
-    if post_item.source_range:
+    if post_item.source_range is not None:
         if not is_same_media(in_source, post_item):
             return None
         post_item.source_range = otio.opentime.TimeRange(


### PR DESCRIPTION
### Fix OTIO tests

### Summarize your change.

1.  Replace clip_if() with find_clips() since it has been deprecated in OTIO
2. Fix _create_transition() where `post_item` was undefined and `if pre_item.source_range` was unhashable

### Describe the reason for the change.
This was preventing `otio_tests::export_multi_clip_with_transition()` and `otio_tests::round_trip()` from passing.

### Describe what you have tested and on which operating system.
The tests were done on MacOS.