### PR TITLE
Feature/Qt6 - Fix issue where Mu Command API Browser is not opening

### DIFF
--- a/src/lib/mu/MuQt6/QVariantType.cpp
+++ b/src/lib/mu/MuQt6/QVariantType.cpp
@@ -48,6 +48,7 @@
 #include <MuQt6/QRegularExpressionType.h>
 #include <MuQt6/QPointType.h>
 #include <MuQt6/QByteArrayType.h>
+#include <MuQt6/QIconType.h>
 
 namespace Mu
 {
@@ -175,6 +176,15 @@ namespace Mu
     {
         MuLangContext* c = static_cast<MuLangContext*>(NODE_THREAD.context());
         const QDateTime arg1 = getqtype<QDateTimeType>(param_val);
+        setqtype<QVariantType>(param_this, QVariant(arg1));
+        return param_this;
+    }
+
+    Pointer qt_QVariant_QVariant_QVariant_QVariant_QIcon(
+        Mu::Thread& NODE_THREAD, Pointer param_this, Pointer param_val)
+    {
+        MuLangContext* c = static_cast<MuLangContext*>(NODE_THREAD.context());
+        const QIcon arg1 = getqtype<QIconType>(param_val);
         setqtype<QVariantType>(param_this, QVariant(arg1));
         return param_this;
     }
@@ -510,6 +520,12 @@ namespace Mu
             NODE_THREAD, NONNIL_NODE_ARG(0, Pointer), NODE_ARG(1, Pointer)));
     }
 
+    static NODE_IMPLEMENTATION(_n_QVariant80, Pointer)
+    {
+        NODE_RETURN(qt_QVariant_QVariant_QVariant_QVariant_QIcon(
+            NODE_THREAD, NONNIL_NODE_ARG(0, Pointer), NODE_ARG(1, Pointer)));
+    }
+
     static NODE_IMPLEMENTATION(_n_QVariant27, Pointer)
     {
         NODE_RETURN(qt_QVariant_QVariant_QVariant_QVariant_QRegularExpression(
@@ -827,6 +843,11 @@ namespace Mu
                          Return, "qt.QVariant", Parameters,
                          new Param(c, "this", "qt.QVariant"),
                          new Param(c, "val", "qt.QDateTime"), End),
+            new Function(c, "QVariant", _n_QVariant80, None, Compiled,
+                         qt_QVariant_QVariant_QVariant_QVariant_QIcon, Return,
+                         "qt.QVariant", Parameters,
+                         new Param(c, "this", "qt.QVariant"),
+                         new Param(c, "val", "qt.QIcon"), End),
             // MISSING: QVariant (QVariant; QVariant this, "const QHash<QString,
             // QVariant> &" val) MISSING: QVariant (QVariant; QVariant this,
             // "const QJsonArray &" val) MISSING: QVariant (QVariant; QVariant

--- a/src/lib/mu/MuQt6/handrolled/QVariantDefinitions.cpp
+++ b/src/lib/mu/MuQt6/handrolled/QVariantDefinitions.cpp
@@ -16,6 +16,22 @@ static NODE_IMPLEMENTATION(toInt, int)
     NODE_RETURN(QVariant_toInt_int(NODE_THREAD, NONNIL_NODE_ARG(0, Pointer)));
 }
 
+Pointer qt_QVariant_QVariant_QVariant_QVariant_QIcon(Mu::Thread& NODE_THREAD,
+                                                     Pointer param_this,
+                                                     Pointer param_val)
+{
+    MuLangContext* c = static_cast<MuLangContext*>(NODE_THREAD.context());
+    const QIcon arg1 = getqtype<QIconType>(param_val);
+    setqtype<QVariantType>(param_this, QVariant(arg1));
+    return param_this;
+}
+
+static NODE_IMPLEMENTATION(_n_QVariant80, Pointer)
+{
+    NODE_RETURN(qt_QVariant_QVariant_QVariant_QVariant_QIcon(
+        NODE_THREAD, NONNIL_NODE_ARG(0, Pointer), NODE_ARG(1, Pointer)));
+}
+
 /*
 static Pointer
 QVariant_toQObject_QObject(Thread& NODE_THREAD, Pointer param_this)

--- a/src/lib/mu/MuQt6/handrolled/QVariantSymbols.cpp
+++ b/src/lib/mu/MuQt6/handrolled/QVariantSymbols.cpp
@@ -8,6 +8,12 @@ addSymbol(new Function(c, "toInt", toInt, None, Compiled, QVariant_toInt_int,
                        Return, "int", Parameters,
                        new Param(c, "this", "qt.QVariant"), End));
 
+addSymbol(new Function(c, "QVariant", _n_QVariant80, None, Compiled,
+                       qt_QVariant_QVariant_QVariant_QVariant_QIcon, Return,
+                       "qt.QVariant", Parameters,
+                       new Param(c, "this", "qt.QVariant"),
+                       new Param(c, "val", "qt.QIcon"), End));
+
 /*
 addSymbol( new Function(c, "toObject", toQObject, None,
                         Compiled, QVariant_toQObject_int,


### PR DESCRIPTION
### Feature/Qt6 - Fix issue where Mu Command API Browser is not opening

### Linked issues
n/a

### Summarize your change.
There were some changes in the Qt 6 QVariant type and it seems like we need to explicitly define a QVariant constructor for QIcon in Qt 6.

### Describe the reason for the change.
Mu Command API Browser is not opening in the build using Qt 6.

### Describe what you have tested and on which operating system.
Rocky 8