### PR TITLE
Add Python initialization in rvls

### DIFF
--- a/src/bin/imgtools/rvls/CMakeLists.txt
+++ b/src/bin/imgtools/rvls/CMakeLists.txt
@@ -30,6 +30,7 @@ FIND_PACKAGE(
 
 TARGET_LINK_LIBRARIES(
   ${_target}
+  PUBLIC MuTwkApp
   PRIVATE IOproxy
           OpenEXR::OpenEXR
           MovieFB
@@ -45,6 +46,7 @@ TARGET_LINK_LIBRARIES(
           Boost::headers
           yaml_cpp
           Qt5::Core
+          PyTwkApp
 )
 
 IF(RV_TARGET_DARWIN)

--- a/src/bin/imgtools/rvls/main.cpp
+++ b/src/bin/imgtools/rvls/main.cpp
@@ -19,6 +19,8 @@
 #include <IOproxy/IOproxy.h>
 #include <ImfThreading.h>
 #include <MovieFB/MovieFB.h>
+#include <MuTwkApp/MuInterface.h>
+#include <PyTwkApp/PyInterface.h>
 #include <TwkFB/TwkFBThreadPool.h>
 #include <MovieProcedural/MovieProcedural.h>
 #include <MovieProxy/MovieProxy.h>
@@ -675,6 +677,17 @@ int utf8Main(int argc, char** argv)
 
     TwkMovie::GenericIO::addPlugin(new MovieFBIO());
     TwkMovie::GenericIO::addPlugin(new MovieProceduralIO());
+
+    try
+    {
+        TwkApp::initMu(nullptr);
+        TwkApp::initPython();
+    }
+    catch (const std::exception &e)
+    {
+        cerr << "ERROR: during initialization: " << e.what() << '\n';
+        exit(-1);
+    }
 
     if (showFormats)
     {


### PR DESCRIPTION
### Add Python initialization in rvls

### Summarize your change.

Initialize Python in rvls main function to match the behaviour of rvio inside the ShotGrid license validation.

### Describe the reason for the change.

The license validation was failing on Linux when using rvls, but the same code was working fine with rvio because of the Python initialization in main(). The Python interpreter from rvio had more capabilities that were needed to properly import Python modules on Linux.

### Describe what you have tested and on which operating system.
This change was tested on Rocky8, MacOS Sonoma and Windows 11.