### PR TITLE
712: Adapt build to latest MSYS2 release

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -32,7 +32,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   RV_TOOLCHAIN=""
 
 # Windows
-elif [[ "$OSTYPE" == "msys"* ]]; then
+elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Visual Studio 17 2022}"
   WIN_PERL="${WIN_PERL:-c:/Strawberry/perl/bin}"
   CMAKE_WIN_ARCH="${CMAKE_WIN_ARCH:--A x64}"
@@ -40,7 +40,7 @@ elif [[ "$OSTYPE" == "msys"* ]]; then
   RV_TOOLCHAIN="-T v143,version=14.40"
 
 else
-  echo "OS does not seem to be linux, darwin or msys. Exiting."
+  echo "OS does not seem to be linux, darwin or msys/cygwin. Exiting."
   exit 1
 fi
 
@@ -58,7 +58,7 @@ if [ -z "$QT_HOME" ]; then
       QT_HOME=$(find ~/Qt/5.15* -type d -maxdepth 4 -path '*/clang_64' | sort -V | tail -n 1)
     fi
 
-  elif [[ "$OSTYPE" == "msys"* ]]; then
+  elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then
     QT_HOME=$(find c:/Qt/5.15* -type d -maxdepth 4 -path '*/msvc2019_64' | sort -V | tail -n 1)
   fi
 
@@ -78,8 +78,8 @@ fi
 rvenv_shell() {
   local activate_path=".venv/bin/activate"
 
-  # Using msys2 as a way to detect if the script is running on Windows.
-  if [[ "$OSTYPE" == "msys"* ]]; then
+  # Using msys2/cygwin as a way to detect if the script is running on Windows.
+  if [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then
     activate_path=".venv/Scripts/activate"
   fi
 
@@ -135,7 +135,7 @@ echo "RV_BUILD is $RV_BUILD"
 echo "RV_INST is $RV_INST"
 echo "CMAKE_GENERATOR is $CMAKE_GENERATOR"
 echo "QT_HOME is $QT_HOME"
-if [[ "$OSTYPE" == "msys"* ]]; then echo "WIN_PERL is $WIN_PERL"; fi
+if [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then echo "WIN_PERL is $WIN_PERL"; fi
 
 echo "To override any of them do unset [name]; export [name]=value; source $SCRIPT"
 echo


### PR DESCRIPTION
### 712: Adapt build to latest MSYS2 release

### Linked issues
Fixes #712 

### Describe the reason for the change.

Thanks to Open RV community member [herronelou](https://github.com/herronelou) who reported this issue (#712).
herronelou found out that the latest MSYS2 install:

<<
In recent versions of MSYS2, $OSTYPE is now reporting cygwin, not msys, causing an issue at https://github.com/AcademySoftwareFoundation/OpenRV/blob/main/rvcmds.sh#L35

See their announcement: https://www.msys2.org/news/
>> 

Thank you [herronelou](https://github.com/herronelou)!

### Summarize your change.

In this commit, the rvcmds.sh script was adapted to support both the older MSYS2 (reporting $OSTYPE as msys), and the newer MSYS2 (reporting $OSTYPE as cygwin).

### Describe what you have tested and on which operating system.
Successfully tested on Windows using both an older MSYS2 install and the latest MSYS2 install (msys2-x86_64-20250221.exe) containing the MSYS2 change.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.