### PR TITLE
Fix OTIO import of tracks with mixed frame rates

### DIFF
--- a/src/lib/ip/IPBaseNodes/SequenceGroupIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/SequenceGroupIPNode.cpp
@@ -17,6 +17,8 @@
 #include <TwkUtil/File.h>
 #include <TwkUtil/sgcHop.h>
 
+#include <algorithm>
+
 namespace IPCore
 {
     using namespace std;
@@ -99,9 +101,15 @@ namespace IPCore
         float fps = m_sequenceNode->imageRangeInfo().fps;
         if (fps == 0.0 && !newInputs.empty())
         {
-            auto const imageRangeInfo = newInputs[index]->imageRangeInfo();
-            if (!imageRangeInfo.isUndiscovered)
-                fps = imageRangeInfo.fps;
+            // Find the first input that has a discovered imageRangeInfo, and
+            // use it for the fps if any.
+            auto it = std::find_if(
+                newInputs.begin(), newInputs.end(), [](const auto& input)
+                { return !input->imageRangeInfo().isUndiscovered; });
+            if (it != newInputs.end())
+            {
+                fps = (*it)->imageRangeInfo().fps;
+            }
         }
 
         bool retimeInputs = m_retimeToOutput->front() ? true : false;

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -260,6 +260,9 @@ def _create_track(in_seq, context=None):
             "frame": [],
         }
 
+        # RV supports only one frame rate per sequence, so we'll use the rate of the first item in the sequence as our sequence rate
+        seq_rate = None
+
         for thing in items_to_serialize:
             if isinstance(thing, tuple):
                 result = _create_transition(*thing, context=context)
@@ -271,11 +274,14 @@ def _create_track(in_seq, context=None):
                 result = create_rv_node_from_otio(thing, context)
                 edl_item, pre_item = thing, None
 
+            if seq_rate is None:
+                seq_rate = thing.trimmed_range().duration.rate
+
             if result:
                 new_inputs.append(result)
 
-                edl_range = _calculate_edl(edl, edl_time, edl_item, pre_item)
-                edl_time = edl_range.end_time_exclusive()
+                edl_range = _calculate_edl(edl, edl_time, edl_item, seq_rate, pre_item)
+                edl_time = edl_range.end_time_exclusive().rescaled_to(seq_rate)
 
         commands.setNodeInputs(new_seq, new_inputs)
 
@@ -327,7 +333,7 @@ def _get_global_transform(tl) -> dict:
     }
 
 
-def _calculate_edl(edl, edl_time, item, pre_transition_item=None):
+def _calculate_edl(edl, edl_time, item, seq_rate, pre_transition_item=None):
     # EDL values don't make much sense for a transitions, since it has two
     # different sources as inputs. So if we have a transition, we'll just set
     # EDL values to consume the whole transition, and rely on the cut values
@@ -338,7 +344,7 @@ def _calculate_edl(edl, edl_time, item, pre_transition_item=None):
         duration = (item.in_offset + item.out_offset).rescaled_to(rate)
         out_frame = otio.opentime.to_frames(duration, rate)
     else:
-        in_frame, out_frame = _get_in_out_frame(item, item.trimmed_range())
+        in_frame, out_frame = _get_in_out_frame(item, item.trimmed_range(), seq_rate)
         duration = item.trimmed_range().duration
 
     edl["in"].append(in_frame)
@@ -365,7 +371,7 @@ def _set_sequence_edl(sequence, edl_time, edl):
     commands.setIntProperty("{}.mode.autoEDL".format(sequence), [0])
 
 
-def _get_in_out_frame(it, range_to_read):
+def _get_in_out_frame(it, range_to_read, seq_rate=None):
     in_frame = out_frame = None
 
     if hasattr(it, "media_reference") and it.media_reference:
@@ -378,13 +384,12 @@ def _get_in_out_frame(it, range_to_read):
             )
 
     if not in_frame and not out_frame:
-        # because OTIO has no global concept of FPS, the rate of the duration
-        # is used as the rate for the range of the source.
+        rate = seq_rate if seq_rate is not None else range_to_read.duration.rate
         in_frame = otio.opentime.to_frames(
-            range_to_read.start_time, rate=range_to_read.duration.rate
+            range_to_read.start_time.rescaled_to(rate), rate=rate
         )
         out_frame = otio.opentime.to_frames(
-            range_to_read.end_time_inclusive(), rate=range_to_read.duration.rate
+            range_to_read.end_time_inclusive().rescaled_to(rate), rate=rate
         )
     return (in_frame, out_frame)
 


### PR DESCRIPTION
### Fix OTIO import of tracks with mixed frame rates

### Linked issues

NA

### Describe the reason for the change.

This commit fixes two issues related to the import of media with mixed frame rates.
Note: RV supports only one frame rate per sequence which is dictated by the first source in the sequence.
RV automatically retimes the clips that do not match the frame rate of the first source.

**Issue#1:** 
The first issue is not OTIO specific and is actually a regression that was introduced 5 years ago with the progressive source loading optimizations (even when progressive source loading is not explicitly used.)

The issue is the following:
When adding multiple sources in one addSources() call, then no retiming gets automatically added for the sources that do not match the first source's frame rate. However, when you add the sources sequentially in two addSources() calls then all the sources are correctly retimed.

Example:

If you add those two sources then no retimer gets added to the second clip. 
Which means that RV will incorrectly playback the second source (too fast)
```
from rv import commands as rvc
rvc.addSources(["[", "clip_30.0fps", "]", "[", "clip_23.976fps", "]"])
```

However if you do this in two consecutive calls then RV adds the retimer and the playback is correct:
```
from rv import commands as rvc
rvc.addSources(["[", "clip_30.0fps", "]"])
rvc.addSources(["[", "clip_23.976fps", "]"])
```

You can achieve the correct behaviour in the first example by setting this env var
export RV_USE_FAST_ADD_SOURCE=0

This fix is in src/lib/ip/IPBaseNodes/SequenceGroupIPNode.cpp


**Issue#2:** 

The second issue is with the OTIO import of a track containing mixed frame rates clips.
The problem was in otio_reader.py::_calculate_edl() when computing the in, out, frame.
Without the fix, each frame is relative to its own timing associated with each clip's frame rate. 
RV assumes that all these frames are in the frame rate of the first clip which dictates the frame rate.

Note that with this fix, the test playlist containing mixed frame rates now imports correctly and matches perfectly the Web playback even though the web playback supports multiple frame rates)

### Summarize your change.

Issue#1: 
I modified the algorithm to figure out the sequence rate when the by looking at all the inputs of the sequence starting with the first one instead 
This issue was caused by an optimization that delayed the RvGraph::connectNewSourcesToDefaultViews() call until all the source of an addSources() are added. Thus preventing the sequence frame rate to be kwown when adding the sources.

### Describe what you have tested and on which operating system.

Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.