### PR TITLE
Add a .clang-tidy to lint the C++ code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,20 @@
+---
+Checks: >
+  bugprone-*,
+  cert-*,
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  google-explicit-constructor,
+  misc-*,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  readability-*,
+
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: 'file'
+...


### PR DESCRIPTION
### Add a .clang-tidy to lint the C++ code

### Summarize your change.

A .clang-tidy was added at the root of the project to lint our C++ code. We should do the same for commercial RV if everyone is happy with this one. The formatStyle is set to 'file' so that the changes suggested by the linter will match the rules in our .clang-format. WarningAsErrors could be changed to match all or any of the checks if, at one point, we would want to enforce the respect of a category. HeaderFilterRegex could be changed if we need to exclude some header files from being lint by clang-tidy.

### Describe the reason for the change.

Just like we are formatting our code with the .clang-format, we should also lint it using a .clang-tidy. This is the one I've been using personally but I think it could be beneficial to others, especially for code reviews since it would help to avoid having to ask for small changes that could have been easily catch by a linter. Ideally, we would also add it to our CI pipeline so that we don't only rely on people generating a compile_commands.json to use it and making the changes suggested to the code by the linter. Here's the documentation 

### If possible, provide screenshots.

Here's an example of what the linter messages could look like:

<img width="1255" alt="Screenshot 2024-12-04 at 3 42 17 PM" src="https://github.com/user-attachments/assets/7eab6730-f46e-4535-8b0a-62c083e5857e">
