### PR TITLE
Fix rvls -x skipping license validation on MacOS

### DIFF
--- a/src/bin/imgtools/rvls/CMakeLists.txt
+++ b/src/bin/imgtools/rvls/CMakeLists.txt
@@ -44,6 +44,7 @@ TARGET_LINK_LIBRARIES(
           stl_ext
           Boost::headers
           yaml_cpp
+          Qt5::Core
 )
 
 IF(RV_TARGET_DARWIN)

--- a/src/bin/imgtools/rvls/main.cpp
+++ b/src/bin/imgtools/rvls/main.cpp
@@ -10,6 +10,7 @@
 
 #ifdef PLATFORM_DARWIN
 #include <DarwinBundle/DarwinBundle.h>
+#include <QtCore/QtCore>
 #else
 #include <QTBundle/QTBundle.h>
 #endif
@@ -577,11 +578,11 @@ vector<string> readSession(string path)
 int utf8Main(int argc, char** argv)
 {
     TwkFB::ThreadPool::initialize();
+    const QCoreApplication qapp(argc, argv);
 
 #ifdef PLATFORM_DARWIN
     TwkApp::DarwinBundle bundle("RV", MAJOR_VERSION, MINOR_VERSION, REVISION_NUMBER);
 #else
-    QCoreApplication qapp(argc, argv);
     TwkApp::QTBundle bundle("rv", MAJOR_VERSION, MINOR_VERSION, REVISION_NUMBER);
     (void) bundle.top();
 #endif


### PR DESCRIPTION
### Fix rvls -x skipping license validation on MacOS

### Summarize your change.

Initialized the QCoreApplication on MacOS before creating the bundle.

### Describe the reason for the change.

The QCoreApplication was not being created properly on MacOS.

### Describe what you have tested and on which operating system.

Successfully tested on MacOS