### PR TITLE
Clean up the OTIO reader annotation

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -48,8 +48,8 @@ def hook_function(
                     "brush": layer.brush,
                     "debug": 1,
                     "join": 3,
-                    "cap": 2,
-                    "splat": 1,
+                    "cap": 1,
+                    "splat": 0,
                     "mode": 0 if layer.type == "COLOR" else 1,
                 },
             )
@@ -91,16 +91,10 @@ def hook_function(
             global_width = 2 / 15  # 0.133333...
 
             for point in layer.points:
-                points = commands.getFloatProperty(points_property)
-                if not (
-                    len(points) > 1
-                    or points[-1] == point.y * global_scale.y
-                    or points[-2] == point.x * global_scale.x
-                ):
-                    commands.insertFloatProperty(
-                        points_property,
-                        [point.x * global_scale.x, point.y * global_scale.y],
-                    )
-                    commands.insertFloatProperty(
-                        width_property, [point.width * global_width]
-                    )
+                commands.insertFloatProperty(
+                    points_property,
+                    [point.x * global_scale.x, point.y * global_scale.y],
+                )
+                commands.insertFloatProperty(
+                    width_property, [point.width * global_width]
+                )

--- a/src/plugins/rv-packages/otio_reader/annotation_schema.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_schema.py
@@ -37,11 +37,11 @@ class Annotation(otio.schema.Effect):
         self.layers = layers
 
     _visible = otio.core.serializable_field(
-        "visible", required_type=bool, doc=("Visible: expects either true or false")
+        "visible", required_type=bool, doc=("visible: expects either true or false")
     )
 
     _layers = otio.core.serializable_field(
-        "layers", required_type=list, doc=("Layers: expects a list of annotation types")
+        "layers", required_type=list, doc=("layers: expects a list of annotation types")
     )
 
     @property
@@ -53,7 +53,14 @@ class Annotation(otio.schema.Effect):
         self._layers = val
 
     def __str__(self) -> str:
-        return f"Annotation({self.name}, {self.effect_name}, {self.visible}, {self.layers})"
+        return (
+            f"Annotation({self.name}, {self.effect_name}, {self.visible}, "
+            f"{self.layers})"
+        )
 
     def __repr__(self) -> str:
-        return f"otio.schema.Annotation(name={self.name!r}, effect_name={self.effect_name!r}, visible={self.visible!r}, layers={self.layers!r})"
+        return (
+            f"otio.schema.Annotation(name={self.name!r}, "
+            f"effect_name={self.effect_name!r}, "
+            f"visible={self.visible!r}, layers={self.layers!r})"
+        )

--- a/src/plugins/rv-packages/otio_reader/paint_schema.py
+++ b/src/plugins/rv-packages/otio_reader/paint_schema.py
@@ -54,11 +54,11 @@ class Paint(otio.core.SerializableObject):
         self.ghost = ghost
 
     name = otio.core.serializable_field(
-        "name", required_type=str, doc=("Name: expects a string")
+        "name", required_type=str, doc=("name: expects a string")
     )
 
     _points = otio.core.serializable_field(
-        "points", required_type=list, doc=("Points: expects a list of point objects")
+        "points", required_type=list, doc=("points: expects a list of point objects")
     )
 
     @property
@@ -66,11 +66,11 @@ class Paint(otio.core.SerializableObject):
         return self._points
 
     @points.setter
-    def points(self, val: list) -> None:
+    def points(self, val: list):
         self._points = val
 
     _rgba = otio.core.serializable_field(
-        "rgba", required_type=list, doc=("RGBA: expects a list of four floats")
+        "rgba", required_type=list, doc=("rgba: expects a list of four floats")
     )
 
     @property
@@ -78,21 +78,21 @@ class Paint(otio.core.SerializableObject):
         return self._rgba
 
     @rgba.setter
-    def rgba(self, val: list) -> list:
+    def rgba(self, val: list) -> None:
         self._rgba = val
 
     type = otio.core.serializable_field(
-        "type", required_type=str, doc=("Type: expects a string")
+        "type", required_type=str, doc=("type: expects a string")
     )
 
     brush = otio.core.serializable_field(
-        "brush", required_type=str, doc=("Brush: expects a string")
+        "brush", required_type=str, doc=("brush: expects a string")
     )
 
     _layer_range = otio.core.serializable_field(
         "layer_range",
         required_type=otio.opentime.TimeRange,
-        doc=("Layer_range: expects a TimeRange object"),
+        doc=("layer_range: expects a TimeRange object"),
     )
 
     @property
@@ -100,15 +100,15 @@ class Paint(otio.core.SerializableObject):
         return self._layer_range
 
     @layer_range.setter
-    def layer_range(self, val) -> otio.opentime.TimeRange:
+    def layer_range(self, val):
         self._layer_range = val
 
     _hold = otio.core.serializable_field(
-        "hold", required_type=bool, doc=("Hold: expects either true or false")
+        "hold", required_type=bool, doc=("hold: expects either true or false")
     )
 
     _ghost = otio.core.serializable_field(
-        "ghost", required_type=bool, doc=("Ghost: expects either true or false")
+        "ghost", required_type=bool, doc=("ghost: expects either true or false")
     )
 
     def __str__(self) -> str:

--- a/src/plugins/rv-packages/otio_reader/point_schema.py
+++ b/src/plugins/rv-packages/otio_reader/point_schema.py
@@ -32,10 +32,7 @@ class Point(otio.core.SerializableObject):
     _name = "Point"
 
     def __init__(
-        self, 
-        width: float | None = None,
-        x: float | None = None,
-        y: float | None = None
+        self, width: float | None = None, x: float | None = None, y: float | None = None
     ) -> None:
         super().__init__()
         self.width = width
@@ -43,7 +40,7 @@ class Point(otio.core.SerializableObject):
         self.y = y
 
     width = otio.core.serializable_field(
-        "width", required_type=float, doc=("Width: expect a float")
+        "width", required_type=float, doc=("width: expects a float")
     )
 
     x = otio.core.serializable_field(
@@ -55,10 +52,9 @@ class Point(otio.core.SerializableObject):
     )
 
     def __str__(self) -> str:
-        return f"Point{self.width}, {self.x}, {self.y}"
+        return f"Point({self.width}, {self.x}, {self.y})"
 
     def __repr__(self) -> str:
         return (
-            f"otio.schema.Point(width={self.width!r}, x={self.x!r}, "
-            f"y={self.y!r})"
+            f"otio.schema.Point(width={self.width!r}, x={self.x!r}, " f"y={self.y!r})"
         )


### PR DESCRIPTION
### Clean up the OTIO reader annotation

This PR aims to clean up a bit the code related to the OTIO reader for annotations in Live Review.

### Question
I see that some files for other hooks and schemas are in camel case instead of snake case. Does anyone knows if there is a reason? Is everyone ok with me renaming the files inside `otio_reader` to use snake case instead?