### PR TITLE
Feature/Qt6 - fix crash when clicking on rvio Export widget while it's exporting quicktime video  (#35176)

### DIFF
--- a/src/lib/app/mu_rvui/HUD.mu
+++ b/src/lib/app/mu_rvui/HUD.mu
@@ -487,6 +487,9 @@ class: ProcessInfo : Widget
         //
         setEventTableBBox(_modeName, "global", vec2f(0,0), vec2f(0,0));
 
+        // create memory space for the (X) button, which we update in render()
+        _buttons = Button[] {{0,0,0,0, nil}};
+
         _x = 40;
         _y = 60;
     }
@@ -585,7 +588,25 @@ class: ProcessInfo : Widget
             rad = th / 2,
             d   = mag(_downPoint - vec2f(pcx + 4 + rad, pcy + rad));
 
-        _buttons = Button[] {{pcx + 4, pcy, rad * 2, rad * 2, killProcess(p,)}};
+
+        // Bugfix: don't recreate the _buttons array, by doNothing
+        // _buttons = Button[] {....};. Instead just update the
+        // content of the boundaries of the button. Otherwise, 
+        // if we recreated the _buttons member, this would dispose
+        // and recreate the array anbd it would be a problem because 
+        // this recreates the memory for the Buttons array and disposes 
+        // of the old memory, and when we handle mouse events (eg: 
+        // click/release or drag/release) in another thread, we 
+        // will likely read old/just-disposed memory. So, we must not 
+        // touch memory space of the Buttons array, we just update its 
+        // x/y/w/h/pid content, member-by-member, which still is not 
+        // 100% ideal, but safe and harmless enough, and we won't crash.
+        _buttons[0]._x = pcx + 4;
+        _buttons[0]._y = pcy;
+        _buttons[0]._w = rad * 2;
+        _buttons[0]._h = rad * 2;
+        _buttons[0]._callback = killProcess(p,);
+
         gltext.writeAt(pcx + 3.0 * rad, pcy, "%-3.1f%%" % pcent);
 
         drawCloseButton(pcx + rad + 4, pcy + rad, rad, 


### PR DESCRIPTION
### Describe the reason for the change.

When we clicked or dragged the widget during a quicktime export (or any instance of the ProcessInfo widget for that matter), we (almost) inevitably always crashed. Happened in Qt5 and Qt6 branch, and as far back as RV 2023, apparently. 

### Summarize your change.

When we clicked on the ProcessInfo widget, the code tries to access the _buttons[] array to see if we are clicking in the (X) button, but simply reading this array crashed RV. 

It turns out that for the ProcessInfo widget, the render() method recreated the _buttons[] array, which contained the coordinates and process info for the (X) cancel button. This was in a different thread than the event-handling thread. So, while the render method was executing and the _buttons[] array was being recreated, the event-handling thread was trying to read the same array to see if w were clicking in the (X) button. Since the memory had been disposed and replaced in the meantime, this caused a crash .

The fix was simply to initialize the array when the ProcessInfo widget is created, and in the render() method we update the x/y/w/h/pid. This does not cause a change in memory space, and the crash no  longer happens. Ideally, we'd need a mutex to sync the read/write tof the x/y/w/h/pid values, but, we're really just reading/writing coordinates here, and the pid always remains constant, so even if there was concurrent read/write access it should be completely harmless.  

Either way, the crash no longer occurs.


### Describe what you have tested and on which operating system
.
This was 100% reproducible on Linux, and I think also macOS, the problem was no platform-specific but Mu-specifc.


### Add a list of changes, and note any that might need special attention during the review.

There is only 1 file to review, so, no big deal.

### If possible, provide screenshots.
n/a