### PR TITLE
Fix build break on CentOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 pyyaml              # License: MIT License (MIT)
 requests            # License: Apache Software License (Apache 2.0)
 wheel               # License: MIT License (MIT)
-py7zr               # License: GNU Lesser General Public License v2 or later (LGPLv2+) (LGPL-2.1-or-later)
+pyzstd==0.15.9      # License: BSD License (BSD-3-Clause)
+py7zr==0.22.0       # License: GNU Lesser General Public License v2 or later (LGPLv2+) (LGPL-2.1-or-later)
 dohq-artifactory    # License: MIT License (MIT License)
 pre-commit          # License: MIT License (MIT)


### PR DESCRIPTION
### Fix build break on CentOS

### Summarize your change.

Set `pyzstd` and `py7zr` to the maximum version working with Python 3.8.

### Describe the reason for the change.

The version of `pyzstd` required by the latest version of `py7zr` doesn't work with Python 3.8 which is used with CentOS 7 which is causing a build break. This fix should be removed once the support for CentOS is dropped.

### Describe what you have tested and on which operating system.

The build step was tested on CentOS 7.