### PR TITLE
717: Fix OUTPUT path of windows openssl cmake custom command

### DIFF
--- a/cmake/dependencies/openssl.cmake
+++ b/cmake/dependencies/openssl.cmake
@@ -238,7 +238,7 @@ ELSE()
     )
     ADD_CUSTOM_COMMAND(
       COMMENT "Installing ${_target}'s libs and bin into ${RV_STAGE_LIB_DIR} and ${RV_STAGE_BIN_DIR}"
-      OUTPUT ${RV_STAGE_LIB_DIR}/${_crypto_lib_name} ${RV_STAGE_LIB_DIR}/${_ssl_lib_name}
+      OUTPUT ${RV_STAGE_BIN_DIR}/${_crypto_lib_name} ${RV_STAGE_BIN_DIR}/${_ssl_lib_name}
       COMMAND ${CMAKE_COMMAND} -E copy_directory ${_lib_dir} ${RV_STAGE_LIB_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy ${_bin_dir}/${_crypto_lib_name} ${RV_STAGE_BIN_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy ${_bin_dir}/${_ssl_lib_name} ${RV_STAGE_BIN_DIR}


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
#717 
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

The custom command's OUTPUT was pointing at the `RV_STAGE_LIB_DIR`, however the copy commands below were copying the files to the `RV_STAGE_BIN_DIR` (`LIB` vs `BIN`), always resulting in a warning during build:

```
       "C:\OpenRV\_build\cmake\dependencies\dependencies.vcxproj" (default target) (1) ->
       "C:\OpenRV\_build\cmake\dependencies\RV_DEPS_OPENSSL-stage-target.vcxproj" (default target)
       (15) ->
       (CustomBuild target) ->
         C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsof
       t.CppCommon.targets(237,5): warning MSB8065: Custom build for item "C:\OpenRV\_build\CMakeFi
       les\d2708addcadbb8629f109d12d3d452c4\libcrypto-1_1-x64.dll.rule" succeeded, but specified ou
       tput "c:\openrv\_build\stage\app\lib\libcrypto-1_1-x64.dll" has not been created. This may c
       ause incremental build to work incorrectly. [C:\OpenRV\_build\cmake\dependencies\RV_DEPS_OPE
       NSSL-stage-target.vcxproj]
         C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsof
       t.CppCommon.targets(237,5): warning MSB8065: Custom build for item "C:\OpenRV\_build\CMakeFi
       les\d2708addcadbb8629f109d12d3d452c4\libcrypto-1_1-x64.dll.rule" succeeded, but specified ou
       tput "c:\openrv\_build\stage\app\lib\libssl-1_1-x64.dll" has not been created. This may caus
       e incremental build to work incorrectly. [C:\OpenRV\_build\cmake\dependencies\RV_DEPS_OPENSS
       L-stage-target.vcxproj]
```

### Describe the reason for the change.

To not get this warning anymore.

### Describe what you have tested and on which operating system.

On Windows, it doesn't show the warning anymore.

### Add a list of changes, and note any that might need special attention during the review.

NA

### If possible, provide screenshots.

NA