### PR TITLE
Feature/qt6 - Clean up code in QTAudioRenderer class

### DIFF
--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -33,7 +33,11 @@
 #include <TwkUtil/sgcHop.h>
 #include <TwkUtil/User.h>
 #include <TwkUtil/Clock.h>
+#ifdef RV_VFX_CY2023
+#include <QTAudioRenderer/QT5AudioRenderer.h>
+#else
 #include <QTAudioRenderer/QTAudioRenderer.h>
+#endif
 #include <iostream>
 #include <iterator>
 #include <thread>

--- a/src/lib/audio/QTAudioRenderer/QT5AudioRenderer.cpp
+++ b/src/lib/audio/QTAudioRenderer/QT5AudioRenderer.cpp
@@ -6,7 +6,7 @@
 //
 //
 #include <string>
-#include <QTAudioRenderer/QTAudioRenderer.h>
+#include <QTAudioRenderer/QT5AudioRenderer.h>
 
 #include <IPCore/IPGraph.h>
 #include <TwkAudio/AudioFormats.h>

--- a/src/lib/audio/QTAudioRenderer/QTAudioRenderer.cpp
+++ b/src/lib/audio/QTAudioRenderer/QTAudioRenderer.cpp
@@ -18,6 +18,7 @@
 #include <QtCore/qendian.h>
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDir>
+#include <QSysInfo>
 
 #include <iostream>
 #include <sstream>
@@ -648,17 +649,9 @@ namespace IPCore
                     m_startSample += numSamplesForAbuffer;
                     m_processedSamples += numSamplesForAbuffer;
 
-                    // Detect if the system is little or big endian.
-                    bool isLittleEndian = false;
-
-                    union
-                    {
-                        uint32_t i;
-                        char c[4];
-                    } test = {0x01020304};
-
-                    isLittleEndian = (test.c[0] == 0x04);
-
+                    // Assume that most consumer facing device will be little
+                    // endian. Note that some mainframe or embedded system could
+                    // be big endian.
                     AudioRenderer::transformFloat32ToInt24(
                         m_abuffer.pointer(), data, m_abuffer.sizeInFloats(),
                         true);

--- a/src/lib/audio/QTAudioRenderer/QTAudioRenderer.cpp
+++ b/src/lib/audio/QTAudioRenderer/QTAudioRenderer.cpp
@@ -60,22 +60,14 @@ namespace IPCore
     // Utility function that returns the Sample size.
     int sampleSize(const QAudioFormat& format)
     {
-#ifdef RV_VFX_CY2023
-        return format.sampleSize() / 8;
-#else
         return format.bytesPerSample();
-#endif
     }
 
     // NOTE_QT: In theory, this should be called sampleFormat for Qt6. Keep it
     // as is for now.
     SampleFormat sampleType(const QAudioFormat& format)
     {
-#ifdef RV_VFX_CY2023
-        return format.sampleType();
-#else
         return format.sampleFormat();
-#endif
     }
 
     //----------------------------------------------------------------------
@@ -475,15 +467,10 @@ namespace IPCore
         {
             const int bufferSize = m_audioOutput->bufferSize();
 
-#if defined(RV_VFX_CY2023)
-            const int periodSize = m_audioOutput->periodSize();
-#else
-            // TODO_QT THIS MIGHT REQUIRE TRY AND ERROR
             // Calculate the period size based on the buffer size and bytes per
-            // frame.
+            // frame. (This calculation changed with Qt 6)
             const int periodSize =
                 bufferSize / m_audioRenderer.m_format.bytesPerFrame();
-#endif
 
 #ifdef PLATFORM_DARWIN
             const bool doPreRoll = false;
@@ -655,21 +642,29 @@ namespace IPCore
                     break;
 
                 case TwkAudio::Int24Format:
+                {
                     bytesWrittenToDevice =
                         m_abuffer.sizeInFloats() * sizeof(char) * 3;
                     m_startSample += numSamplesForAbuffer;
                     m_processedSamples += numSamplesForAbuffer;
+
+                    // Detect if the system is little or big endian.
+                    bool isLittleEndian = false;
+
+                    union
+                    {
+                        uint32_t i;
+                        char c[4];
+                    } test = {0x01020304};
+
+                    isLittleEndian = (test.c[0] == 0x04);
+
                     AudioRenderer::transformFloat32ToInt24(
                         m_abuffer.pointer(), data, m_abuffer.sizeInFloats(),
-#if defined(RV_VFX_CY2023)
-                        (m_audioRenderer.m_format.byteOrder()
-                         == QAudioFormat::LittleEndian));
-#else
-                        // TODO_QT QUERY THE SYSTEM
                         true);
-#endif
 
                     break;
+                }
 
                 case TwkAudio::Int16Format:
                     bytesWrittenToDevice =
