### PR TITLE
Feature/Qt6 - Export dialog will freeze at the end of an export

### DIFF
--- a/src/lib/app/mu_rvui/external_qprocess.mu
+++ b/src/lib/app/mu_rvui/external_qprocess.mu
@@ -41,7 +41,7 @@ class: ExternalQProcess : ExternalProcess
         }
     }
 
-    method: finish (void; int exitcode = -1)
+    method: finish (void; int exitcode = -1, qt.QProcess.ExitStatus exitStatus = -1)
     {
         if (_proc neq nil)
         {


### PR DESCRIPTION
### Summarize your change.

When exporting (or, for that matter, calling an external process) was finished, the "finish" callback faied and caused RV to crash. 

The fix was simply to add a missing parameter at the end of the signature of the callback method called by connect() when QProcess.finish is called, to match what is expected in Qt6 (and Qt5, actually)

This crash appeared whenever launching an external process, not just rvio. So other issues we found regarding a crash when launching an external process should also be fixed with this change.

### Describe the reason for the change.

Fixes crash at end of export process


### Describe what you have tested and on which operating system.
Tested on Linux64 Rocky 9.5.

It's not clear why this worked on the Qt5 branch and crashed on Qt6. Indeed, the "finish" signal always took 2 parameters, while the Mu signal only took one.

see below : similar signature of QProcess.finish()
https://doc.qt.io/qt-5/qprocess.html
https://doc.qt.io/qt-6/qprocess.html

**Please retest this with a Qt5 build of the qt6 branch.**

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a
