### PR TITLE
Fix rvio timecode option issue with FFmpeg 6

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -4245,6 +4245,7 @@ namespace TwkMovie
         {
             avStream->time_base.num = m_duration;
             avStream->time_base.den = m_timeScale;
+            avStream->avg_frame_rate = av_d2q(m_info.fps, INT_MAX);
             avCodecContext->time_base.num = m_duration;
             avCodecContext->time_base.den = m_timeScale;
             avCodecContext->codec_id = avCodec->id;
@@ -4253,6 +4254,7 @@ namespace TwkMovie
             avCodecContext->width = m_info.width;
             avCodecContext->height = m_info.height;
             avCodecContext->color_primaries = AVCOL_PRI_BT709; // 1
+            avCodecContext->framerate = avStream->avg_frame_rate;
             //
             //  XXX should come back to this.  should transfer function also be
             //  something else for mjpeg ?  Maybe need user control.


### PR DESCRIPTION
### 696: Fix rvio timecode option issue with FFmpeg 6

### Linked issues

Fixes #696

### Describe the reason for the change.

The the rvio's 'timecode' option was used, the following error is reported in the console and the timecode option is ignored:
`ERROR: Valid timecode frame rate must be specified. Minimum value is 1`

This is a regression that was introduced when updating RV to FFmpeg 6

### Summarize your change.

Now initializing the required avStream->avg_frame_rate and avCodecContext->framerate which is required in FFmpeg 6 to make the timecode rvio output option.

Note that this commit only impacts the mio_ffmpeg export function. 

### Describe what you have tested and on which operating system.

Successfully tested on macOS. The issue is not OS specific.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.