### PR TITLE
Fix AJA not working on Windows

### DIFF
--- a/src/plugins/output/AJADevices/AJAModule.cpp
+++ b/src/plugins/output/AJADevices/AJAModule.cpp
@@ -80,6 +80,17 @@ namespace AJADevices
 
       deviceIndex++;
     }
+
+#ifdef PLATFORM_WINDOWS
+    GLenum error = glewInit(nullptr);
+    if (error != GLEW_OK)
+    {
+        std::string message = "AJA: GLEW initialization failed: ";
+        throw std::runtime_error(
+            message + reinterpret_cast<const char*>(glewGetErrorString(error))
+        );
+    }
+#endif
   }
 
   void AJAModule::close()


### PR DESCRIPTION
### Fix AJA not working on Windows

### Summarize your change.

The GLEW library was not initialized before using other GLEW extension 

### Describe the reason for the change.

The AJA output module was having the same issue as the one mention in the following PR with BlackMagic: [[#116](https://git.autodesk.com/media-and-entertainment/rv/pull/116)](https://git.autodesk.com/media-and-entertainment/rv/pull/116).

### Describe what you have tested and on which operating system.

Starting the presentation mode on Windows 11 with an AJA Io 4K Plus device does not make RV crash anymore.