### PR TITLE
Remove show property from annotation hook

### DIFF
--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -20,17 +20,9 @@ SET(PYTHON_VERSION_MAJOR
     3
 )
 
-RV_VFX_SET_VARIABLE(
-  PYTHON_VERSION_MINOR
-  CY2023 "10"
-  CY2024 "11"
-)
+RV_VFX_SET_VARIABLE(PYTHON_VERSION_MINOR CY2023 "10" CY2024 "11")
 
-RV_VFX_SET_VARIABLE(
-  PYTHON_VERSION_PATCH
-  CY2023 "13"
-  CY2024 "9"
-)
+RV_VFX_SET_VARIABLE(PYTHON_VERSION_PATCH CY2023 "13" CY2024 "9")
 
 SET(_python3_version
     "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.${PYTHON_VERSION_PATCH}"
@@ -44,12 +36,11 @@ SET(RV_DEPS_PYTHON_VERSION_SHORT
 )
 
 SET(_opentimelineio_version
-    "0.15"
+    "0.16.0"
 )
 
 RV_VFX_SET_VARIABLE(
-  _pyside2_version
-  CY2023 "5.15.10"
+  _pyside2_version CY2023 "5.15.10"
   # Need 5.15.11+ to support Python 3.11.
   CY2024 "5.15.11"
 )
@@ -57,11 +48,7 @@ RV_VFX_SET_VARIABLE(
 SET(_python3_download_url
     "https://github.com/python/cpython/archive/refs/tags/v${_python3_version}.zip"
 )
-RV_VFX_SET_VARIABLE(
-  _python3_download_hash
-  CY2023 "21b32503f31386b37f0c42172dfe5637"
-  CY2024 "392eccd4386936ffcc46ed08057db3e7"
-)
+RV_VFX_SET_VARIABLE(_python3_download_hash CY2023 "21b32503f31386b37f0c42172dfe5637" CY2024 "392eccd4386936ffcc46ed08057db3e7")
 
 SET(_opentimelineio_download_url
     "https://github.com/AcademySoftwareFoundation/OpenTimelineIO"
@@ -73,11 +60,7 @@ SET(_opentimelineio_git_tag
 SET(_pyside2_archive_url
     "https://mirrors.ocf.berkeley.edu/qt/official_releases/QtForPython/pyside2/PySide2-${_pyside2_version}-src/pyside-setup-opensource-src-${_pyside2_version}.zip"
 )
-RV_VFX_SET_VARIABLE(
-  _pyside2_download_hash
-  CY2023 "87841aaced763b6b52e9b549e31a493f"
-  CY2024 "8f652b08c1c74f9a80a2c0f16ff2a4ca"
-)
+RV_VFX_SET_VARIABLE(_pyside2_download_hash CY2023 "87841aaced763b6b52e9b549e31a493f" CY2024 "8f652b08c1c74f9a80a2c0f16ff2a4ca")
 
 SET(_install_dir
     ${RV_DEPS_BASE_DIR}/${_python3_target}/install
@@ -236,20 +219,19 @@ SET(_requirements_install_command
 )
 
 IF(RV_TARGET_WINDOWS)
-  SET(_patch_python3_11_command 
+  SET(_patch_python3_11_command
       "patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/python.3.11.openssl.props.patch &&\
        patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/python.3.11.python.props.patch &&\
        patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/python.3.11.get_externals.bat.patch"
   )
 
-  RV_VFX_SET_VARIABLE(
-    _patch_command
-    CY2023 ""
-    CY2024 "${_patch_python3_11_command}"
-  )
+  RV_VFX_SET_VARIABLE(_patch_command CY2023 "" CY2024 "${_patch_python3_11_command}")
   # Split the command into a semi-colon separated list.
-  separate_arguments(_patch_command)
-  STRING(REGEX REPLACE ";+" ";" _patch_command "${_patch_command}")
+  SEPARATE_ARGUMENTS(_patch_command)
+  STRING(
+    REGEX
+    REPLACE ";+" ";" _patch_command "${_patch_command}"
+  )
 ENDIF()
 
 EXTERNALPROJECT_ADD(

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -36,9 +36,7 @@ def hook_function(
             frame_component = f"{paint_node}.frame:{frame}"
 
             # Set properties on the paint component of the RVPaint node
-            effectHook.set_rv_effect_props(
-                paint_component, {"nextId": stroke_id + 1, "show": layer.visible}
-            )
+            effectHook.set_rv_effect_props(paint_component, {"nextId": stroke_id + 1})
 
             # Add and set properties on the pen component of the RVPaint node
             effectHook.add_rv_effect_props(


### PR DESCRIPTION
### Remove show property from annotation hook

### Summarize your change.

The `visible` layer attribute is not used anymore to indicate if annotations should be shown or not. Therefore, the `show` attribute of the RVPaint node should not be set with that attribute value. Show and hide annotation actions are now only being handled in the Live Review plugin. The required changes were made in this [PR](https://git.autodesk.com/media-and-entertainment/rv/pull/336).

### Describe the reason for the change.

Since Creative Review is now sending an event as part of the `PLAYBACK_SETTINGS` command, we should not use the `visible` attribute of the OTIO Timeline to know if the annotations should be shown or not.

### Describe what you have tested and on which operating system.
This change was tested on macOS in a Live Review session between RV and the Creative Review prototype.