@@ -798,26 +793,17 @@ namespace IPCore
         return QIODevice::bytesAvailable();
     }
 
-//----------------------------------------------------------------------
-//      QTAudioOutput
-//
-//      This is the Qt audio output class that lives
-//      with the audio thread.
-//----------------------------------------------------------------------
-#if defined(RV_VFX_CY2023)
-    QTAudioOutput::QTAudioOutput(QAudioDeviceInfo& audioDevice,
-#else
+    //----------------------------------------------------------------------
+    //      QTAudioOutput
+    //
+    //      This is the Qt audio output class that lives
+    //      with the audio thread.
+    //----------------------------------------------------------------------
     QTAudioOutput::QTAudioOutput(QAudioDevice& audioDevice,
-#endif
                                  QAudioFormat& audioFormat,
                                  QTAudioIODevice& ioDevice,
                                  QTAudioThread& audioThread)
-        :
-#if defined(RV_VFX_CY2023)
-        QAudioOutput(audioDevice, audioFormat)
-#else
-        QAudioSink(audioDevice, audioFormat)
-#endif
+        : QAudioSink(audioDevice, audioFormat)
         , m_device(audioDevice)
         , m_format(audioFormat)
         , m_ioDevice(ioDevice)
@@ -989,9 +975,6 @@ namespace IPCore
             // preference that would have polluted the RV preferences
             // unnecessarily.
 
-#if defined(RV_VFX_CY2023)
-            const bool audioDeviceIsWASAPI = m_device.realm() == "wasapi";
-#else
             // Device id may contain backend information (e.g. wasapi or waveout
             // for WinMM).
             const QString deviceId = m_device.description();
@@ -1000,7 +983,6 @@ namespace IPCore
             const bool audioDeviceIsWASAPI =
                 deviceId.contains("wasapi", Qt::CaseInsensitive)
                 || deviceName.contains("wasapi", Qt::CaseInsensitive);
-#endif
 
             if (audioDeviceIsWASAPI && evApplyWasapiFix.getValue())
             {
@@ -1086,13 +1068,7 @@ namespace IPCore
                 << " isPlaying=" << (int)s->isPlaying()
                 << " isScrubbingAudio=" << (int)s->isScrubbingAudio()
                 << " audioOutput state=" << (int)state()
-                << " audioOutput bufferSize=" << (int)bufferSize()
-#if defined(RV_VFX_CY2023)
-                << " audioOutput periodSize=" << (int)periodSize();
-            // TODO_QT: Is there a equivalent in Qt6?
-#else
-                ;
-#endif
+                << " audioOutput bufferSize=" << (int)bufferSize();
         }
     }
 
@@ -1123,24 +1099,12 @@ namespace IPCore
 
     TwkAudio::Format QTAudioRenderer::getTwkAudioFormat() const
     {
-#if defined(RV_VFX_CY2023)
-        return convertToTwkAudioFormat(sampleSize(m_format),
-                                       sampleType(m_format));
-#else
         return convertToTwkAudioFormat(sampleType(m_format));
-#endif
     }
 
     TwkAudio::Format
-#if defined(RV_VFX_CY2023)
-    QTAudioRenderer::convertToTwkAudioFormat(int fmtSize,
-                                             SampleFormat fmtType) const
-#else
     QTAudioRenderer::convertToTwkAudioFormat(SampleFormat fmtType) const
