### PR TITLE
Feature/Qt6 - Fix various qt console warnings

### DIFF
--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -99,7 +99,7 @@ namespace
 
     bool isSilencedQtMessage(const string_view& text)
     {
-        array<string_view, 5> silenced = {
+        const array<string_view, 5> silenced = {
             // In Qt6, when KVM or YubiKey or other HID device is plugged in or
             // out. This warning seems fixed with QT 6.6.3
             "scroll event from unregistered device"sv,
@@ -160,7 +160,7 @@ namespace
             return;
         RecursionLock l;
 
-        string msg = qmsg.toUtf8().constData();
+        const string msg = qmsg.toUtf8().constData();
 
         // We always report Qt debug messages except for known issues.
         // In which case the following function can be used to check

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -97,9 +97,9 @@ namespace
     using namespace boost;
     using namespace std;
 
-    bool isSilencedQtMessage(const string_view& text)
+    bool isSilencedQtMessage(std::string_view text)
     {
-        const array<string_view, 5> silenced = {
+        constexpr array silenced = {
             // In Qt6, when KVM or YubiKey or other HID device is plugged in or
             // out. This warning seems fixed with QT 6.6.3
             "scroll event from unregistered device"sv,

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -118,12 +118,12 @@ namespace Rv
     {
         const string silenced[] = {
             // In Qt6, when KVM or YubiKey or other HID device is plugged in or
-            // out. This error seems fixed with QT 6.6.3
+            // out. This warning seems fixed with QT 6.6.3
             string("scroll event from unregistered device"),
 
             // Another relic of an unneeded warning resulting from the Qt6 port.
-            // This one originates from initializing PyQt, when calling
-            // PyInit_QtConcurrent(), which calls
+            // This one originates when loading Python which calls
+            // PyInit_QtConcurrent(), which then calls
             // qRegisterMetaType<QFuture<QString>>(char const*){}
             // This is just a warning that the registration is already done, so
             // we can safely ignore it.
@@ -177,9 +177,8 @@ namespace Rv
         string msg = qmsg.toUtf8().constData();
 
         // We always report Qt debug messages except for known issues.
-        // In which case the following environment variable can be used to
-        // check whether those known messages are still reported or not by
-        // Qt.
+        // In which case the following function can be used to check
+        // whether those known messages are still reported or not by Qt.
         if (isSilencedQtMessage(msg))
             return;
 


### PR DESCRIPTION
This fixes SG-36654 SG-36655 SG-36656 

### Summarize your change.

Added a method to filter out some Qt messages that are known/harmless warnings.

One such warning had Qt reporting a warning about a scroll event occuring from a HID device whenever it was connected/disconnected/kvm'd.   This appears to be fixed with Qt 6.6.3 but we are at 6.5.3, so we shut it up.

Another such warning was about a Qt handler for a type conversion already registered (but when initializing PyQt it was tried to be initialized again), etc.

### Describe the reason for the change.

Pollutes the console window needlessly with harmless warnings which are Qt bugs that were later fixed.

### Describe what you have tested and on which operating system.

macOS and Linux.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.