### PR TITLE
CI - Run job on all changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: OpenRV
 
 on:
   push:
+    branches:
+      # This will run when PR is merged or direct pushes to main.
+      - main
 
-  pull_request:
+  pull_request: # This handles PR creation and subsequent commits.
 
   schedule:
     # Midnight build every day

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,8 @@ name: OpenRV
 
 on:
   push:
-    # Skip jobs when only those files are changed.
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - 'Notice.txt'
-      - 'rvcmds.sh'
 
   pull_request:
-    # Skip jobs when only those files are changed.
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - 'Notice.txt'
-      - 'rvcmds.sh'
 
   schedule:
     # Midnight build every day


### PR DESCRIPTION
### CI - Run job on all changes

### Linked issues
n/a

### Summarize your change.
Remove the path-ignores in the CI.

### Describe the reason for the change.
It causes issues where the CI is not running but is still mandatory.