### PR TITLE
Feature/Qt6 - Fix dropperSampler not working correctly

### DIFF
--- a/src/lib/app/RvCommon/RvCommon/GLView.h
+++ b/src/lib/app/RvCommon/RvCommon/GLView.h
@@ -64,6 +64,8 @@ namespace Rv
 
         void* syncClosure() const { return m_syncThreadData; }
 
+        QImage readPixels(int x, int y, int w, int h);
+
     public slots:
         void eventProcessingTimeout();
 
@@ -72,6 +74,8 @@ namespace Rv
         void resizeGL(int w, int h);
         void paintGL();
         void swapBuffersNoSync();
+        bool validateReadPixels(int x, int y, int w, int h);
+        void debugSaveFramebuffer();
 
     private:
         RvDocument* m_doc;

--- a/src/lib/app/RvCommon/RvCommon/MuUICommands.h
+++ b/src/lib/app/RvCommon/RvCommon/MuUICommands.h
@@ -89,6 +89,7 @@ namespace Rv
     NODE_DECLARATION(launchTLI, void);
     NODE_DECLARATION(rvioSetup, void);
     NODE_DECLARATION(javascriptMuExport, void);
+    NODE_DECLARATION(framebufferPixelValue, Mu::Vector4f);
 
 } // namespace Rv
 

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -2969,6 +2969,7 @@ namespace IPCore
         // is this needed ? YES this is needed, otherwise fonts wont render
         // right with FTGL
         GLPushAttrib attr1(GL_ALL_ATTRIB_BITS);
+        TWK_GLDEBUG;
         GLPushClientAttrib attr2(GL_CLIENT_ALL_ATTRIB_BITS);
         TWK_GLDEBUG;
 

--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -672,8 +672,7 @@ class: AnnotateMinorMode : MinorMode
             sName  = sourceNameWithoutFrame(pinfo.name),
             ip     = state.pointerPosition;
 
-        float[] pixels;
-        glReadPixels(ip.x, ip.y, 1, 1, GL_RGBA, pixels);
+        let pixels = framebufferPixelValue(ip.x, ip.y);
         let c = Color(pixels[0], pixels[1], pixels[2], pixels[3]);
         _sampleColor += c;
         _sampleCount++;


### PR DESCRIPTION
### Summarize your change.

The dropperSampler tool in RV was not working correctly anymore in the qt6 branch. It had a strange offset (horizontally and vertically) because the OpenGL function glReadPixels was reading from the wrong context and the wrong framebuffer object.

in annotate_mode.mu, the method dropperSampler() called an OpenGL method (glReadPixels) while not in a rendering pass. This somehow worked in the old Qt5/GLWidget implementation, because the current OpenGL context and FBO always remained set to the main view widget.  But since switching to Qt6/QOpenGLWidget, this no longer holds true - the Qt6/QOpenGLWidget backend has a OpenGL compositor that works differently, and the OpenGL context/fbo of the main view was no longer current after the application was done refreshing.

Since we want to query the final rendered view using glReadPixels, we implemented a mu method called framebufferPixelValue(x, y) which internally eventually sets the OpenGL context/fbo to the correct one, calls glReadPixels(), and then restores the old one. 


### Describe the reason for the change.

See first paragraph of the "Summarize your change" section

### Describe what you have tested and on which operating system.

I have tested the dropperSampler tool, with different layouts and docked windows, but on Linux64 only. Please test in Darwin and Windows.

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a