### PR TITLE
Qt6: Set correct locale before Qt gets a chance to complain about it …

### DIFF
--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -220,6 +220,9 @@ static void setPlatformSpecificLocale()
     //    ..."no need to try language or region specific CTYPEs, as they
     //        all point back to the same generic UTF-8 CTYPE."
     //
+    // NOTE: Leaving this here for completeness for the curious minded,
+    // but the main.cpp file for macOS is actually src/bin/nsapps/RV/main.cpp
+
     locale = "UTF-8";
 #elif defined(PLATFORM_LINUX)
     // this is valid for Rocky Linux. As per the Qt code, some other Unixes may

--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -194,6 +194,51 @@ TwkApp::QTBundle bundle(EXECUTABLE_SHORT_NAME, MAJOR_VERSION, MINOR_VERSION,
 extern "C" int XInitThreads();
 #endif
 
+//
+// This function is an attempt to prevent QCoreApplication::initLocale() method
+// to complain that an invalid locale is currently set.
+//
+// Before this bugfix, RV's init code explicitely set the current locale to "C".
+// At the same time, this locale is now explicitely unsupported by Qt6, and
+// instead will instead switch to "C.UTF-8" under Linux, or "UTF-8" under Darwin
+// (macOS)
+//
+// For more information about how Qt initializes the locale, look at
+// initLocale() in the file:
+//
+// QT_HOME/Qt6.x.x/Src/qtbase/src/corelib/kernel/qcoreapplication.cpp
+//
+static void setPlatformSpecificLocale()
+{
+    std::string locale = "";
+
+#if defined(PLATFORM_DARWIN)
+    // In Darwin, "C.UTF-8" isn't directly supported, but we can use any
+    // "<region>.UTF-8" locale.  However, as per Qt's initLocale() method
+    // for in macOS, there is...
+    //
+    //    ..."no need to try language or region specific CTYPEs, as they
+    //        all point back to the same generic UTF-8 CTYPE."
+    //
+    locale = "UTF-8";
+#elif defined(PLATFORM_LINUX)
+    // this is valid for Rocky Linux. As per the Qt code, some other Unixes may
+    // also support "C.utf-8" as an alias to C.UTF-8", but for Rocky Linux there
+    // is no need.
+    locale = "C.UTF-8";
+#elif defined(WIN32)
+    // Under Windows, it seems Qt does not try to enfore switching to "C.UTF-8",
+    // (as this function only seems to be compiled for unix-variants).
+    // Therefore, we leave it as the "C" locale.
+    locale = "C";
+#endif
+
+    setEnvVar("LANG", locale);
+    setEnvVar("LC_ALL", locale);
+    // cout << "Set locale to " << locale.c_str() << endl; // for debugging at
+    // console
+}
+
 int utf8Main(int argc, char* argv[])
 {
 #ifdef PLATFORM_LINUX
@@ -287,8 +332,9 @@ int utf8Main(int argc, char* argv[])
     {
         setEnvVar("ORIGINALLOCAL", "en");
     }
-    setEnvVar("LANG", "C");
-    setEnvVar("LC_ALL", "C");
+
+    setPlatformSpecificLocale();
+
     QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
     TwkFB::ThreadPool::initialize();
 

--- a/src/bin/nsapps/RV/main.cpp
+++ b/src/bin/nsapps/RV/main.cpp
@@ -195,6 +195,20 @@ string scarfFile(const string& fileName)
     return buffer.str();
 }
 
+static void setPlatformSpecificLocale()
+{
+    // on MacOS, we now use "UTF-8" as a replacement for the "C" locale.
+    // In principle it should make no difference  to use "C" or "UTF-8", and
+    // on macOS, "UTF-8" is a catch-all, region-agnostic UTF-8 locale
+    // (ex: "UTF-8" is an alias to "en_US.UTF-8" "en_GB.UTF-8" "*.UTF-8", etc)
+
+    // setenv("LANG", "C", 1);    // Qt5
+    // setenv("LC_ALL", "C", 1);  // Qt5
+
+    setenv("LANG", "UTF-8", 1);
+    setenv("LC_ALL", "UTF-8", 1);
+}
+
 //
 //  We happen to know that Mu objects NEVER get stashed in 3rd party
 //  static areas so let's just remove all of them.
@@ -243,8 +257,8 @@ int main(int argc, char* argv[])
     {
         setenv("ORIGINALLOCAL", "en", 1);
     }
-    setenv("LANG", "C", 1);
-    setenv("LC_ALL", "C", 1);
+
+    setPlatformSpecificLocale();
 
     // Qt 5.12.1 specific
     // Disable Qt Quick hardware rendering because QwebEngineView conflicts with


### PR DESCRIPTION
### Summarize your change.

This fix is to prevent QCoreApplication::initLocale() method to complain that an invalid locale is currently set. Before this bugfix, RV's init code explicitly set the current locale to "C". At the same time, this locale is now explicitly unsupported by Qt6, and instead will instead switch to "C.UTF-8" under Linux, or "UTF-8" under Darwin (macOS)

For more information about how Qt initializes the locale, look at initLocale() in the file:

QT_HOME/Qt6.x.x/Src/qtbase/src/corelib/kernel/qcoreapplication.cpp

### Describe the reason for the change.

See above.

### Describe what you have tested and on which operating system.
Tested on Rocky 9.5, waiting on Cedrik to test on Darwin.

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a
