### PR TITLE
Add CMake custom build to the Rocky9 build instructions

### DIFF
--- a/docs/build_system/config_linux_centos7.md
+++ b/docs/build_system/config_linux_centos7.md
@@ -48,7 +48,7 @@ python3 -m pip install -r requirements.txt
 
 ## Install CMake
 
-You need CMake version 3.24+ to build RV. The yum-installable version is not quite recent enough, you'll to build and install CMake from sources.
+You need CMake version 3.24+ to build RV. The yum-installable version is not quite recent enough, you'll need to build and install CMake from source.
 
 ```bash
 wget https://github.com/Kitware/CMake/releases/download/v3.24.0/cmake-3.24.0.tar.gz

--- a/docs/build_system/config_linux_rocky8.md
+++ b/docs/build_system/config_linux_rocky8.md
@@ -51,7 +51,7 @@ python3 -m pip install -r requirements.txt
 
 ## Install CMake
 
-You need CMake version 3.27+ to build RV. The dnf-installable version is not quite recent enough, you'll to build and install CMake from sources.
+You need CMake version 3.27+ to build RV. The dnf-installable version is not quite recent enough, you'll need to build and install CMake from source.
 
 ```bash
 wget https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3.tar.gz

--- a/docs/build_system/config_linux_rocky9.md
+++ b/docs/build_system/config_linux_rocky9.md
@@ -57,6 +57,22 @@ Some of the RV build scripts requires extra python packages. They can be install
 python3 -m pip install -r requirements.txt
 ```
 
+## Install CMake
+
+You need CMake version 3.27+ to build RV. The dnf-installable version is not quite recent enough, you'll need to build and install CMake from source.
+
+```bash
+wget https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3.tar.gz
+tar -zxvf cmake-3.30.3.tar.gz
+cd cmake-3.30.3
+./bootstrap --parallel=32  # 32 or whatever your machine allows
+make -j 32  # 32 or whatever your machine allows
+sudo make install
+
+cmake --version  # confirm the version of your newly installed version of CMake
+cmake version3.30.3
+```
+
 ## Install Qt
 
 Download the last version of Qt 5.15.x that you can get using the online installer on the [Qt page](https://www.qt.io/download-open-source). During Qt Setup's Select Components phase, check the "Archive" box on the right side of the window then click on "Filter" to see Qt 5.15.x options. Logs, Android, iOS and WebAssembly are not required to build OpenRV. Make sure to note the destination of the Qt install, as you will have to set the `QT_HOME` environment variable to this location's build dir.


### PR DESCRIPTION
### Add CMake custom build to the Rocky9 build instructions

### Linked issues
NA

### Summarize your change.

Add CMake custom build to the Rocky9 build instructions

### Describe the reason for the change.

A newer version of CMake than the one coming standard with Rocky 9 is required to build an RV dependency.

### Describe what you have tested and on which operating system.

Validated on Rocky 9

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.