### PR TITLE
Feature/Qt6 - Fix OpenGL Context corruption after exiting Desktop Presentation Mode

### DIFF
--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -369,7 +369,6 @@ namespace Rv
         // image.save("/home/<username>>/<orv_folder>/fbo.png");
     }
 
-
     void GLView::paintGL()
     {
         IPCore::Session* session = m_doc->session();
@@ -446,12 +445,13 @@ namespace Rv
             //          The issue I see on MacOS that the background is brown
             //          istead of black with the default background.
             //
-            // Even on Qt6/QOpenGLWidget, we need to call 
-            // glBindFramebuffer(); it otherwise complains and fails 
+            // Even on Qt6/QOpenGLWidget, we need to call
+            // glBindFramebuffer(); it otherwise complains and fails
             // on glClear() on macOS
-            glBindFramebuffer(
-                GL_FRAMEBUFFER,
+            glBindFramebufferEXT(
+                GL_FRAMEBUFFER_EXT,
                 QOpenGLContext::currentContext()->defaultFramebufferObject());
+            TWK_GLDEBUG;
 
             glPushAttrib(GL_COLOR_BUFFER_BIT);
             TWK_GLDEBUG;
@@ -507,30 +507,30 @@ namespace Rv
         //
 
         // Note for Qt6 . QOpenGLWidget implementation:
-        // 
+        //
         // With the new QOpenGLWidget (Qt6 branch), all of the rendering of
         // each widget is done in its own FBOs (aka: off-screen buffers), as
         // opposed to the old Qt5/QGLWidget branch where the rendering was
         // done in each GGLWidget's backbuffer (aka: GL_BACK, an on-screen
         // framebuffer surface).
-        // 
-        // With QOpenGLWidget, it is now the WainWindow's responsibility 
-        // (more technically, the MainWindow's rendering backend, which 
+        //
+        // With QOpenGLWidget, it is now the WainWindow's responsibility
+        // (more technically, the MainWindow's rendering backend, which
         // happens to be Qt's OpenGL rendering backend when QOpenGLWidget are
-        // present in the children tree) to gather and composite all of the 
-        // off-screen buffers (regardless of which image type they are, eg: 
-        // cpu-memory images, gpu/opengl images, etc) and finally to call 
-        // swapBuffers to show the final contents of the mainWindow. 
-        //  
-        // As a result, I'm not sure there's a point -- at all -- 
+        // present in the children tree) to gather and composite all of the
+        // off-screen buffers (regardless of which image type they are, eg:
+        // cpu-memory images, gpu/opengl images, etc) and finally to call
+        // swapBuffers to show the final contents of the mainWindow.
+        //
+        // As a result, I'm not sure there's a point -- at all --
         // in calling swapBuffers on the GLView anywhere amnymore. From old
-        // comments in the previous version of this tile, it appears that 
-        // calling swapBuffers was done to force a quicker visual update, or 
-        // to minimize visual tearing of some sort. This would have worked 
-        // with the old QGLWidget (becayuse each QGLWidget had its own 
-        // context, and its rendering target was directly the GL_BACK 
+        // comments in the previous version of this tile, it appears that
+        // calling swapBuffers was done to force a quicker visual update, or
+        // to minimize visual tearing of some sort. This would have worked
+        // with the old QGLWidget (becayuse each QGLWidget had its own
+        // context, and its rendering target was directly the GL_BACK
         // framebuffer, but, again, with QOpenGLWidget, the rendering target
-        // is no longer GL_BACK, it is an FBO that is meant to be used at 
+        // is no longer GL_BACK, it is an FBO that is meant to be used at
         // the end of the application's drawing / visual update pipeline.
 
         if (debug)

--- a/src/lib/graphics/TwkGLF/GL.cpp
+++ b/src/lib/graphics/TwkGLF/GL.cpp
@@ -71,8 +71,8 @@ const char* shorterPath(const char* path)
 
 bool twkGlPrintError(const char* file, const char* function, const int line)
 {
-    static GLint lastFBO = -1;
-    static GLint lastRBO = -1;
+    //    static GLint lastFBO = -1;
+    //    static GLint lastRBO = -1;
 
     if (GLuint err = glGetError())
     {
@@ -80,34 +80,35 @@ bool twkGlPrintError(const char* file, const char* function, const int line)
                   << ":" << line << " [" << TwkGLF::errorString(err) << "]"
                   << std::endl;
     }
+    /*
+        GLint currFBO = -1;
+        GLint currRBO = -1;
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currFBO);
+        glGetIntegerv(GL_RENDERBUFFER_BINDING, &currRBO);
 
-    GLint currFBO = -1;
-    GLint currRBO = -1;
-    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currFBO);
-    glGetIntegerv(GL_RENDERBUFFER_BINDING, &currRBO);
+        bool changedFBO = lastFBO != currFBO;
+        bool changedRBO = lastRBO != currRBO;
 
-    bool changedFBO = lastFBO != currFBO;
-    bool changedRBO = lastRBO != currRBO;
+        if (changedFBO || changedRBO)
+        {
+            std::cerr << "[FBO " << lastFBO << " to " << currFBO << "] "
+                      << "[RBO " << lastRBO << " to " << currRBO << "] "
+                      << shorterPath(file) << "::" << function << ":" << line
+                      << std::endl;
 
-    if (changedFBO || changedRBO)
-    {
-        std::cerr << "[FBO " << lastFBO << " to " << currFBO << "] "
-                  << "[RBO " << lastRBO << " to " << currRBO << "] "
-                  << shorterPath(file) << "::" << function << ":" << line
-                  << std::endl;
+            lastFBO = currFBO;
+            lastRBO = currRBO;
+        }
 
-        lastFBO = currFBO;
-        lastRBO = currRBO;
-    }
+        // sorry about explicit if statement -- it just allows to put a
+       breakpoint
+        // on the changedRBO or changedFBO we want.
+        if (changedRBO)
+            return changedRBO;
 
-    // sorry about explicit if statement -- it just allows to put a breakpoint
-    // on the changedRBO or changedFBO we want.
-    if (changedRBO)
-        return changedRBO;
-
-    if (changedFBO)
-        return changedFBO;
-
+        if (changedFBO)
+            return changedFBO;
+    */
     return false;
 }
 

--- a/src/lib/graphics/TwkGLF/GL.cpp
+++ b/src/lib/graphics/TwkGLF/GL.cpp
@@ -61,6 +61,56 @@ namespace TwkGLF
 
 } // namespace TwkGLF
 
+const char* shorterPath(const char* path)
+{
+    const char* src = strstr(path, "/src/");
+    if (src)
+        return src;
+    return path;
+}
+
+bool twkGlPrintError(const char* file, const char* function, const int line)
+{
+    static GLint lastFBO = -1;
+    static GLint lastRBO = -1;
+
+    if (GLuint err = glGetError())
+    {
+        std::cerr << "GL_ERROR: " << shorterPath(file) << "::" << function
+                  << ":" << line << " [" << TwkGLF::errorString(err) << "]"
+                  << std::endl;
+    }
+
+    GLint currFBO = -1;
+    GLint currRBO = -1;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &currFBO);
+    glGetIntegerv(GL_RENDERBUFFER_BINDING, &currRBO);
+
+    bool changedFBO = lastFBO != currFBO;
+    bool changedRBO = lastRBO != currRBO;
+
+    if (changedFBO || changedRBO)
+    {
+        std::cerr << "[FBO " << lastFBO << " to " << currFBO << "] "
+                  << "[RBO " << lastRBO << " to " << currRBO << "] "
+                  << shorterPath(file) << "::" << function << ":" << line
+                  << std::endl;
+
+        lastFBO = currFBO;
+        lastRBO = currRBO;
+    }
+
+    // sorry about explicit if statement -- it just allows to put a breakpoint
+    // on the changedRBO or changedFBO we want.
+    if (changedRBO)
+        return changedRBO;
+
+    if (changedFBO)
+        return changedFBO;
+
+    return false;
+}
+
 bool glSupportsExtension(const char* extstring)
 {
     char* s = (char*)glGetString(GL_EXTENSIONS);    // Get our extension-string

--- a/src/lib/graphics/TwkGLF/TwkGLF/GL.h
+++ b/src/lib/graphics/TwkGLF/TwkGLF/GL.h
@@ -102,16 +102,8 @@ struct GLPushMatrix
 #ifdef NDEBUG
 #define TWK_GLDEBUG ;
 #else
-// #define TWK_ABORT abort()
-#define TWK_ABORT
-#define TWK_GLDEBUG                                                \
-    if (GLuint err = glGetError())                                 \
-    {                                                              \
-        std::cerr << "GL_ERROR: in " << __FILE__ << ", function "  \
-                  << __FUNCTION__ << ", line " << __LINE__ << ": " \
-                  << TwkGLF::errorString(err) << std::endl;        \
-        TWK_ABORT;                                                 \
-    }
+bool twkGlPrintError(const char* file, const char* function, const int line);
+#define TWK_GLDEBUG twkGlPrintError(__FILE__, __FUNCTION__, __LINE__);
 #endif
 
 //----------------------------------------------------------------------

--- a/src/lib/graphics/TwkGLF/TwkGLF/GLFBO.h
+++ b/src/lib/graphics/TwkGLF/TwkGLF/GLFBO.h
@@ -305,6 +305,9 @@ namespace TwkGLF
         GLFBO() {}
 
     private:
+        bool m_ownsFBOHandle; // true when GLFBO constructor creates
+                              // the FBO handle, false when inherits
+                              // from another source
         GLuint m_id;
         std::string m_idstr;
 

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -1330,15 +1330,21 @@ namespace IPCore
         }
 
         context.targetFBO->bind();
