### PR TITLE
Fix Open RV not launching on macOS Sequoia 15.2

### DIFF
--- a/cmake/dependencies/gc.cmake
+++ b/cmake/dependencies/gc.cmake
@@ -85,6 +85,7 @@ FILE(MAKE_DIRECTORY ${_include_dir})
 
 LIST(APPEND _configure_options "-Denable_parallel_mark=ON")
 LIST(APPEND _configure_options "-Denable_cplusplus=ON")
+LIST(APPEND _configure_options "-Denable_large_config=yes")
 IF(RV_TARGET_WINDOWS)
   LIST(APPEND _configure_options "-DCMAKE_USE_WIN32_THREADS_INIT=1")
 ELSE()


### PR DESCRIPTION
### Fix Open RV not launching on macOS Sequoia 15.2

### Linked issues

NA

### Summarize your change.

Increased the Garbage Collector's maximum number of roots from 2048 to 4096 by enabling the large config option in the garbage collector config.

### Describe the reason for the change.

RV+Open RV could no longer launch since Apple released macOS Sequoia 15.2 (2 days ago).
The following fatal error was reported by the garbage collector component of RV:
"Too many root sets"

### Describe what you have tested and on which operating system.
Successfully tested on macOS Sequoia 15.2.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.