### PR TITLE
Fix issue with runtime.build_os and runtime.build_architecture

### DIFF
--- a/cmake/defaults/rv_targets.cmake
+++ b/cmake/defaults/rv_targets.cmake
@@ -9,20 +9,23 @@ SET(CMAKE_SKIP_RPATH
 )
 
 IF(APPLE)
-  # Only native builds are supported (x86_64 on Intel MacOS and ARM64 on Apple chipset).
-  # Rosetta can be used to build x86_64 on Apple chipset.
+  # Only native builds are supported (x86_64 on Intel MacOS and ARM64 on Apple chipset). Rosetta can be used to build x86_64 on Apple chipset.
   IF("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     SET(RV_TARGET_APPLE_X86_64
         ON
         CACHE INTERNAL "Compile for x86_64 on Apple MacOS" FORCE
     )
-    SET(__target_arch__ -DRV_ARCH_X86_64)
+    SET(__target_arch__
+        -DRV_ARCH_X86_64
+    )
   ELSEIF("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
     SET(RV_TARGET_APPLE_ARM64
         ON
         CACHE INTERNAL "Compile for arm64 on Apple MacOS" FORCE
     )
-    SET(__target_arch__ -DRV_ARCH_ARM64)
+    SET(__target_arch__
+        -DRV_ARCH_ARM64
+    )
   ENDIF()
 
   MESSAGE(STATUS "Building for ${CMAKE_HOST_SYSTEM_PROCESSOR}")
@@ -42,6 +45,11 @@ IF(APPLE)
   SET(PLATFORM
       "DARWIN"
       CACHE STRING "Platform identifier used in Tweak Makefiles"
+  )
+
+  SET(ARCH
+      "${CMAKE_HOST_SYSTEM_PROCESSOR}"
+      CACHE STRING "CPU Architecture identifier"
   )
 
   SET(CMAKE_MACOSX_RPATH
@@ -105,6 +113,16 @@ ELSEIF(UNIX)
     -DTWK_NO_SGI_BYTE_ORDER
     -DGL_GLEXT_PROTOTYPES
     -DPLATFORM_OPENGL=1
+  )
+
+  SET(PLATFORM
+      "LINUX"
+      CACHE STRING "Platform identifier"
+  )
+
+  SET(ARCH
+      "IA32_64"
+      CACHE STRING "CPU Architecture identifier"
   )
 
   EXECUTE_PROCESS(


### PR DESCRIPTION
### Fix issue with runtime.build_os and runtime.build_architecture

### Linked issues
n/a

### Summarize your change.
Add missing compiler definitions for MacOS and Linux. There are some unrelated changes because of the pre-commit hook.

### Describe the reason for the change.
The command build_os and build_architecture were returning empty strings on Linux.

### Describe what you have tested and on which operating system.
Rocky 8