### PR TITLE
Fix the doc about setProgressiveSourceLoading()

### DIFF
--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-two.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-two.md
@@ -77,9 +77,13 @@ If you need to, RV can load sources asynchronously, also known as progressive so
 
 **Use one of these methods to enable asynchronous source loading:**
 
-- Set `setProgressiveSourceLoading = true`
 - With the command line argument: `-progressiveSourceLoading 1`
 - With the environment variable: `RV_PROGRESSIVE_SOURCE_LOADING`
+- Execute the following command in an RV Python package:
+```python
+from rv import commands as rvc
+rvc.setProgressiveSourceLoading(True)
+```
 
 > Note: `setProgressiveSourceLoading` affects the behaviour of the following scripting commands:
 >


### PR DESCRIPTION
### Fix the doc about setProgressiveSourceLoading()

### Linked issues
na

### Summarize your change.

The Open RV documentation incorrectly stated that the following command could be executed to enable progressive source loading in Open RV:

`setProgressiveSourceLoading = true`

This was incorrect and fixed in this commit.
Here is the fix marked down preview:

<img width="813" alt="setProgressiveSourceLoading_cmd_overview" src="https://github.com/user-attachments/assets/1e6d1905-c531-4077-8ac0-660dc26fbd7d">


### Describe the reason for the change.

Incorrect documentation

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.