### PR TITLE
Fix default Python locale and now honor PYTHONUTF8 env var

### DIFF
--- a/src/lib/app/PyTwkApp/PyInterface.cpp
+++ b/src/lib/app/PyTwkApp/PyInterface.cpp
@@ -255,6 +255,15 @@ namespace TwkApp
 
   void initPython( int argc, char** argv )
   {
+    // PreInitialize Python
+    // Note: This is necessary for Python to utilize environment variables like PYTHONUTF8
+    PyPreConfig preconfig;
+    PyPreConfig_InitPythonConfig(&preconfig);
+    PyStatus status=Py_PreInitialize(&preconfig);
+    if (PyStatus_Exception(status)) {
+      Py_ExitStatusException(status);
+    }
+
     Py_InitializeEx( 1 );
     static wchar_t delim = L'\0';
 


### PR DESCRIPTION
### Fix default Python locale and now honour PYTHONUTF8 env var

### Linked issues
NA

### Summarize your change.

Now pre-initializing the Python interpreter in RV to ensure that the PyConfig.use_environment is set to 1 (default).
Without this pre-initialization, PyConfig.use_environment defaults to 0 which means that the currently set locale gets ignored as well as the PYTHONUTF8 env var if set by the user.

### Describe the reason for the change.

Since commercial RV 2023 (Python 3.9.13), the default Python locale was no longer respecting the currently set environment variables (including the PYTHONUTF8 env var) and the script described below, was always returning:
US-ASCII
0

Prior to this release, such as commercial RV 2022.3.1 (Python 3.7.13), the default Python locale was respecting both the currently set environment variables, including PYTHONUTF8 env var. So we would generally have
UTF-8
1


### Describe what you have tested and on which operating system.

I used this python script to validate the fix:

```
import locale
import sys
print(locale.getpreferredencoding(False))
print(sys.flags.utf8_mode)
```
It now returns:
UTF-8
1

and now honours the PYTHONUTF8 env var
export PYTHONUTF8=0 

It now returns:
US-ASCII
0


### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.