### PR TITLE
Fix the failing readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,8 @@ python:
     - requirements: docs/requirements.txt
    
 sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
   fail_on_warning: false
   
 formats:


### PR DESCRIPTION
### Fix the failing readthedocs build

### Linked issues
n/a

### Summarize your change.
I added the `configuration` key to the `.readthedocs.yaml` because it is required.

### Describe the reason for the change.
Since December 2024, the `configuration` key is required.
See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.