### PR TITLE
620: Fix overrides of video output command line options

### DIFF
--- a/src/lib/app/RvCommon/RvPreferences.cpp
+++ b/src/lib/app/RvCommon/RvPreferences.cpp
@@ -3593,6 +3593,10 @@ RvPreferences::videoFormatChanged(int v)
         settings.setValue("videoFormat", v);
         settings.endGroup();
 
+        // The user has set a new video format which overrides the video format
+        // specified on the command line if any
+        Rv::Options::sharedOptions().presentFormat=nullptr;
+
         updateVideoDataFormat(d);
         updateVideoSync(d);
         updateVideoSyncSource(d);
@@ -3650,6 +3654,10 @@ RvPreferences::videoDataFormatChanged(int v)
         settings.beginGroup(QString::fromUtf8(str.str().c_str()));
         settings.setValue("dataFormat", v);
         settings.endGroup();
+
+        // The user has set a new video data format which overrides the video 
+        // data format specified on the command line if any
+        Rv::Options::sharedOptions().presentData=nullptr;
 
         updateVideoSync(d);
         updateVideoSyncSource(d);
@@ -3711,6 +3719,9 @@ RvPreferences::videoAudioCheckBoxChanged(int v)
         settings.beginGroup(QString::fromUtf8(str.str().c_str()));
         settings.setValue("useAsAudioDevice", checked);
         settings.endGroup();
+
+        // This user action overrides the presentAudio command line option if any
+        Rv::Options::sharedOptions().presentAudio=-1;
     }
 }
 


### PR DESCRIPTION
### 620: Fix overrides of video output command line options

### Linked issues
Fixes #620

### Summarize your change.

This commit now enables the user to override the following optional video output related command line options:
- presentVideoFormat
- presentDataFormat
- presentAudio

### Describe the reason for the change.

User cannot override settings presentVideoFormat and presentDataFormat once specified on the command line

### Describe what you have tested and on which operating system.

Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.