### PR TITLE
Handle hide annotations

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -18,7 +18,7 @@ def hook_function(
     """A hook for the annotation schema"""
     for layer in in_timeline.layers:
         if layer.name == "Paint":
-            if isinstance(layer.layer_range, otio._opentime.TimeRange):
+            if isinstance(layer.layer_range, otio.opentime.TimeRange):
                 time_range = layer.layer_range
             else:
                 time_range = otio.opentime.TimeRange(
@@ -37,7 +37,7 @@ def hook_function(
 
             # Set properties on the paint component of the RVPaint node
             effectHook.set_rv_effect_props(
-                paint_component, {"nextId": stroke_id + 1, "show": True}
+                paint_component, {"nextId": stroke_id + 1, "show": layer.visible}
             )
 
             # Add and set properties on the pen component of the RVPaint node

--- a/src/plugins/rv-packages/otio_reader/effectHook.py
+++ b/src/plugins/rv-packages/otio_reader/effectHook.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2025  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import sys
 from rv import commands
@@ -43,7 +43,7 @@ def set_rv_effect_props(node_component, prop_map):
             map of prop names of node_component to their value
     """
     for prop, value in prop_map.items():
-        if value:
+        if value is not None:
             _set_rv_prop("{}.{}".format(node_component, prop), _get_rv_value(value))
 
 
@@ -59,7 +59,7 @@ def add_rv_effect_props(node_component, prop_map):
             map of prop names of node_component to their value
     """
     for prop, value in prop_map.items():
-        if value:
+        if value is not None:
             prop_name = "{}.{}".format(node_component, prop)
             rv_value = _get_rv_value(value)
 

--- a/src/plugins/rv-packages/otio_reader/paint_schema.py
+++ b/src/plugins/rv-packages/otio_reader/paint_schema.py
@@ -18,7 +18,7 @@ is ready to be used.
 ```python
 Example:
 myObject = otio.schemadef.Paint.Paint(
-    name, points, rgba, type, brush, layer_range, hold, ghost
+    name, points, rgba, type, brush, layer_range, hold, ghost, ghost_before, ghost_after, visible
 )
 """
 
@@ -39,9 +39,12 @@ class Paint(otio.core.SerializableObject):
         rgba: list | None = None,
         type: str = "",
         brush: str = "",
-        layer_range: dict | None = None,
+        layer_range: otio.opentime.TimeRange | None = None,
         hold: bool = False,
         ghost: bool = False,
+        ghost_before: int = 0,
+        ghost_after: int = 0,
+        visible: bool = True,
     ) -> None:
         super().__init__()
         self.name = name
@@ -52,6 +55,9 @@ class Paint(otio.core.SerializableObject):
         self.layer_range = layer_range
         self.hold = hold
         self.ghost = ghost
+        self.ghost_before = ghost_before
+        self.ghost_after = ghost_after
+        self.visible = visible
 
     name = otio.core.serializable_field(
         "name", required_type=str, doc=("name: expects a string")
@@ -103,18 +109,31 @@ class Paint(otio.core.SerializableObject):
     def layer_range(self, val):
         self._layer_range = val
 
-    _hold = otio.core.serializable_field(
+    hold = otio.core.serializable_field(
         "hold", required_type=bool, doc=("hold: expects either true or false")
     )
 
-    _ghost = otio.core.serializable_field(
+    ghost = otio.core.serializable_field(
         "ghost", required_type=bool, doc=("ghost: expects either true or false")
+    )
+
+    _ghost_before = otio.core.serializable_field(
+        "ghost_before", required_type=int, doc=("ghost_before: expects an integer")
+    )
+
+    _ghost_after = otio.core.serializable_field(
+        "ghost_after", required_type=int, doc=("ghost_after: expects an integer")
+    )
+
+    visible = otio.core.serializable_field(
+        "visible", required_type=bool, doc=("visible: expects either true or false")
     )
 
     def __str__(self) -> str:
         return (
             f"Paint({self.name}, {self.points}, {self.rgba}, {self.type}, "
-            f"{self.brush}, {self.layer_range}, {self.hold}, {self.ghost})"
+            f"{self.brush}, {self.layer_range}, {self.hold}, {self.ghost}, "
+            f"{self.ghost_before}, {self.ghost_after}, {self.visible})"
         )
 
     def __repr__(self) -> str:
@@ -122,5 +141,6 @@ class Paint(otio.core.SerializableObject):
             f"otio.schema.Paint(name={self.name!r}, points={self.points!r}, "
             f"rgba={self.rgba!r}, type={self.type!r}, brush={self.brush!r}, "
             f"layer_range={self.layer_range!r}, hold={self.hold!r}, "
-            f"ghost={self.ghost!r})"
+            f"ghost={self.ghost!r}, ghost_before={self.ghost_before!r}, "
+            f"ghost_after={self.ghost_after!r}, visible={self.visible!r})"
         )


### PR DESCRIPTION
### Handle hide annotation

### Summarize your change.

The paint schema was updated to reflect the latest changes done to the Live Review spec, and the annotation hook is now using the `visible` attribute to set the visibility of the annotations based on the OTIO timeline received by the ReviewApp.

### Describe the reason for the change.

During a Live Review session, a presenter can click on a `hide annotations` button to hide all the annotations on all the frames. The PR allows RV to correctly display the annotations as a Live Review participant based on the presenter's choice.

### Describe what you have tested and on which operating system.

The changes were successfully tested on MacOS.