-#endif
     {
-        // TODO_QT
-
         // Qt5
         // QAudioFormat::Unknown	    0	Not Set
         // QAudioFormat::SignedInt	    1	Samples are signed integers
@@ -1158,69 +1122,6 @@ namespace IPCore
         // Keeping the fmtSize parameters for now, but it is not needed because
         // QAudioFormat::SampleFormat tell us the size and the type.
 
-#if defined(RV_VFX_CY2023)
-        switch (fmtSize)
-        {
-        case 8:
-            switch (fmtType)
-            {
-            case QAudioFormat::SignedInt:
-                return TwkAudio::Int8Format;
-                break;
-
-            default:
-                break;
-            }
-
-            break;
-
-        case 16:
-            switch (fmtType)
-            {
-            case QAudioFormat::SignedInt:
-                return TwkAudio::Int16Format;
-                break;
-
-            default:
-                break;
-            }
-
-            break;
-
-        case 24:
-            switch (fmtType)
-            {
-            case QAudioFormat::SignedInt:
-                return TwkAudio::Int24Format;
-                break;
-
-            default:
-                break;
-            }
-
-            break;
-
-        case 32:
-            switch (fmtType)
-            {
-            case QAudioFormat::SignedInt:
-                return TwkAudio::Int32Format;
-                break;
-
-            case QAudioFormat::Float:
-                return TwkAudio::Float32Format;
-                break;
-
-            default:
-                break;
-            }
-
-            break;
-
-        case 64:
-            break;
-        }
-#else
         switch (fmtType)
         {
         case QAudioFormat::UInt8:
@@ -1235,12 +1136,10 @@ namespace IPCore
         default:
             break;
         }
-#endif
 
         return TwkAudio::UnknownFormat;
     }
 
-#if defined(RV_VFX_CY2024)
     QAudioFormat::SampleFormat
     QTAudioRenderer::convertToQtAudioFormat(TwkAudio::Format fmtType) const
     {
@@ -1275,29 +1174,14 @@ namespace IPCore
 
         return QAudioFormat::Unknown;
     }
-#endif
 
     void QTAudioRenderer::availableLayouts(const Device& d,
                                            LayoutsVector& layouts)
     {
-#if defined(RV_VFX_CY2023)
-        const QAudioDeviceInfo& device = m_deviceList[d.index];
-        const QList<int> channelCounts = device.supportedChannelCounts();
-#else
         const QAudioDevice& device = m_deviceList[d.index];
-#endif
 
         layouts.clear();
 
-#if defined(RV_VFX_CY2023)
-        for (QList<int>::const_iterator ci = channelCounts.begin();
-             ci != channelCounts.end(); ci++)
-        {
-            LayoutsVector l = TwkAudio::channelLayouts(*ci);
-            for (int i = 0; i < l.size(); i++)
-                layouts.push_back(l[i]);
-        }
-#else
         QAudioFormat testFormat;
         // Set valid value to the parameters that we are not testing.
         testFormat.setSampleRate(AudioRenderer::defaultParameters().rate);
@@ -1320,57 +1204,8 @@ namespace IPCore
                 }
             }
         }
-#endif
     }
 
