### PR TITLE
Fix live review annotation opacity

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -46,7 +46,7 @@ def hook_function(in_timeline, argument_map=None) -> None:
                     "join": 3,
                     "cap": 2,
                     "splat": 1,
-                    "mode": 0 if layer.type.lower() == "color" else 1,
+                    "mode": 0 if layer.type == "COLOR" else 1,
                 },
             )
 
@@ -67,11 +67,20 @@ def hook_function(in_timeline, argument_map=None) -> None:
                 commands.newProperty(width_property, commands.FloatType, 1)
 
             global_width = 2 / 15  # 0.133333...
+
             for point in layer.points:
-                commands.insertFloatProperty(
-                    points_property,
-                    [point.x * global_scale.x, point.y * global_scale.y],
-                )
-                commands.insertFloatProperty(
-                    width_property, [point.width * global_width]
-                )
+                points = commands.getFloatProperty(points_property)
+                if (
+                    len(points) > 1
+                    and points[-1] == point.y * global_scale.y
+                    and points[-2] == point.x * global_scale.x
+                ):
+                    pass
+                else:
+                    commands.insertFloatProperty(
+                        points_property,
+                        [point.x * global_scale.x, point.y * global_scale.y],
+                    )
+                    commands.insertFloatProperty(
+                        width_property, [point.width * global_width]
+                    )


### PR DESCRIPTION
### Fix live review annotation opacity

### Summarize your change.

Add a new points to the list of points to draw only if it's not already there.

### Describe the reason for the change.

The number of points was causing the opacity level too be too opaque.

### Describe what you have tested and on which operating system.

The opacity level was tested by changing it's value in the ReviewApp and seeing the resulting annotation in RV on MacOS.