### PR TITLE
Add PNG as slow random access codec

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -247,6 +247,13 @@ IF(RV_TARGET_WINDOWS)
   LIST(APPEND RV_FFMPEG_COMMON_CONFIG_OPTIONS "--toolchain=msvc")
 ENDIF()
 
+# Change the condition to TRUE to be able to debug into FFmpeg.
+IF(FALSE)
+  LIST(APPEND RV_FFMPEG_COMMON_CONFIG_OPTIONS "--disable-optimizations")
+  LIST(APPEND RV_FFMPEG_COMMON_CONFIG_OPTIONS "--enable-debug=3")
+  LIST(APPEND RV_FFMPEG_COMMON_CONFIG_OPTIONS "--disable-stripping")
+ENDIF()
+
 # Controls the EXTERNALPROJECT_ADD/BUILD_ALWAYS option
 SET(${_force_rebuild}
     FALSE


### PR DESCRIPTION
### Add PNG as slow random access codec

### Linked issues
n/a

### Summarize your change.
Adding PNG codec to the slow random access array and changing the seeking offset to -1 instead of -3 because RV was using that an offset of -1 before FFmpeg 6.

### Describe the reason for the change.
There are some issues when RV is using two readers threads and FFmpeg multithreading. By adding PNG as a slow random access codec, the decoding performance is a lot better.

### Describe what you have tested and on which operating system.
Rocky Linux 8

An offset of -1 during seeking had better performance during my testing.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.