### PR TITLE
SG-38731: Update annotation tool's undo/redo and clear to match Live Review's behaviour

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -1205,8 +1205,34 @@ class: AnnotateMinorMode : MinorMode
             let u = getStringProperty(upropName),
                 r = getStringProperty(rpropName);
 
-            u.push_back(r.back());
-            r.resize(r.size()-1);
+            int startIndex = -1;
+            int endIndex = -1;
+
+            for (int i = 0; i < r.size(); i++)
+            {
+                if (r[i] == "start")
+                {
+                    startIndex = i;
+                }
+                if (r[i] == "end")
+                {
+                    endIndex = i;
+                }
+            }
+
+            if (r.size() >= 3 && startIndex != -1 && endIndex != -1)
+            {
+                for (int i = startIndex + 1; i < endIndex; i++)
+                {
+                    u.push_back(r[i]);
+                }
+                r.erase(startIndex, endIndex - startIndex + 1);
+            }
+            else
+            {
+                u.push_back(r.back());
+                r.resize(r.size() - 1);
+            }
 
             setStringProperty(upropName, u, true);
             setStringProperty(rpropName, r, true);
@@ -1226,9 +1252,14 @@ class: AnnotateMinorMode : MinorMode
             let u = getStringProperty(upropName),
                 r = getStringProperty(rpropName);
 
-            for (int i = u.size()-1; i >= 0; i--)
-                r.push_back(u[i]);
-            u.clear();
+            if (u.size() > 0)
+            {
+                r.push_back("start");
+                for (int i = 0; i < u.size(); i++)
+                    r.push_back(u[i]);
+                r.push_back("end");
+                u.clear();
+            }
 
             setStringProperty(upropName, u, true);
             setStringProperty(rpropName, r, true);


### PR DESCRIPTION
### [SG-38731](https://jira.autodesk.com/browse/SG-38731): Update annotation tool's undo/redo and clear to match Live Review's behaviour

### Summarize your change.

The keywords start and end were added as delimiters for a list of strokes cleared on the same frame in _clearPaint_. If the keywords are detected in _redoPaint_ all the strokes between the two words will be added to the undo stack and removed from the redo stack. Otherwise, only one stroke is added. Note that the keywords are not added to the undo stack since each stroke should be popped individually once that action is reached.

### Describe the reason for the change.

The current undo/redo implementation in the annotation tool needed to be updated to match the annotation behaviour in the Live Review plugin.

### Describe what you have tested and on which operating system.

The changes were tested on macOS.

### If possible, provide screenshots.

https://github.com/user-attachments/assets/dd8a1c4f-4667-486d-8c57-53a3a6cafce7
