### PR TITLE
457: Fix OCIO failure with 1D LUTs of 2048 length

### DIFF
--- a/src/lib/ip/IPCore/ShaderFunction.cpp
+++ b/src/lib/ip/IPCore/ShaderFunction.cpp
@@ -1346,6 +1346,7 @@ Function::hashAuxNames()
     static regex funcDefRE(" ?\\w+ (\\w+) ?\\([^\\{]+\\{\\}$");
     static regex varRE("const .*?(\\w+) ?=");
     static regex varArrayRE("const .*?(\\w+)\\[\\w+] ?= ?\\w+\\[\\w+].*$");
+    static regex uniformSamplerRE("uniform sampler\\wD (\\w+).*$");
 
     for (size_t i = 0; i < lines.size(); i++)
     {
@@ -1354,7 +1355,8 @@ Function::hashAuxNames()
 
         if (regex_search(line, sm, funcDefRE) ||
             regex_search(line, sm, varRE) ||
-            regex_search(line, sm, varArrayRE))
+            regex_search(line, sm, varArrayRE) ||
+            regex_search(line, sm, uniformSamplerRE) )
         {
             if (sm[1] != m_name)
             {


### PR DESCRIPTION
### 457: Fix OCIO failure with 1D LUTs of 2048 length

### Linked issues
Fixes #457

### Summarize your change.

Prevent shader collisions with 'uniform sampler1D' or 'uniform sampler2D' variables by adding a hash to the
array variable name to make it unique.
This was already done for other kinds of variables but not uniform sampler1D or sampler2D.

This is not an issue with OCIOv2 per say. This is an issue because Open RV combines the results of multiple shaders generated by OCIOv2 so Open RV needs to make the generated global variables unique.

Note that this issue happened with 1D LUTs of 2048 length because OCIOv2 uses different sampler types depending  of the LUT size: a sampler1D for LUTs<=2048 entries, and a sampler2D type for LUTs>2048.

#### Solution
Similar to a previously fixed [issue](https://github.com/AcademySoftwareFoundation/OpenRV/commit/c7d1cd495c0340b1590e02884419f38c7f9c5d6a#diff-1f024a562fd99e22efc42e11e6824c1f0c4259b1a6c7e80cb3b942a7f79e5603R1348), we are now appending a hash to a uniform sampler1D or uniform sampler2D to make it really unique to prevent shader compilation errors.

### Describe the reason for the change.

A specific OCIOv2 use case (https://github.com/AcademySoftwareFoundation/OpenRV/issues/457) involving a 1D LUT with 2048 entries was not working in Open RV.
The following error was reported by Open RVl 

```
ERROR: compiling program: 
      		with functions:  OCIO_l_identity_2048_sourceGroup000000_lookPipeline_0_5927894d66be2f09_0ResizeDownSampleDerivative SourcePlanarYUV OCIO_c_issue_space_2_scene_linear_sourceGroup000000_tolinPipeline_0_2744ed689522d6e3

ERROR: Multiple declarations of 'ocio_lut1d_0Sampler' have different types (sampler2D and sampler1D)
ERROR: failed to compile/select GL program: ERROR: failed to select the GL program
```

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.