### PR TITLE
Add RV as a participant using the new Live Review schema

### DIFF
--- a/docs/rv-packages/rv-otio-reader.md
+++ b/docs/rv-packages/rv-otio-reader.md
@@ -17,6 +17,7 @@ The RV package is installed in the usual Python package installation location: `
 The package also uses a number of files located in `Plugins/SupportFiles/otio_reader` and detailed below.
 
 - `manifest.json`: Provides examples of schemas and hooks used in the import process.
+- `annotation_schema.py` An example schema of an annotation.
 - `cdlExportHook.py`: An example of exporting an RVLinearize to a custom CDL effect in OTIO.
 - `cdlHook.py`: An example of importing a custom CDL effect in OTIO into an RVLinearize node.
 - `cdlSchema.py` An example schema of a CDL effect.

--- a/src/plugins/rv-packages/otio_reader/PACKAGE
+++ b/src/plugins/rv-packages/otio_reader/PACKAGE
@@ -18,6 +18,8 @@ modes:
 files:
   - file: manifest.json
     location: SupportFiles/$PACKAGE
+  - file: annotation_schema.py
+    location: SupportFiles/$PACKAGE
   - file: cdlSchema.py
     location: SupportFiles/$PACKAGE
   - file: cdlHook.py
@@ -80,6 +82,13 @@ description: |
     <p>
     manifest.json
     This is used to provide examples schemas and hooks used in the import process.
+    </p>
+    </li>
+
+    <li>
+    <p>
+    annotation_schema.py
+    An example schema of an annotation.
     </p>
     </li>
 
@@ -260,4 +269,3 @@ description: |
     <p>
     For pre- and post- hooks, no return value is expected.
     </p>
-

--- a/src/plugins/rv-packages/otio_reader/annotation_schema.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_schema.py
@@ -1,0 +1,59 @@
+# *****************************************************************************
+# Copyright 2024 Autodesk, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# *****************************************************************************
+
+"""
+For our OTIO output to effectively interface with other programs
+using the OpenTimelineIO Python API, our custom schema need to be
+specified and registered with the API.
+
+As per OTIO documentation, a class such as this one must be created,
+the schema must be registered with a PluginManifest, and the path to that
+manifest must be added to $OTIO_PLUGIN_MANIFEST_PATH; then the schema
+is ready to be used.
+
+Example:
+myObject = otio.schemadef.Annotation.Annotation(name, visible, layers)
+"""
+
+import opentimelineio as otio
+
+
+@otio.core.register_type
+class Annotation(otio.schema.Effect):
+    """A schema for annotations."""
+
+    _serializable_label = "Annotation.1"
+    _name = "Annotation"
+
+    def __init__(
+        self, name: str = "", visible: bool = True, layers: list | None = None
+    ) -> None:
+        super().__init__(name=name, effect_name="Annotation.1")
+        self.visible = visible
+        self.layers = layers
+
+    _visible = otio.core.serializable_field(
+        "visible", required_type=bool, doc=("Visible: expects either true or false")
+    )
+
+    _layers = otio.core.serializable_field(
+        "layers", required_type=list, doc=("Layers: expects a list of annotation types")
+    )
+
+    @property
+    def layers(self) -> list:
+        return self._layers
+
+    @layers.setter
+    def layers(self, val: list):
+        self._layers = val
+
+    def __str__(self) -> str:
+        return f"Annotation({self.name}, {self.effect_name}, {self.visible}, {self.layers})"
+
+    def __repr__(self) -> str:
+        return f"otio.schema.Annotation(name={self.name!r}, effect_name={self.effect_name!r}, visible={self.visible!r}, layers={self.layers!r})"

--- a/src/plugins/rv-packages/otio_reader/manifest.json
+++ b/src/plugins/rv-packages/otio_reader/manifest.json
@@ -3,6 +3,12 @@
     "schemadefs" : [
         {
             "OTIO_SCHEMA" : "SchemaDef.1",
+            "name" : "Annotation",
+            "execution_scope" : "in process",
+            "filepath" : "annotation_schema.py"
+        },
+        {
+            "OTIO_SCHEMA" : "SchemaDef.1",
             "name" : "CDL",
             "execution_scope" : "in process",
             "filepath" : "cdlSchema.py"

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -281,7 +281,7 @@ def _get_global_transform(tl):
     # that can contain all clips
     def find_display_bounds(tl):
         display_bounds = None
-        for clip in tl.clip_if():
+        for clip in tl.find_clips():
             try:
                 bounds = clip.media_reference.available_image_bounds
                 if bounds:

--- a/src/plugins/rv-packages/otio_reader/otio_writer.py
+++ b/src/plugins/rv-packages/otio_reader/otio_writer.py
@@ -396,8 +396,8 @@ def _create_transition(rv_trx, *args, **kwargs):
     :param node_name: `str`
     :return: `otio.schema.Transition`
     """
-    pre_item = kwargs.get("pre_item")
-    pre_item = kwargs.get("post_item")
+    pre_item = kwargs.get("pre_item")[0]
+    post_item = kwargs.get("post_item")
 
     transition_type = TRANSITION_TYPE_MAP.get(
         commands.nodeType(rv_trx), otio.schema.TransitionTypes.Custom
@@ -438,12 +438,12 @@ def _create_transition(rv_trx, *args, **kwargs):
         rate=fps,
     )
 
-    if pre_item.source_range:
+    if pre_item.source_range is not None:
         if not is_same_media(out_source, pre_item):
             return None
         pre_item.source_range = pre_item.source_range.duration_extended_by(in_offset)
 
-    if post_item.source_range:
+    if post_item.source_range is not None:
         if not is_same_media(in_source, post_item):
             return None
         post_item.source_range = otio.opentime.TimeRange(


### PR DESCRIPTION
### Add RV as a participant using the new Live Review schema

### Summarize your change.

The `read_otio_string` function was added to parse the OTIO object containing the timeline sent by the Review App when RV is joining a new session as a participant. Since the timeline contains some annotation fields, the annotation schema was added in order to let OTIO know that it is a known schema during the deserialization step. However, nothing is done with the annotations at this stage.

### Describe the reason for the change.

This is the first step in adding back the new OTIO schema as the preferred way of communication between RV and the Review App.

### Describe what you have tested and on which operating system.

Live review using the new schema was tested between a local Review App where the feature was enabled with https://creative-collab.dev.shotguncloud.com and RV on MacOS.