### PR TITLE
Feature/Qt6 - Fix issue with QItemSelectionModel::select method in Mu

### DIFF
--- a/src/lib/mu/MuQt6/MuQt6/Bridge.h
+++ b/src/lib/mu/MuQt6/MuQt6/Bridge.h
@@ -26,6 +26,10 @@ namespace Mu
                                  const Type* T, Value& v, QString& s,
                                  QVariant& qv);
 
+    QMetaMethodArgument argument(STLVector<Pointer>::Type& gcCache,
+                                 QMetaMethod& method, const Type* T, Value& v,
+                                 QString& s, QVariant& qv);
+
 } // namespace Mu
 
 #endif // __MuQt__Bridge__h__


### PR DESCRIPTION
### Feature/Qt6 - Fix issue with QItemSelectionModel::select method in Mu

### Linked issues
n/a

### Summarize your change.
Added a special case to deal with calls to `QItemSelectionModel::select`.

### Describe the reason for the change.
The new implementation of `QMetaMethod:invoke` in Qt 6 is using variadic templates and C++ type deduction (instead of `QGenericArgument`). Therefore, it does not convert the `QItemSelectionModel::SelectionFlags` enum to `int` and an error message appears.

### Describe what you have tested and on which operating system.
Rocky 8 and MacOS