### PR TITLE
#604: Fix Blackmagic Video Output plugin build on Windows

### DIFF
--- a/cmake/dependencies/bmd.cmake
+++ b/cmake/dependencies/bmd.cmake
@@ -59,6 +59,16 @@ EXTERNALPROJECT_ADD(
   INSTALL_COMMAND ""
 )
 
+# Generate the DeckLinkAPI.h file from DeckLinkAPI.idl provided with the DeckLink SDK
+IF(RV_TARGET_WINDOWS)
+  EXTERNALPROJECT_ADD_STEP(
+    ${_target} post_install_step
+    COMMAND midl.exe ARGS /header DeckLinkAPI.h /iid DeckLinkAPIDispatch.cpp DeckLinkAPI.idl
+    WORKING_DIRECTORY ${_include_dir}
+    DEPENDEES install
+  )
+ENDIF()
+
 ADD_LIBRARY(BlackmagicDeckLinkSDK INTERFACE)
 ADD_DEPENDENCIES(BlackmagicDeckLinkSDK ${_target})
 TARGET_INCLUDE_DIRECTORIES(


### PR DESCRIPTION
### 604: Fix Blackmagic Video Output plugin build on Windows

### Linked issues

Fixes #604

### Summarize your change.

Added a post-install step in the BlackMagicDevice cmake file (bmd.cmake) to generate the DeckLinkAPI.h header file via midl.exe which is required to build the Blackmagic Video Output plugin on Windows.

Note that the BlackMagic SDK only provides .idl files on Windows (not .h header files). Since that we are building OpenRV in a non managed way, we need to generate a DesktopLinkAPI.h header file from the provided .idl files.

### Describe the reason for the change.

The Blackmagic Video Output plugin build on Windows was broken.

### Describe what you have tested and on which operating system.

Successfully tested on Windows.
Note that this commit is Windows specific so it should not impact any other OS.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.