### PR TITLE
Feature/qt6 - Remove usage of Core5Compat library

### DIFF
--- a/src/bin/apps/rv/CMakeLists.txt
+++ b/src/bin/apps/rv/CMakeLists.txt
@@ -20,16 +20,9 @@ SET(CMAKE_AUTORCC
     ON
 )
 
-IF(RV_VFX_PLATFORM STREQUAL CY2024)
-# TODO_QT: Core5Compat is temporary to fix issue with QTextCodec and other things = faster build to test.
-#          https://doc.qt.io/qt-6.5/qtcore5compat-module.html
-SET(_main_qt_components Core5Compat)
-SET(_main_link_libraries Qt6::Core5Compat)
-ENDIF()
-
 FIND_PACKAGE(
   ${RV_QT_PACKAGE_NAME}
-  COMPONENTS Core Gui Widgets OpenGL ${_main_qt_components}
+  COMPONENTS Core Gui Widgets OpenGL
   REQUIRED
 )
 
@@ -112,7 +105,6 @@ TARGET_LINK_LIBRARIES(
           TwkGLF
           arg
           stl_ext
-          ${_main_link_libraries}
 )
 
 IF(RV_TARGET_WINDOWS)

--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -94,7 +94,9 @@
 #include <IPCore/ImageRenderer.h>
 #endif
 
+#if defined(RV_VFX_CY2023)
 #include <QTextCodec>
+#endif
 #include <QtWidgets/QtWidgets>
 #include <QtGui/QtGui>
 #include <RvCommon/RvDocument.h>
@@ -338,7 +340,10 @@ int utf8Main(int argc, char* argv[])
 
     setPlatformSpecificLocale();
 
-    QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
+    // Refresh the locale using the environment variable set by
+    // setPlatformSpecificLocale.
+    QLocale::setDefault(QLocale::system());
+
     TwkFB::ThreadPool::initialize();
 
     // Qt 5.12.1 specific

--- a/src/lib/app/RvCommon/CMakeLists.txt
+++ b/src/lib/app/RvCommon/CMakeLists.txt
@@ -21,21 +21,11 @@ SET(CMAKE_AUTORCC
     ON
 )
 
-IF(RV_VFX_PLATFORM STREQUAL CY2024)
-  # TODO_QT: Core5Compat is temporary to fix issue with QTextCodec. https://doc.qt.io/qt-6.5/qtcore5compat-module.html
-  SET(_rvcommon_core5compat_component
-      Core5Compat
-  )
-  SET(_rvcommon_core5compat_link_libraries
-      Qt6::Core5Compat
-  )
-ENDIF()
-
 #
 # This find_package statement is also required to find QT's build tools like 'uic' required just below. Keep this line before 'qt5_wrap_ui'
 FIND_PACKAGE(
   ${RV_QT_PACKAGE_NAME}
-  COMPONENTS Core Gui OpenGL Widgets ${QT6_QOPENGLWIDGET_COMPONENT} ${_rvcommon_core5compat_component}
+  COMPONENTS Core Gui OpenGL Widgets ${QT6_QOPENGLWIDGET_COMPONENT}
   REQUIRED
 )
 
@@ -236,7 +226,6 @@ TARGET_LINK_LIBRARIES(
          Qt::Widgets
          Qt::OpenGL
          ${QT6_QOPENGLWIDGET_TARGET}
-         ${_rvcommon_core5compat_link_libraries}
   PRIVATE Python::Python
           IPBaseNodes
           ${RV_QT_MU_TARGET}

--- a/src/lib/app/RvCommon/RvWebManager.cpp
+++ b/src/lib/app/RvCommon/RvWebManager.cpp
@@ -9,7 +9,11 @@
 #include <IPCore/Session.h>
 #include <QtCore/QUrl>
 #include <QtCore/QDir>
+
+#if defined(RV_VFX_CY2023)
 #include <QTextCodec>
+#endif
+
 #include <QtCore/QStandardPaths>
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
@@ -156,7 +160,7 @@ namespace Rv
         reply->setReadBufferSize(0); // unlimited
 
         connect(reply, SIGNAL(readyRead()), this, SLOT(replyRead()));
-        connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this,
+        connect(reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this,
                 SLOT(replyError(QNetworkReply::NetworkError)));
         connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this,
                 SLOT(replySSLErrors(QList<QSslError>)));
@@ -226,7 +230,7 @@ namespace Rv
         reply->setReadBufferSize(0); // unlimited
 
         connect(reply, SIGNAL(readyRead()), this, SLOT(replyRead()));
-        connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this,
+        connect(reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this,
                 SLOT(replyError(QNetworkReply::NetworkError)));
         connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this,
                 SLOT(replySSLErrors(QList<QSslError>)));
@@ -300,7 +304,7 @@ namespace Rv
         reply->setReadBufferSize(0); // unlimited
 
         connect(reply, SIGNAL(readyRead()), this, SLOT(replyRead()));
-        connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this,
+        connect(reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this,
                 SLOT(replyError(QNetworkReply::NetworkError)));
         connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this,
                 SLOT(replySSLErrors(QList<QSslError>)));
@@ -366,8 +370,16 @@ namespace Rv
                 //  Text, convert to UTF-8 for Mu
                 //
 
+#if defined(RV_VFX_CY2023)
                 QTextCodec* codec = QTextCodec::codecForHtml(array);
                 QString u = codec->toUnicode(array);
+#else
+                // Assume that the data is utf-8 encoded because about 98-99% of
+                // websites uses utf-8. The second closest is ISO-8859-1
+                // with 1.1%.
+                QStringDecoder decoder(QStringDecoder::Utf8);
+                QString u = decoder.decode(array);
+#endif
                 QByteArray utf8 = u.toUtf8();
                 if (!replyErrorString.isEmpty())
                     utf8 = replyErrorString.toUtf8();

--- a/src/lib/mu/MuQt5/RvNetworkAccessManager.cpp
+++ b/src/lib/mu/MuQt5/RvNetworkAccessManager.cpp
@@ -117,7 +117,7 @@ QNetworkReply* RvNetworkAccessManager::createRequest(
     //
     if (printErrors)
     {
-        connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this,
+        connect(reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this,
                 SLOT(errorReplySlot(QNetworkReply::NetworkError)));
         connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this,
                 SLOT(sslErrorsReplySlot(QList<QSslError>)));

--- a/src/lib/mu/MuQt6/RvNetworkAccessManager.cpp
+++ b/src/lib/mu/MuQt6/RvNetworkAccessManager.cpp
@@ -117,7 +117,7 @@ QNetworkReply* RvNetworkAccessManager::createRequest(
     //
     if (printErrors)
     {
-        connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this,
+        connect(reply, SIGNAL(errorOccurred(QNetworkReply::NetworkError)), this,
                 SLOT(errorReplySlot(QNetworkReply::NetworkError)));
         connect(reply, SIGNAL(sslErrors(QList<QSslError>)), this,
                 SLOT(sslErrorsReplySlot(QList<QSslError>)));


### PR DESCRIPTION
### Feature/qt6 - Remove usage of Core5Compat library

### Linked issues
n/a

### Summarize your change.

I have eliminated all instances of QTextCodec, as this class is no longer supported in Qt 6. Previously, the code relied on the Core5Compat library, which incorporates deprecated and obsolete Qt 5 classes.

### Describe what you have tested and on which operating system.

I created a python plugin to execute the httpGet method from the RvWebManager class.