### PR TITLE
Add default global scale value if missing in the annotation hook

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -6,6 +6,7 @@
 # *****************************************************************************
 
 
+import logging
 import effectHook
 import opentimelineio as otio
 from rv import commands, extra_commands
@@ -59,12 +60,19 @@ def hook_function(in_timeline, argument_map=None) -> None:
 
             global_scale = argument_map.get("global_scale")
             if global_scale is None:
-                first_source_node = commands.sourcesAtFrame(0)[0]
-                media_info = commands.sourceMediaInfo(first_source_node)
-                height = media_info["height"]
-                aspect_ratio = media_info["width"] / height
-                scale = aspect_ratio / 16
-                global_scale = otio.schema.V2d(scale, scale)
+                try:
+                    first_source_node = commands.sourcesAtFrame(0)[0]
+                    media_info = commands.sourceMediaInfo(first_source_node)
+                    height = media_info["height"]
+                    aspect_ratio = media_info["width"] / height
+                except Exception:
+                    logging.exception(
+                        "Unable to determine aspect ratio, using default value of 16:9"
+                    )
+                    aspect_ratio = 1920 / 1080
+                finally:
+                    scale = aspect_ratio / 16
+                    global_scale = otio.schema.V2d(scale, scale)
 
             points_property = f"{pen_component}.points"
             width_property = f"{pen_component}.width"

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -58,6 +58,14 @@ def hook_function(in_timeline, argument_map=None) -> None:
             )
 
             global_scale = argument_map.get("global_scale")
+            if global_scale is None:
+                first_source_node = commands.sourcesAtFrame(0)[0]
+                media_info = commands.sourceMediaInfo(first_source_node)
+                height = media_info["height"]
+                aspect_ratio = media_info["width"] / height
+                scale = aspect_ratio / 16
+                global_scale = otio.schema.V2d(scale, scale)
+
             points_property = f"{pen_component}.points"
             width_property = f"{pen_component}.width"
 

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -60,6 +60,9 @@ def hook_function(in_timeline, argument_map=None) -> None:
 
             global_scale = argument_map.get("global_scale")
             if global_scale is None:
+                logging.warning(
+                    "Unable to get the global scale, using the aspect ratio of the first media file"
+                )
                 try:
                     first_source_node = commands.sourcesAtFrame(0)[0]
                     media_info = commands.sourceMediaInfo(first_source_node)


### PR DESCRIPTION
### Add default global scale value if missing

### Summarize your change.

A default global scale value is calculated based on the aspect ratio of the first source if it couldn't be obtained from the OTIO.

### Describe the reason for the change.

When no `available_image_bounds` is present in the OTIO, no global scale value was being calculated. This was causing an issue where the annotations couldn't be displayed in RV during a Live Review Session.

### Describe what you have tested and on which operating system.

Successfully test on MacOS