### PR TITLE
Feature/qt6 - Fix issue with Windows CI (release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,7 +755,7 @@ jobs:
             ./_build/RV_DEPS_*
             ./_build/cmake/dependencies
             ./_build/_deps
-          key: windows-dependencies
+          key: windows-${{ matrix.arch-type }}-${{ matrix.vfx-platform }}-dependencies
 
       - name: Configure OpenRV
         if: ${{ matrix.vfx-platform == 'CY2023' }}


### PR DESCRIPTION
### Feature/qt6 - Fix issue with Windows CI (release)

### Linked issues
n/a

### Summarize your change.
I added the architecture and vfx platform to the key for the dependencies cache on Windows. It is already present for MacOS.

### Describe the reason for the change.
Sometimes, the release Windows build was failing because it was using the cache from a VFX2023 build.

### Describe what you have tested and on which operating system.
CI