### PR TITLE
Add missing RV network python module

### DIFF
--- a/src/plugins/python/CMakeLists.txt
+++ b/src/plugins/python/CMakeLists.txt
@@ -5,4 +5,5 @@
 #
 
 ADD_SUBDIRECTORY(gtoContainer)
+ADD_SUBDIRECTORY(network)
 ADD_SUBDIRECTORY(rvSession)

--- a/src/plugins/python/network/CMakeLists.txt
+++ b/src/plugins/python/network/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (C) 2025  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+RV_STAGE(TARGET network TYPE "PYTHON_SOURCE_MODULE" FILES network)

--- a/src/plugins/python/network/__init__.py
+++ b/src/plugins/python/network/__init__.py
@@ -1,6 +1,0 @@
-#
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
-#
-from .rvNetwork import RvCommunicator

--- a/src/plugins/python/network/network/__init__.py
+++ b/src/plugins/python/network/network/__init__.py
@@ -1,0 +1,6 @@
+#
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+from .rvNetwork import RvCommunicator

--- a/src/plugins/python/network/network/addSource.py
+++ b/src/plugins/python/network/network/addSource.py
@@ -1,8 +1,8 @@
 #! /usr/bin/python
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 
 import rvNetwork

--- a/src/plugins/python/network/network/muConsole.py
+++ b/src/plugins/python/network/network/muConsole.py
@@ -1,8 +1,8 @@
 #! /usr/bin/python
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 
 import rvNetwork

--- a/src/plugins/python/network/network/playControl.py
+++ b/src/plugins/python/network/network/playControl.py
@@ -1,8 +1,8 @@
 #! /usr/bin/python
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 
 import rvNetwork

--- a/src/plugins/python/network/network/rvNetwork.py
+++ b/src/plugins/python/network/network/rvNetwork.py
@@ -1,8 +1,8 @@
 #! /usr/bin/python
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from __future__ import print_function
 
@@ -319,7 +319,7 @@ class RvCommunicator:
             else:
                 print("ERROR: unknown message type: %s\n" % messType, file=sys.stderr)
 
-        for (event, contents) in self.eventQueue:
+        for event, contents in self.eventQueue:
             if event in self.handlers:
                 self.handlers[event](contents)
 


### PR DESCRIPTION
### Add missing RV network python module

### Linked issues
NA

### Describe the reason for the change.

This python module was unfortunately forgotten when RV was open sourced.

### Summarize your change.

I moved the RV network python module files one sub-directory under their current location in order to be able to use the RV_STAGE("PYTHON_SOURCE_MODULE" FILES network_driectory) Cmake macro to install and made the necessary adjustments to the CMake build system to install it when building Open RV.
With this commit, once built, the RV network python module files will be under the 
RV.app/Contents/PlugIns/Python/network directory.

### Describe what you have tested and on which operating system.

Successfully testes on macOS.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.