### PR TITLE
616: Fix MediaLibrary crash when prog source loading enabled

### DIFF
--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/FileSourceIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/FileSourceIPNode.h
@@ -170,6 +170,10 @@ class FileSourceIPNode : public SourceIPNode
 
     static std::string cacheHash(const std::string& filename, const std::string& prefix);
 
+    // Lookup filename in the media library, save associated HTTP header and cookies if any, 
+    // and return the actual filename to be used for opening the movie in case of redirection.
+    std::string lookupFilenameInMediaLibrary(const std::string& filename);
+
     static void setSourceNameInID(bool b) { m_sourceNameInID = b; }
     static bool sourceNameInID() { return m_sourceNameInID; };
 


### PR DESCRIPTION
### 616: Fix MediaLibrary crash when prog source loading enabled

### Linked issues

Fixes #616

### Summarize your change.

#### Note about progressive source loading in Open RV
Note: Progressive source loading is NOT enabled by default in Open RV as it significantly complexifies custom scripting since many previously synchronous operations become asynchronous. 
For reference: https://aswf-openrv.readthedocs.io/en/latest/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-two.html#progressive-source-loading

Progressive source loading in RV can be enabled by setting the following environment variable:
`export RV_PROGRESSIVE_SOURCE_LOADING=1`

#### Problem
Open RV sometimes crashes when executing the following script repeatedly:

```python
from rv import commands as rvc

rvc.setProgressiveSourceLoading(True)

srcA = {
    "Streaming":
    "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4",
    "Frames":
    "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4"
}
srcAp = {
    "Streaming":
    "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4",
    "Frames":
    "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4"
}


rvc.addSourcesVerbose([[srcA["Streaming"], "+mediaRepName", "Small"]])
rvc.addSourceMediaRep("last", "Large", [srcA["Frames"]])


rvc.addSourcesVerbose([[srcAp["Streaming"], "+mediaRepName", "Small"]])
rvc.addSourceMediaRep("last", "Large", [srcAp["Frames"]])

```

#### Cause
When progressive source loading is enabled (which is not the default in RV), the actual loading of the media is done in worker threads in order to parallelize and thus optimize multiple source load as much as possible.
The actual code executed is here: `FileSourceIPNode::openMovieTask()`
This code contains MediaLibrary accesses. When RV was open sourced, the MediaLibrary code was refactored to be Python plugin based to make the MediaLibrary functionality more generic. The original implementation was c++ based and thread safe. The new implementation should not be called outside of the main thread.  This is what was causing the random crash when progressive source loading was enabled.

#### Solution
I have extracted the MediaLibrary code and moved it into its own dedicated method named `FileSourceIPNode::lookupFilenameInMediaLibrary()`,  which is now invoked from the main thread prior to launch the openMovieTasks . Note that the code is exactly like before. It is just invoked differently, that's all.

### Describe the reason for the change.

Open RV sometimes crashes when adding media with progressive source loading enabled

### Describe what you have tested and on which operating system.

Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.