### PR TITLE
CI - Fix issue with icu4c

### DIFF
--- a/.github/actions/build-qt5-for-arm64/action.yml
+++ b/.github/actions/build-qt5-for-arm64/action.yml
@@ -36,7 +36,7 @@ runs:
           echo "cached=${{ steps.arm64-qt.outputs.cache-hit }}" >> $GITHUB_OUTPUT
         shell: bash
           
-      - name: Switch to XCode 14
+      - name: Switch to XCode 15
         if: steps.arm64-qt.outputs.cache-hit != 'true'
         run: |
           sudo xcode-select -switch /Applications/Xcode_${{ inputs.xcode-version }}.app
@@ -48,7 +48,7 @@ runs:
           brew install --quiet --formula libiconv libpng libpq libtool libuv libxau libxcb libxdmcp
           brew install --quiet --formula autoconf automake cmake pcre2 harfbuzz freetype node@18 nspr nss
           brew install --quiet --formula xcb-proto xcb-util xcb-util-cursor xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm
-          brew install --quiet --formula brotli bzip2 dbus glew icu4c jpeg md4c openssl@1.1 pkg-config sqlite xorgproto zlib zstd
+          brew install --quiet --formula brotli bzip2 dbus glew icu4c@76 jpeg md4c openssl@1.1 pkg-config sqlite xorgproto zlib zstd
           brew list openssl@1.1
         shell: bash
 
@@ -98,6 +98,17 @@ runs:
           curl https://www.nic.funet.fi/pub/mirrors/download.qt-project.org/official_releases/qt/5.15/${{ inputs.qt-version }}/single/qt-everywhere-opensource-src-${{ inputs.qt-version }}.tar.xz -o qt.tar.xz
           tar xf qt.tar.xz
           mv qt-everywhere-src-${{ inputs.qt-version }} qt-src
+          ls -al
+          pwd
+        shell: bash
+
+      - name: Patch Qt ${{ matrix.qt-version }}
+        # There is an issue with Clang15 and Qt < 5.15.15.
+        run: |
+          curl -o file.zip https://codereview.qt-project.org/changes/qt%2Fqtbase~503172/revisions/3/files/mkspecs%2Ffeatures%2Ftoolchain.prf/download
+          unzip file.zip
+          ls -al ${{ github.workspace }}/qt-src
+          cp $(unzip -l file.zip | awk 'NR==4 {print $4}') ${{ github.workspace }}/qt-src/mkspecs/features/toolchain.prf
         shell: bash
 
       - name: Create directory for build
@@ -141,7 +152,7 @@ runs:
           -skip qtpurchasing \
           -skip qtlocation \
           -I /opt/homebrew/Cellar/openssl@1.1/1.1.1w/include -L /opt/homebrew/Cellar/openssl@1.1/1.1.1w/lib \
-          -I /opt/homebrew/Cellar/icu4c/74.2/include -L /opt/homebrew/Cellar/icu4c/74.2/lib
+          -I $(realpath $(brew --prefix icu4c@76))/include -L $(realpath $(brew --prefix icu4c@76))/lib
         working-directory: ${{ github.workspace }}/qt-build
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,6 @@ jobs:
           sudo rm -rf /Applications/Xcode_15.3.app
           sudo rm -rf /Applications/Xcode_15.2.app
           sudo rm -rf /Applications/Xcode_15.1.app
-          sudo rm -rf /Applications/Xcode_15.0.1.app
           sudo rm -rf /Users/runner/Library/Android
 
       - name: Display disk space
@@ -328,7 +327,7 @@ jobs:
           qt-version: "5.15.15"
           python3-version: "3.11.9"
           python2-version: "2.7.18"
-          xcode-version: "14.3.1"
+          xcode-version: "15.0"
           qt-output: "deps"
 
       - name: Activate Python ${{ matrix.python-version }} if Qt was taken from cache
@@ -343,7 +342,8 @@ jobs:
   
       - name: Install Homebrew dependencies
         run: |
-          brew install --quiet --formula cmake ninja readline sqlite3 xz zlib tcl-tk autoconf automake libtool python yasm clang-format black meson nasm pkg-config glew icu4c
+          brew install --formula cmake ninja readline sqlite3 xz zlib tcl-tk python-tk autoconf automake libtool python yasm clang-format black meson nasm pkg-config glew
+          brew install --formula icu4c@76
 
       - name: Set QT_HOME
         if: matrix.arch-type == 'x86_64'


### PR DESCRIPTION
### CI - Fix issue with icu4c

### Linked issues
n/a

### Summarize your change.
Locked the version of homebrew package icu4c to version 74.

### Describe the reason for the change.
Github action are failing because of an update of icu4c. Qt5 need icu4c version 74.

### Describe what you have tested and on which operating system.
Mac