+        TWK_GLDEBUG;
 
         GLPushAttrib attr1(GL_ALL_ATTRIB_BITS);
+        TWK_GLDEBUG;
 #ifdef PLATFORM_DARWIN
         GLPushClientAttrib attr2(GL_CLIENT_ALL_ATTRIB_BITS);
+        TWK_GLDEBUG;
 #endif
 
         glDisable(GL_LIGHTING);
+        TWK_GLDEBUG;
         glDisable(GL_DEPTH_TEST);
+        TWK_GLDEBUG;
         glDisable(GL_BLEND);
+        TWK_GLDEBUG;
 
         setupBlendMode(context);
     }
@@ -1397,6 +1403,7 @@ namespace IPCore
 
         if (m_outputDevice.glDevice)
             m_outputDevice.glDevice->makeCurrent();
+        TWK_GLDEBUG;
 
         if (d)
             m_imageFBOManager.clearAllFences();
@@ -1447,12 +1454,13 @@ namespace IPCore
             }
 
             m_outputDevice.clearFBOs();
+            TWK_GLDEBUG;
         }
 
         if (device.glDevice)
         {
             device.glDevice->makeCurrent();
-
+            TWK_GLDEBUG;
             //
             //  Initilaize a bunch of low level shaders
             //
@@ -1500,6 +1508,7 @@ namespace IPCore
                 if (m_outputDevice.glDevice)
                     m_outputDevice.glDevice->makeCurrent();
                 m_outputDevice.clearFBOs();
+                TWK_GLDEBUG;
 
                 if (m_outputDevice.glBindableDevice)
                 {


### PR DESCRIPTION
### Summarize your change.

This is an initial code fix while debugging and fixing SG-25296 (can't use 2nd monitor desktop window as presentation device on macOS M computers). This change does NOT Fix the issue (we still get a black screen) but during the port to Qt6, we introduced a change that deleted the current FBO in the current OpenGL context (a GLFBO class destroyed a FBO object that was owned by Qt, not by GLFBO) and made the GLView class unstable. This fix only addresses the incorrect OpenGL FBO destruction that occurs after exiting presentation mode.

More concretely: GLFBO has 2 constructors: one where a FBO object is created using glGenFramebuffersEXT (in which case the GLFBO instance owns the FBO) and another one where the FBO handle is passed as an argument to the constructor (in which case the GLFBO instance does not own the FBO).  Upon calling the destructor, any non-zero handle was destroyed, but since the non-owned FBOs actually belonged to Qt, we ended up corrupting the current OpenGL context because it no longer had a rendering surface to render onto. To fix this, I have just added a bool member to GLFBO to guide what happens in the GLFBO destructor.

Also, while investigating this issue, I noticed that several places missed a call to the de debug macro TWK_GLDEBUG, so I have added them.

Finally, I updated the formatting of the error log for gl errors, which was overly verbose.

### Describe the reason for the change.

After exiting 2nd-monitor-desktop presentation mode, the OpenGL context got scrapped because an FBO object was mistakenly destroyed, which caused RV to stop displaying content until the view got resize/recreated with new FBOs.

### Describe what you have tested and on which operating system.

macOS. Should work just the same on other platforms.

### Add a list of changes, and note any that might need special attention during the review.
n/a

### If possible, provide screenshots.
n/a