### PR TITLE
Qt6 Feature branch - Fix issue with menu on MacOS

### DIFF
--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -1693,7 +1693,9 @@ RvDocument::buildMenu()
 void
 RvDocument::mergeMenu(const TwkApp::Menu* menu, bool shortcuts)
 {
-    //purgeMenus();
+#if defined( RV_VFX_CY2023 )
+    purgeMenus();
+#endif
 
     if (!menu) 
     {
@@ -1711,7 +1713,11 @@ RvDocument::mergeMenu(const TwkApp::Menu* menu, bool shortcuts)
 
 
 #if !defined(PLATFORM_DARWIN)
+#if defined( RV_VFX_CY2023 )
     if (!m_rvMenu || !workAroundActionLeak)
+#else
+    if (!m_rvMenu)
+#endif
     {
         m_rvMenu = mb()->addMenu(UI_APPLICATION_NAME);
         m_rvMenu->addAction(RvApp()->aboutAction());
@@ -1747,6 +1753,7 @@ RvDocument::mergeMenu(const TwkApp::Menu* menu, bool shortcuts)
         {
             QString title = utf8(item->title());
 
+#if defined( RV_VFX_CY2024 )
             // Overwrite the existing menu if it is already present in the QMenuBar.
             for (QAction* action : mb()->actions())
             {
@@ -1757,8 +1764,8 @@ RvDocument::mergeMenu(const TwkApp::Menu* menu, bool shortcuts)
                     mb()->removeAction(menu->menuAction());
                 }
             }
-            
-            QMenuBar* bar = mb();
+#endif       
+
             QMenu* menu = mb()->addMenu(title);
             //  rt.go();
             connect(menu, SIGNAL(aboutToShow()), this, SLOT(aboutToShowMenu()));

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -1693,7 +1693,7 @@ RvDocument::buildMenu()
 void
 RvDocument::mergeMenu(const TwkApp::Menu* menu, bool shortcuts)
 {
-    purgeMenus();
+    //purgeMenus();
 
     if (!menu) 
     {
@@ -1742,11 +1742,23 @@ RvDocument::mergeMenu(const TwkApp::Menu* menu, bool shortcuts)
     for (int i=0; i < menu->items().size(); i++)
     {
         const TwkApp::Menu::Item* item = menu->items()[i];
-
-        if (item->subMenu())
+        
+        if (item->subMenu())    
         {
             QString title = utf8(item->title());
 
+            // Overwrite the existing menu if it is already present in the QMenuBar.
+            for (QAction* action : mb()->actions())
+            {
+                QMenu* menu = action->menu();
+                if (menu && menu->title() ==  title)
+                {
+
+                    mb()->removeAction(menu->menuAction());
+                }
+            }
+            
+            QMenuBar* bar = mb();
             QMenu* menu = mb()->addMenu(title);
             //  rt.go();
             connect(menu, SIGNAL(aboutToShow()), this, SLOT(aboutToShowMenu()));


### PR DESCRIPTION
### Qt6 Feature branch - Fix issue with menu on MacOS

### Linked issues
n/a

### Summarize your change.
The QMenuBar and QMenu has changed in Qt6. Some behaviours seems to have changed in Qt6, and the code around a memory leak (based on the comments) is not longer working.

I made some changes that works on MacOS and Rocky Linux 8. There no information about how to reproduce that memory leak.
**We'll need to test around that to make sure that it is not the case with Qt6 anymore.**

### Describe the reason for the change.
Multiple menu were appearing on the menu bar on MacOS.

### Describe what you have tested and on which operating system.

- [x] MacOS
- [x] Rocky Linux 8