### PR TITLE
Feature/Qt6 - Fix nuke and rv integration

### DIFF
--- a/src/lib/mu/MuQt6/QTextStreamType.cpp
+++ b/src/lib/mu/MuQt6/QTextStreamType.cpp
@@ -861,7 +861,9 @@ namespace Mu
                          Compiled, print_void_qt_QTextStream_string, Parameters,
                          new Param(c, "textstream", "qt.QTextStream"),
                          new Param(c, "outputString", "string"), End),
+            EndArguments);
 
+        addSymbols(
             new Function(c, "QTextStream", _n_QTextStream0, None, Compiled,
                          qt_QTextStream_QTextStream_QTextStream_QTextStream,
                          Return, "qt.QTextStream", Parameters,

--- a/src/lib/mu/MuQt6/handrolled/QTextStreamSymbols.cpp
+++ b/src/lib/mu/MuQt6/handrolled/QTextStreamSymbols.cpp
@@ -9,7 +9,9 @@ globalScope()->addSymbols(
                  print_void_qt_QTextStream_string, Parameters,
                  new Param(c, "textstream", "qt.QTextStream"),
                  new Param(c, "outputString", "string"), End),
+    EndArguments);
 
+addSymbols(
     new Function(c, "QTextStream", _n_QTextStream0, None, Compiled,
                  qt_QTextStream_QTextStream_QTextStream_QTextStream, Return,
                  "qt.QTextStream", Parameters,

--- a/src/plugins/rv-packages/rvnuke/rvnuke_mode.mu.in
+++ b/src/plugins/rv-packages/rvnuke/rvnuke_mode.mu.in
@@ -1978,7 +1978,7 @@ nuke.executeMultiple((writeNode,), ([%s, %s, %s],))
             let newInitFile = qt.QFile (initPath),
                 newInitStream = qt.QTextStream (newInitFile);
 
-            if (! newInitFile.open (qt.QFile.WriteOnly | qt.QFile.Text | qt.QFile.Truncate))
+            if (! newInitFile.open (qt.QFile.ReadWrite | qt.QFile.Text | qt.QFile.Truncate))
             {
                 let msg = "cannot open init.py '%s' for writing." % initPath;
                 deb (msg);


### PR DESCRIPTION
### Feature/Qt6 - Fix nuke and rv integration

### Linked issues
n/a

### Summarize your change.
This PR update the rvNetwork,py to Python 3 (copied from src/plugins/python/network/network/rvNetwork.py) and fix some issues in the Mu binding for the QTextStream class.

I will also update the rvNetwork.py file in the main branch in another PR.

### Describe the reason for the change.
Nuke and RV integration was broken. An image or video could not be played in RV.

### Describe what you have tested and on which operating system.
Rocky Linux 8