### PR TITLE
Feature/Qt6 - Fix hdpi issue that magically fixes itself when resizing the main window

### DIFF
--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -187,6 +187,26 @@ namespace Rv
         m_glView->setFocus(Qt::OtherFocusReason);
         // qApp->installEventFilter(m_glView);
 
+        // #ifdef PLATFORM_DARWIN
+        //  Under macOS, for Qt6/QOpenGLWidget port,
+        //  the initial display shows incorrect pixel
+        //  scaling due to some sort of effect related
+        //  to high-dpi on mac, until the main view is
+        //  resized by the user. This is a workaround
+        //  on macOS to force this resize;
+        //  Also enabling this on other platforms which
+        //  may have HDPI display with pixel doubling
+        //  enabled.
+        QTimer::singleShot(0, this,
+                           [this]()
+                           {
+                               QSize currentSize = size();
+                               resize(currentSize.width() + 1,
+                                      currentSize.height());
+                               resize(currentSize);
+                           });
+        // #endif
+
         m_resetPolicyTimer = new QTimer(this);
         m_resetPolicyTimer->setSingleShot(true);
         connect(m_resetPolicyTimer, SIGNAL(timeout()), this,


### PR DESCRIPTION

### Summarize your change.

Added a singleshot timer to force a resize event to the main window, in order to fix an image scale issue when first starting RV.

### Describe the reason for the change.

On macOS (and, presumably, any platform that supports HDPI) the initial display of the main view's image will not be scaled properly. After much investigation, this appears to be a Qt bug but were being unable to truly identify the root cause (coordinates are ok, pixel scale is ok, pixel ratio is ok, gl surface is ok, gl viewport is ok, etc etc. 

Oddly enough, the issue disappeared when resizing the view, even 1 pixel, but this has to be done after the view is first shown.

As a result, we dimply decided to force two resize events to occur (+1 pixel, and then -1 pixel). This has no visible effect on startup (or, you'd really need eagle eyes) to go: "A-HA!"

### Describe what you have tested and on which operating system.

This was reported on macOS, so I tested it on macOS, but it's possible it may occur on other platofrms as well. Unfortunately I did not have HDPI displays where the OS does pixel-doubling by itself like on macOS.

### Add a list of changes, and note any that might need special attention during the review.

This is a simple change in RvDocument, where  we initially set up the main view.

### If possible, provide screenshots.

No need, simply confirm that RV now starts correctly on macOS
