### PR TITLE
Feature/Qt6 - Fix error popup occurs when opening presentation device (eg: NDI)

### DIFF
--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -407,11 +407,12 @@ namespace Rv
             //          The issue I see on MacOS that the background is brown
             //          istead of black with the default background.
             //
-            // NOTE PB: Not sure wy we just can't do the following 5 lines of 
-            // gl code below for all cases, for the "else" statement as well. 
-            // Are the glPush/glPopAttrib, and the glClear of also the depth 
-            // buffer that bad on modern hardware? It would simplify this 
-            // already-complicated function.
+            // Even on Qt6/QOpenGLWidget, we need to call 
+            // glBindFramebuffer(); it otherwise complains and fails 
+            // on glClear() on macOS
+            glBindFramebuffer(
+                GL_FRAMEBUFFER, 
+                QOpenGLContext::currentContext()->defaultFramebufferObject());
 
             glPushAttrib(GL_COLOR_BUFFER_BIT);
             TWK_GLDEBUG;

--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -335,7 +335,7 @@ namespace Rv
     {
         IPCore::Session* session = m_doc->session();
         bool debug = IPCore::debugProfile && session;
-        
+
         if (!m_postFirstNonEmptyRender && session
             && session->postFirstNonEmptyRender())
         {
@@ -362,7 +362,7 @@ namespace Rv
     //  and holding them in the display even when rv redraws.  the
     //  effect being that parts of previous displays will be "left
     //  behind" and not updated even when rv plays.  especially when
-    //  going to/from fullscreen. 
+    //  going to/from fullscreen.
     //
 #ifdef PLATFORM_WINDOWS
     SetWindowRgn (this->winId(), 0, false);
@@ -411,7 +411,7 @@ namespace Rv
             // glBindFramebuffer(); it otherwise complains and fails 
             // on glClear() on macOS
             glBindFramebuffer(
-                GL_FRAMEBUFFER, 
+                GL_FRAMEBUFFER,
                 QOpenGLContext::currentContext()->defaultFramebufferObject());
 
             glPushAttrib(GL_COLOR_BUFFER_BIT);

--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -372,7 +372,7 @@ namespace Rv
         if (m_doc && session && m_videoDevice)
         {
             // m_frameBuffer->makeCurrent();
-            m_videoDevice->makeCurrent(); // this just calls void GLtext::setContext(Context c) {}... which calls pthread_get/setspecific(ctx)
+            m_videoDevice->makeCurrent();
 
             if (m_userActive && m_activityTimer.elapsed() > 1.0)
             {

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -1595,7 +1595,7 @@ namespace Rv
         Rv::Session* session = static_cast<Rv::Session*>(doc);
         RvDocument* rvDoc = (RvDocument*)session->opaquePointer();
 
-            if (m_presentationMode)
+        if (m_presentationMode)
         {
             if (VideoDevice* d = findPresentationDevice(opts.presentDevice))
             {

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -1629,7 +1629,7 @@ namespace Rv
                                        QApplication::screenAt(
                                            rvDoc->mapToGlobal(QPoint(0, 0)))))
                         {
-                            TWK_THROW_EXC_STREAM( 
+                            TWK_THROW_EXC_STREAM(
                                 "Cannot open presentation device for the same "
                                 "screen the controller is on");
                         }

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -1595,7 +1595,7 @@ namespace Rv
         Rv::Session* session = static_cast<Rv::Session*>(doc);
         RvDocument* rvDoc = (RvDocument*)session->opaquePointer();
 
-        if (m_presentationMode)
+            if (m_presentationMode)
         {
             if (VideoDevice* d = findPresentationDevice(opts.presentDevice))
             {
@@ -1628,7 +1628,6 @@ namespace Rv
                                    == QApplication::screens().indexOf(
                                        QApplication::screenAt(
                                            rvDoc->mapToGlobal(QPoint(0, 0)))))
-                            ;
                         {
                             TWK_THROW_EXC_STREAM(
                                 "Cannot open presentation device for the same "

--- a/src/lib/app/RvCommon/RvCommon/GLView.h
+++ b/src/lib/app/RvCommon/RvCommon/GLView.h
@@ -71,7 +71,6 @@ namespace Rv
         void initializeGL();
         void resizeGL(int w, int h);
         void paintGL();
-        void swapBuffersNoSync();
 
     private:
         RvDocument* m_doc;

--- a/src/lib/app/mu_rvui/HUD.mu
+++ b/src/lib/app/mu_rvui/HUD.mu
@@ -487,6 +487,9 @@ class: ProcessInfo : Widget
         //
         setEventTableBBox(_modeName, "global", vec2f(0,0), vec2f(0,0));
 
+        // create memory space for the (X) button, which we update in render()
+        _buttons = Button[] {{0,0,0,0, nil}};
+
         _x = 40;
         _y = 60;
     }
@@ -585,7 +588,25 @@ class: ProcessInfo : Widget
             rad = th / 2,
             d   = mag(_downPoint - vec2f(pcx + 4 + rad, pcy + rad));
 
-        _buttons = Button[] {{pcx + 4, pcy, rad * 2, rad * 2, killProcess(p,)}};
+
+        // Bugfix: don't recreate the _buttons array, by doNothing
+        // _buttons = Button[] {....};. Instead just update the
+        // content of the boundaries of the button. Otherwise, 
+        // if we recreated the _buttons member, this would dispose
+        // and recreate the array anbd it would be a problem because 
+        // this recreates the memory for the Buttons array and disposes 
+        // of the old memory, and when we handle mouse events (eg: 
+        // click/release or drag/release) in another thread, we 
+        // will likely read old/just-disposed memory. So, we must not 
+        // touch memory space of the Buttons array, we just update its 
+        // x/y/w/h/pid content, member-by-member, which still is not 
+        // 100% ideal, but safe and harmless enough, and we won't crash.
+        _buttons[0]._x = pcx + 4;
+        _buttons[0]._y = pcy;
+        _buttons[0]._w = rad * 2;
+        _buttons[0]._h = rad * 2;
+        _buttons[0]._callback = killProcess(p,);
+
         gltext.writeAt(pcx + 3.0 * rad, pcy, "%-3.1f%%" % pcent);
 
         drawCloseButton(pcx + rad + 4, pcy + rad, rad, 


### PR DESCRIPTION
Fixes #38133

### Describe the reason for the change.

Could not open presentation device after setting Presenation device to NDIDevice, and then doing CTRL-P to enable it.  The error message was due to a ";" at the end of an if-statement, but then it caused opengl errors down the line due to the gl context being invalid after calling swapBuffers.

Turns out all the swapBuffer management is no longer needed with QOpenGLWidget, explanation in the summary below.

### Summarize your change.

Note for Qt6 . QOpenGLWidget implementation:

With the new QOpenGLWidget (Qt6 branch), all of the rendering of each widget is done in its own FBOs (aka: off-screen buffers), as opposed to the old Qt5/QGLWidget branch where the rendering was done in each GGLWidget's backbuffer (aka: GL_BACK, an on-screen framebuffer surface).

With QOpenGLWidget, it is now the WainWindow's responsibility (more technically, the MainWindow's rendering backend, which happens to be Qt's OpenGL rendering backend when QOpenGLWidget are present in the children tree) to gather and composite all of the  off-screen buffers (regardless of which image type they are, eg: cpu-memory images, gpu/opengl images, etc) and finally to call swapBuffers to show the final contents of the mainWindow. 

As a result, I'm not sure there's a point -- at all -- in calling swapBuffers on the GLView anywhere amnymore. From old comments in the previous version of this tile, it appears that calling swapBuffers was done to force a quicker visual update, or to minimize visual tearing of some sort. This would have worked with the old QGLWidget (becayuse each QGLWidget had its own context, and its rendering target was directly the GL_BACK 
framebuffer, but, again, with QOpenGLWidget, the rendering target is no longer GL_BACK, it is an FBO that is meant to be used at the end of the application's drawing / visual update pipeline.

I am not sure how this would affect (if at all?) the display of the rendered buffer on external video devices. This needs to be tested extensively.



### Describe what you have tested and on which operating system.

I have tested on Linux64 and have seen no adverse effects.

**Note for QA**: Please test this extensively on all 3 platforms, and with all VideoDevices (NDI, SDI, AJA, BlackMagic), to make sure this causes no problem.


### Add a list of changes, and note any that might need special attention during the review.


### If possible, provide screenshots.
n/a