### PR TITLE
746: fix issue with with new OCIOIPNode optimisations and viewing in stack mode.

### DIFF
--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -569,14 +569,7 @@ namespace IPCore
 
             string shaderCacheID = gpuProcessor->getCacheID();
 
-            if (gpuProcessor->isNoOp())
-            {
-                if (m_state->function)
-                    m_state->function->retire();
-                m_state->function = 0;
-                m_state->shaderID = shaderCacheID = "";
-            }
-            else if (m_state->shaderID != shaderCacheID)
+            if (m_state->shaderID != shaderCacheID)
             {
                 if (m_state->function)
                     m_state->function->retire();


### PR DESCRIPTION
Fixes #746 

Removed the pass-through logic when the gpuProcessor->isNoOp() is true as it was causing issues when using annotations in stack mode and a raw display/view was selected.
