### PR TITLE
Fix rv.commands.clearSession() caching issue

### DIFF
--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -1790,6 +1790,7 @@ namespace IPCore
         checkInDisplayImage();
 
         m_inc = 1;
+        const auto mode = cachingMode();
         setCaching(NeverCache);
         graph().cache().lock();
         graph().cache().clearAllButFrame(currentFrame(), true);
@@ -1821,6 +1822,9 @@ namespace IPCore
                 graph().connectDisplayGroup(m_controlVideoDevice);
                 graph().setDevice(m_controlVideoDevice, m_outputVideoDevice);
             }
+
+            // Restore caching mode
+            setCaching(mode);
         }
     }
 


### PR DESCRIPTION
### Fix rv.commands.clearSession() caching issue

### Linked issues
NA

### Describe the reason for the change.

**Problem:**
In some situations, invoking the rv.commands.clearSession() would leave with the caching turned off for the remainder of the RV process lifetime which was impacting playback performances for the remainder of the RV process lifetime.
Note that the caching=off would not be persisted. So at the next RV relaunch, the caching would be enabled.

This problem can be reproduced when importing an OTIO into RV.

Before the OTIO import, caching is on:
<img width="490" alt="rv_cache_is_initially_on_good" src="https://github.com/user-attachments/assets/83e0089f-9cb0-4662-98e0-377f81809be0" />

After the OTIO import, the media caching would be effectively disabled:
<img width="490" alt="rv_cache_is_turned_off_after_otio_import" src="https://github.com/user-attachments/assets/f6f348bf-b003-4854-9726-441b4bbb62e7" />

### Summarize your change.

**Cause:**
This was caused by the rv.commands.clearSession() which momentarily turn off caching to empty its content.
But the original caching state is never restored until the user relaunches RV.

**Fix:**
Now restoring the original caching state in Session::clear().

### Describe what you have tested and on which operating system.
Successfully tested on macOS. This issue is not OS specific.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.