### PR TITLE
Fix issue with CI - related to AQT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
         
       - name: Install Python dependencies
         run: |
@@ -289,7 +289,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
 
       - name: Patch Qt ${{ matrix.qt-version }}
         if: matrix.arch-type == 'x86_64'
@@ -521,7 +521,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
### Fix issue with CI - related to AQT

### Linked issues
n/a

### Summarize your change.
The old caches systems used by Github Actions were [decommissioned on the 15th of April](https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/) and that causes issue with AQT (Qt installer). Therefore, the  Qt packages are always downloaded currently, and it seems like there are issues with some modules downloaded from mirrors (e.g. checksum calculation).

I will try to update to the latest version of AQT and see if something was done. Otherwise, I might have to do something like this:
https://github.com/dpaulat/supercell-wx/commit/d34224c1351527097d5d24954906cf953769937d


### Describe the reason for the change.
Fix the CI