### PR TITLE
#616: Fix crash when prog source loading enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ compile_commands.json
 **/.python-version
 
 cmake-*/*
-build/*
-_build/*
+/*build*/
 _install/*
 .venv/*


### PR DESCRIPTION
### 616: Fix crash with missing media when progressive source loading enabled

### Linked issues
Fixes #616 

### Summarize your change.

#### Note about progressive source loading in Open RV
Note: Progressive source loading is NOT enabled by default in Open RV as it significantly complexifies custom scripting since many previously synchronous operations become asynchronous. 
For reference: https://aswf-openrv.readthedocs.io/en/latest/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-two.html#progressive-source-loading

Progressive source loading in RV can be enabled by setting the following environment variable:
`export RV_PROGRESSIVE_SOURCE_LOADING=1`

#### Problem
Open RV sometimes crashes when loading an rv session containing missing media with progressive source loading enabled.

#### Cause
Modifying the RV execution graph that can potentially trigger events to be notified to Mu or Python plugins can only be done in the main thread. When progressive source loading is enabled, there is a special mechanism that is used to dispatch any such operations to the main thread: Application::instance()->dispatchToMainThread().
However, there was a scenario that was not covered by this mechanism: when some media was missing in action for example. This caused graph events, such as media.active=false to be notified inside the progressive loading worker threads and ultimately random crashes.

#### Solution
Now leveraging the already existing Application::instance()->dispatchToMainThread() mechanism in the event that some media is missing.
Note that this fix only impacts when progressive loading is enabled in Open RV. It is therefore low risk for the default behaviour.

### Describe the reason for the change.

Open RV sometimes crashes when loading an rv session containing missing media with progressive source loading enabled

### Describe what you have tested and on which operating system.

Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.