### PR TITLE
Fix MMR support in OTIO reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,7 +469,7 @@ jobs:
           python -c "import sys; print(sys.executable)"
 
       - name: Cache CMake for Windows
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         id: windows-cmake-cache
         with:
           path: "C:/Program Files/CMake"
@@ -478,7 +478,7 @@ jobs:
       - name: Install CMake ${{ matrix.cmake-version }} with chocolatey
         if: steps.windows-cmake-cache.outputs.cache-hit != 'true'
         run: |
-          choco install cmake --version=${{ matrix.cmake-version }}
+          choco install cmake --version=${{ matrix.cmake-version }} --allow-downgrade
           
       - name: Set PATH environment variable
         run: |

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -358,7 +358,9 @@ def _set_sequence_edl(sequence, edl_time, edl):
     # edl.in/out are terminated by 0. edl.frame is terminated by last frame + 1.
     edl["in"].append(0)
     edl["out"].append(0)
-    edl["frame"].append(edl_time.to_frames() + 1)
+    # Note that the edl_time is already exclusive so we don't need to add 1 here
+    # For reference: _create_track() - edl_time = edl_range.end_time_exclusive()
+    edl["frame"].append(edl_time.to_frames())
 
     # This effectively forces each cut to use the otio trimmed_range, regardless
     # of effects or other modifications to a sources timing.
@@ -454,6 +456,15 @@ def _create_media(media_ref, trimmed_range, context=None):
 
 
 def _create_sources(item, context=None):
+    def rename_media_rep(media_rep_name):
+        media_rep_name_replacement = {
+            "mp4": "Streaming",
+            "original_media": "Original",
+            "path_to_movie": "Movie",
+            "path_to_frames": "Frames",
+        }
+        return media_rep_name_replacement.get(media_rep_name, media_rep_name)
+
     def add_media(media_ref, active_key, cmd, *cmd_args):
         media = _create_media(media_ref, item.trimmed_range(), context)
 
@@ -493,7 +504,9 @@ def _create_sources(item, context=None):
     )
     if hasattr(item, "media_reference") and item.media_reference:
         active_source = add_media(
-            item.media_reference, active_key, commands.addSourceVerbose
+            item.media_reference,
+            rename_media_rep(active_key),
+            commands.addSourceVerbose,
         )
 
     source_group = commands.nodeGroup(active_source)
@@ -501,7 +514,11 @@ def _create_sources(item, context=None):
         for key, media_ref in item.media_references().items():
             if key != active_key:
                 add_media(
-                    media_ref, None, commands.addSourceMediaRep, active_source, key
+                    media_ref,
+                    None,
+                    commands.addSourceMediaRep,
+                    active_source,
+                    rename_media_rep(key),
                 )
 
         switch_group = commands.nodeConnections(source_group)[1][0]
@@ -516,7 +533,7 @@ def _create_sources(item, context=None):
 def _get_media_path(target_url: str, context: dict | None = None) -> str:
     context = context or {}
 
-    if "sg_url" in context:
+    if "sg_url" in context and target_url.startswith("/file_serve/version"):
         return context.get("sg_url") + target_url
 
     if not os.path.isabs(target_url):


### PR DESCRIPTION
### Fix multiple media representation support (MMR) in OTIO reader

### Linked issues
NA

### Describe the reason for the change.

There were a couple issues associated with multiple media representation support in OTIO reader:
- Local file path could not be used because the server URL was always preprended.
- When creating a video track, its duration was 1 frame too long
- New OTIO based media representation names were inconsistent with the previously named MMR in RV such as 'mp4', 'path_to_movie', and 'path_to_frames'

### Summarize your change.

- Now only prepending the server URL when the target url starts with /file_serve/version
- Fixed the duration in  _set_sequence_edl()
- Renamed known media representation names to standard media rep names used by RV such as Streaming, Movie, and Frames.

### Describe what you have tested and on which operating system.
Successfully tested on macOS. The fix is not OS specific

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.