-#if defined(RV_VFX_CY2023)
-    void QTAudioRenderer::availableFormats(const Device& d,
-                                           FormatVector& formats)
-    {
-        const QAudioDeviceInfo& info = m_deviceList[d.index];
-        const QList<int> sizes = info.supportedSampleSizes();
-        const QList<SampleFormat> types = info.supportedSampleTypes();
-        const QList<int> rates = info.supportedSampleRates();
-        const int channelCount = TwkAudio::channelsCount(d.layout);
-
-        formats.clear();
-
-        for (QList<int>::const_iterator ci = sizes.begin(); ci != sizes.end();
-             ci++)
-        {
-            for (QList<SampleFormat>::const_iterator cj = types.begin();
-                 cj != types.end(); cj++)
-            {
-                TwkAudio::Format fmt = convertToTwkAudioFormat(*ci, *cj);
-
-                if (fmt != TwkAudio::UnknownFormat)
-                {
-                    QAudioFormat f;
-
-                    f.setChannelCount(channelCount);
-                    f.setCodec(QString(m_codec.c_str()));
-                    f.setByteOrder(QAudioFormat::LittleEndian);
-                    f.setSampleSize(*ci);
-                    f.setSampleType(*cj);
-
-                    // Now we check that a supported format
-                    // has a supported rate.
-                    // Oddly on linux a supported format can
-                    // have no rate thats supported!
-                    for (size_t i = 0; i < rates.size(); i++)
-                    {
-                        f.setSampleRate(rates[i]);
-                        if (info.isFormatSupported(f))
-                        {
-                            formats.push_back(fmt);
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-#else
     void QTAudioRenderer::availableFormats(const Device& d,
                                            FormatVector& formats)
     {
@@ -1414,7 +1249,6 @@ namespace IPCore
             }
         }
     }
-#endif
 
     //
     // Sets the sample size and type in qformat for a given twkFormat.
@@ -1429,53 +1263,25 @@ namespace IPCore
         switch (twkFormat)
         {
         case TwkAudio::Float32Format:
-#if defined(RV_VFX_CY2023)
-            qformat.setSampleSize(32);
-            qformat.setSampleType(QAudioFormat::Float);
-#else
             qformat.setSampleFormat(QAudioFormat::Float);
-#endif
             break;
 
         case TwkAudio::Int32Format:
-#if defined(RV_VFX_CY2023)
-            qformat.setSampleSize(32);
-            qformat.setSampleType(QAudioFormat::SignedInt);
-#else
             qformat.setSampleFormat(QAudioFormat::Int32);
-#endif
             break;
 
-        case TwkAudio::Int24Format:
-#if defined(RV_VFX_CY2023)
-            qformat.setSampleSize(24);
-            qformat.setSampleType(QAudioFormat::SignedInt);
-#else
-            // Qt6 does not have a direct equivalent for 24-bit audio.
-            // TODO_QT: Might have to handle this specially or not support it.
-            qformat.setSampleFormat(QAudioFormat::Int32);
-#endif
-            break;
+            // case TwkAudio::Int24Format:
+            //     // Qt6 does not have a direct equivalent for 24-bit audio.
+            //     qformat.setSampleFormat(QAudioFormat::Int32);
+            //     break;
 
         case TwkAudio::Int16Format:
-#if defined(RV_VFX_CY2023)
-            qformat.setSampleSize(16);
-            qformat.setSampleType(QAudioFormat::SignedInt);
-#else
             qformat.setSampleFormat(QAudioFormat::Int16);
-#endif
             break;
 
-        case TwkAudio::Int8Format:
-#if defined(RV_VFX_CY2023)
-            qformat.setSampleSize(8);
-            qformat.setSampleType(QAudioFormat::SignedInt);
-#else
-            // Qt6 does not have a direct equivalent for signed 8-bit audio.
-            // TODO_QT: Might have to handle this specially or not support it.
-            qformat.setSampleFormat(QAudioFormat::UInt8);
-#endif
-            break;
+            // case TwkAudio::Int8Format:
+            //     // Qt6 does not have a direct equivalent for signed 8-bit
+            //     audio. qformat.setSampleFormat(QAudioFormat::UInt8); break;
 
         default:
             cout << "AUDIO: format unknown" << endl;
@@ -1489,31 +1295,10 @@ namespace IPCore
         QAudioFormat f;
 
         f.setChannelCount(TwkAudio::channelsCount(d.layout));
-#if defined(RV_VFX_CY2023)
-        f.setCodec(QString(m_codec.c_str()));
-        f.setByteOrder(QAudioFormat::LittleEndian);
-#endif
-
         setSampleSizeAndType(d.layout, format, f);
-
-#if defined(RV_VFX_CY2023)
-        const QAudioDeviceInfo& device = m_deviceList[d.index];
-        QList<int> rates = device.supportedSampleRates();
-        sort(rates.begin(), rates.end());
-#else
         const QAudioDevice& device = m_deviceList[d.index];
-#endif
 
         audiorates.clear();
-
-#if defined(RV_VFX_CY2023)
-        for (size_t i = 0; i < rates.size(); i++)
-        {
-            f.setSampleRate(rates[i]);
-            if (device.isFormatSupported(f))
-                audiorates.push_back(rates[i]);
-        }
-#else
 
         // Floating point exception are trowned when the sample rate is under
         // TWEAK_AUDIO_MIN_SAMPLE_RATE and above TWEAK_AUDIO_MAX_SAMPLE_RATE
@@ -1527,7 +1312,6 @@ namespace IPCore
 
         audiorates.push_back(deviceMin);
         audiorates.push_back(deviceMax);
-#endif
     }
 
     //
@@ -1535,51 +1319,27 @@ namespace IPCore
     // of channels as specified by m_parameters.layout.
     //
     bool
-#if defined(RV_VFX_CY2023)
-    QTAudioRenderer::supportsRequiredChannels(
-        const QAudioDeviceInfo& device) const
-#else
     QTAudioRenderer::supportsRequiredChannels(const QAudioDevice& device) const
-#endif
     {
 #ifdef PLATFORM_LINUX
         if (AudioRenderer::debug)
         {
-#if defined(RV_VFX_CY2023)
-            const QList<int> channels = device.supportedChannelCounts();
-            for (QList<int>::const_iterator ci = channels.begin();
-                 ci != channels.end(); ci++)
-                TwkUtil::Log("AUDIO") << device.deviceName().toStdString()
-                                      << " supports channel count = " << (*ci);
-#else
             TwkUtil::Log("AUDIO")
                 << device.description().toStdString() << " supports minimum "
                 << device.minimumChannelCount() << " to maximum "
                 << device.maximumChannelCount() << " channels";
-#endif
         }
 
         // Its possible e.g. Linux that some devices hv no channel count info
         // so we assume its supported... hence we always return true.
         return true;
 #else
-#if defined(RV_VFX_CY2023)
-        const QList<int> channels = device.supportedChannelCounts();
-#endif
-
         if (AudioRenderer::debug)
         {
-#if defined(RV_VFX_CY2023)
-            for (QList<int>::const_iterator ci = channels.begin();
-                 ci != channels.end(); ci++)
-                TwkUtil::Log("Audio") << device.deviceName().toStdString()
-                                      << " supports channel count = " << (*ci);
-#else
             TwkUtil::Log("AUDIO")
                 << device.description().toStdString() << " supports minimum "
                 << device.minimumChannelCount() << " to maximum "
                 << device.maximumChannelCount() << " channels";
-#endif
         }
 
         //
@@ -1588,46 +1348,14 @@ namespace IPCore
         //  available in the input sources
         //
 
-#if defined(RV_VFX_CY2023)
-        return (!channels.empty());
-#else
         return (device.maximumChannelCount() > 0);
-#endif
 
 #endif
     }
 
     void QTAudioRenderer::initDeviceList()
     {
-#if defined(RV_VFX_CY2023)
-        if (m_deviceList.empty())
-        {
-            //
-            //  This appears to be a bug with Linux (on centos6.5).
-            //  Basically the size returned by availbleDevices() is different
-            //  the first time you call it compared to all subsequent times.
-            //  So this logic between keeps calling availableDevices() until
-            //  its size doesnt change; we limit this to five attempts.
-            //
-            int noOfAttempts = 5;
-            int noOfDevices = 0;
-            int prev_noOfDevices = 0;
-
-            do
-            {
-                prev_noOfDevices = noOfDevices;
-                noOfDevices =
-                    QAudioDeviceInfo::availableDevices(QAudio::AudioOutput)
-                        .size();
-                --noOfAttempts;
-            } while (prev_noOfDevices != noOfDevices && noOfAttempts);
-
-            m_deviceList << QAudioDeviceInfo::availableDevices(
-                QAudio::AudioOutput);
-        }
-#else
         m_deviceList << QMediaDevices::audioOutputs();
-#endif
     }
 
     //  The purpose of init() is to
@@ -1653,23 +1381,14 @@ namespace IPCore
 
         if (m_parameters.device == "Default" || m_parameters.device.empty())
         {
-#if defined(RV_VFX_CY2023)
-            const QAudioDeviceInfo& defaultDevice =
-                QAudioDeviceInfo::defaultOutputDevice();
-#else
             const QAudioDevice& defaultDevice =
                 QMediaDevices::defaultAudioOutput();
-#endif
             bool validDevice = false;
 
             for (size_t i = 0; i < m_deviceList.size(); ++i)
             {
-#if defined(RV_VFX_CY2023)
-                if (m_deviceList[i].deviceName() == defaultDevice.deviceName())
-#else
                 if (m_deviceList[i].description()
                     == defaultDevice.description())
-#endif
                 {
                     validDevice = true;
                     break;
@@ -1680,11 +1399,7 @@ namespace IPCore
             // number of channels.
             if (validDevice && supportsRequiredChannels(defaultDevice))
             {
-#if defined(RV_VFX_CY2023)
-                m_parameters.device = defaultDevice.deviceName().toStdString();
-#else
                 m_parameters.device = defaultDevice.description().toStdString();
-#endif
                 if (AudioRenderer::debug)
                 {
                     TwkUtil::Log("AUDIO")
@@ -1695,19 +1410,9 @@ namespace IPCore
 
                 qformat.setSampleRate((int)m_parameters.rate);
                 qformat.setChannelCount(channelCount);
-#if defined(RV_VFX_CY2023)
-                qformat.setCodec(QString(m_codec.c_str()));
-                qformat.setByteOrder(QAudioFormat::LittleEndian);
-                // qformat.setByteOrder(QAudioFormat::BigEndian);
-#endif
 
-#if defined(RV_VFX_CY2023)
                 setSampleSizeAndType(m_parameters.layout, m_parameters.format,
                                      qformat);
-#else
-                setSampleSizeAndType(m_parameters.layout, m_parameters.format,
-                                     qformat);
-#endif
                 //
                 // If the default device does not support the format
                 // defined by m_parameters; we change to the
@@ -1716,13 +1421,8 @@ namespace IPCore
                 {
                     const QAudioFormat defaultFormat =
                         defaultDevice.preferredFormat();
-#if defined(RV_VFX_CY2023)
-                    m_parameters.format = convertToTwkAudioFormat(
-                        sampleSize(defaultFormat), sampleType(defaultFormat));
-#else
                     m_parameters.format =
                         convertToTwkAudioFormat(sampleType(defaultFormat));
-#endif
                 }
             }
         }
@@ -1730,26 +1430,14 @@ namespace IPCore
         m_outputDevices.clear();
         for (size_t i = 0; i < m_deviceList.size(); ++i)
         {
-#if defined(RV_VFX_CY2023)
-            const QAudioDeviceInfo& device = m_deviceList[i];
-#else
             const QAudioDevice& device = m_deviceList[i];
-#endif
 
             if (device.isNull() || !supportsRequiredChannels(device))
                 continue;
 
             const QAudioFormat defaultFormat = device.preferredFormat();
 
-#if defined(RV_VFX_CY2023)
-            std::string deviceName = device.deviceName().toStdString();
-#else
             std::string deviceName = device.description().toStdString();
-#endif
-
-            // TODO_QT NOTE_QT: I would assume that below is not true anymore or
-            // fixed because QtMultimedia had a big
-            //                  refactor in Qt6.
 
             // On Windows, a QAudioDevice can be listed twice with the same name
             // This is due to the fact that both Qt audio plugins, wasapi and
@@ -1761,11 +1449,7 @@ namespace IPCore
             // name.
             while (findDeviceByName(deviceName) != -1)
             {
-#if defined(RV_VFX_CY2023)
-                deviceName += "_" + device.realm().toStdString();
-#else
                 deviceName += "_" + device.description().toStdString();
-#endif
             }
 
             Device d(deviceName);
@@ -1784,13 +1468,8 @@ namespace IPCore
                 // Instead we pick the first device that supports the channel
                 // count we need.
                 m_parameters.device = d.name;
-#if defined(RV_VFX_CY2023)
-                m_parameters.format = convertToTwkAudioFormat(
-                    sampleSize(defaultFormat), sampleType(defaultFormat));
-#else
                 m_parameters.format =
                     convertToTwkAudioFormat(sampleType(defaultFormat));
-#endif
             }
 
             if (m_parameters.device == d.name)
@@ -1807,17 +1486,11 @@ namespace IPCore
             {
                 cout << "AUDIO: device=" << d.name << " with channelsCount = "
                      << TwkAudio::channelsCount(d.layout)
-#if defined(RV_VFX_CY2023)
-                     << " defaultSampleSize=" << (int)sampleSize(defaultFormat)
-                     << " defaultSampleType=" << (int)sampleType(defaultFormat)
-                     << " defaultSampleByteOrder="
-                     << (int)defaultFormat.byteOrder()
-#else
                      << " defaultSampleFormat="
                      << (int)sampleType(defaultFormat)
-                // Qt6: No custom sample size.
-                // Qt6: No custom byte orde. Qt expect the order of the host.
-#endif
+                     // Qt6: No custom sample size.
+                     // Qt6: No custom byte orde. Qt expect the order of the
+                     // host.
                      << " defaultrate=" << (int)d.defaultRate
                      << " isDefaultDevice=" << (int)d.isDefaultDevice << endl;
             }
@@ -1827,13 +1500,8 @@ namespace IPCore
 
         if (AudioRenderer::debug)
         {
-#if defined(RV_VFX_CY2023)
-            cout << "AUDIO: init default device="
-                 << m_device.deviceName().toStdString() << endl;
-#else
             cout << "AUDIO: init default device="
                  << m_device.description().toStdString() << endl;
-#endif
 
             cout << "AUDIO: init m_parameters.device=" << m_parameters.device
                  << endl;
@@ -1918,21 +1586,6 @@ namespace IPCore
 
             if (!rates.empty())
             {
-
-#if defined(RV_VFX_CY2023)
-                double nearRate = rates[0];
-                for (size_t i = 1; i < rates.size(); i++)
-                {
-                    if (fabs(rates[i] - state.rate)
-                        < fabs(nearRate - state.rate))
-                    {
-                        nearRate = rates[i];
-                    }
-                }
-
-                state.rate = nearRate;
-                m_parameters.rate = state.rate;
-#else
                 // Check if the value is within the lower and upper boundaries
                 // sets in the rates vector.
                 int minVal = rates.front();
@@ -1948,7 +1601,6 @@ namespace IPCore
                 }
 
                 m_parameters.rate = state.rate;
-#endif
             }
 
             //
@@ -1956,24 +1608,15 @@ namespace IPCore
             //
             m_format.setSampleRate((int)state.rate);
             m_format.setChannelCount(TwkAudio::channelsCount(state.layout));
-#if defined(RV_VFX_CY2023)
-            m_format.setCodec(QString(m_codec.c_str()));
-            m_format.setByteOrder(QAudioFormat::LittleEndian);
-            // m_format.setByteOrder(QAudioFormat::BigEndian);
-#endif
-            // TODO_QT: Not sure about codec.
+
             // Qt6: Expect the endian of the host.
             setSampleSizeAndType(state.layout, state.format, m_format);
 
             if (!m_device.isFormatSupported(m_format))
             {
-#if defined(RV_VFX_CY2023)
-                m_format = m_device.nearestFormat(m_format);
-#else
-                // NOTE_QT: Qt6: does not have the nearestFormat avaiable. Take
-                // the default prefered.
+                // Qt6: does not have the nearestFormat avaiable. Take the
+                // prefered format.
                 m_format = m_device.preferredFormat();
-#endif
 
                 if (sampleType(m_format) == QAudioFormat::Unknown)
                 {
@@ -1987,15 +1630,8 @@ namespace IPCore
                 {
                     if (AudioRenderer::debug)
                     {
-#if defined(RV_VFX_CY2023)
-                        cout << "AUDIO: nearest m_format.sampleType()="
-                             << (int)sampleType(m_format) << endl;
-                        cout << "AUDIO: nearest m_format.sampleSize()="
-                             << (int)sampleSize(m_format) << endl;
-#else
                         cout << "AUDIO: nearest m_format.sampleFormat()="
                              << (int)sampleType(m_format) << endl;
-#endif
                         cout << "AUDIO: nearest m_format.sampleRate()="
                              << (int)m_format.sampleRate() << endl;
                         cout << "AUDIO: nearest m_format.channelCount()="
@@ -2012,15 +1648,8 @@ namespace IPCore
 #ifdef DEBUG_QTAUDIO
             if (AudioRenderer::debug)
             {
-#if defined(RV_VFX_CY2023)
-                cout << "AUDIO: nearest m_format.sampleType()="
-                     << (int)sampleType(m_format) << endl;
-                cout << "AUDIO: nearest m_format.sampleSize()="
-                     << (int)sampleSize(m_format) << endl;
-#else
                 cout << "AUDIO: nearest m_format.sampleFormat()="
                      << (int)sampleType(m_format) << endl;
-#endif
                 cout << "AUDIO: m_format.sampleRate()="
                      << (int)m_format.sampleRate() << endl;
                 cout << "AUDIO: m_format.channelCount()="

--- a/src/lib/audio/QTAudioRenderer/QTAudioRenderer/QTAudioRenderer.h
+++ b/src/lib/audio/QTAudioRenderer/QTAudioRenderer/QTAudioRenderer.h
@@ -17,16 +17,9 @@
 #include <QtCore/QIODevice>
 
 #include <QtMultimedia/QAudioFormat>
-#if defined(RV_VFX_CY2023)
-// Qt5
-#include <QtMultimedia/QAudioOutput>
-#include <QtMultimedia/QAudioDeviceInfo>
-#else
-// Qt6+
 #include <QtMultimedia/QAudioDevice>
 #include <QtMultimedia/QAudioSink>
 #include <QtMultimedia/QMediaDevices>
-#endif
 
 #include <QtCore/QThread>
 #include <QtCore/QMutex>
@@ -36,11 +29,7 @@
 namespace IPCore
 {
 
-#ifdef RV_VFX_CY2023
-    using SampleFormat = QAudioFormat::SampleType;
-#else
     using SampleFormat = QAudioFormat::SampleFormat;
-#endif
 
     class QTAudioThread;
     class QTAudioRenderer;
@@ -67,22 +56,13 @@ namespace IPCore
         QTAudioThread& m_thread;
     };
 
-#if defined(RV_VFX_CY2023)
-    class QTAudioOutput : public QAudioOutput
-#else
     class QTAudioOutput : public QAudioSink
-#endif
     {
         Q_OBJECT
 
     public:
-#if defined(RV_VFX_CY2023)
-        QTAudioOutput(QAudioDeviceInfo& audioDevice,
-#else
-        QTAudioOutput(QAudioDevice& audioDevice,
-#endif
-                      QAudioFormat& audioFormat, QTAudioIODevice& ioDevice,
-                      QTAudioThread& audioThread);
+        QTAudioOutput(QAudioDevice& audioDevice, QAudioFormat& audioFormat,
+                      QTAudioIODevice& ioDevice, QTAudioThread& audioThread);
         ~QTAudioOutput();
 
     public slots:
@@ -101,11 +81,7 @@ namespace IPCore
         std::string toString(QAudio::State state);
 
     private:
-#if defined(RV_VFX_CY2023)
-        QAudioDeviceInfo& m_device;
-#else
         QAudioDevice& m_device;
-#endif
         QAudioFormat& m_format;
         QTAudioIODevice& m_ioDevice;
         QTAudioThread& m_thread;
@@ -247,17 +223,10 @@ namespace IPCore
         static IPCore::AudioRenderer::Module addQTAudioModule();
 
         TwkAudio::Format getTwkAudioFormat() const;
-#if defined(RV_VFX_CY2023)
-        TwkAudio::Format convertToTwkAudioFormat(int fmtSize,
-                                                 SampleFormat fmtType) const;
-#else
         TwkAudio::Format convertToTwkAudioFormat(SampleFormat fmtType) const;
-#endif
 
-#if defined(RV_VFX_CY2024)
         QAudioFormat::SampleFormat
         convertToQtAudioFormat(TwkAudio::Format fmtType) const;
-#endif
 
         void setSampleSizeAndType(Layout twkLayout, Format twkFormat,
                                   QAudioFormat& qformat) const;
@@ -265,11 +234,7 @@ namespace IPCore
         friend class QTAudioThread;
 
     private:
-#if defined(RV_VFX_CY2023)
-        bool supportsRequiredChannels(const QAudioDeviceInfo& info) const;
-#else
         bool supportsRequiredChannels(const QAudioDevice& info) const;
-#endif
 
         void init();
 
@@ -279,13 +244,8 @@ namespace IPCore
         QObject* m_parent;
         QTAudioThread* m_thread;
         QAudioFormat m_format;
-#if defined(RV_VFX_CY2023)
-        QAudioDeviceInfo m_device;
-        QList<QAudioDeviceInfo> m_deviceList;
-#else
         QAudioDevice m_device;
         QList<QAudioDevice> m_deviceList;
-#endif
         std::string m_codec;
     };
 


### PR DESCRIPTION
### Feature/qt6 - Clean up code in QTAudioRenderer class

### Linked issues
n/a

### Summarize your change.
Removed #ifdef related to RV_VFX_CY2023 since they are not needed in QTAudioRenderer class (QT5AudioRenderer is used for CY2023).

### Describe the reason for the change.
Clean up code to make it more readable.

### Describe what you have tested and on which operating system.
Rocky Linux 8