### PR TITLE
Feature/Qt6 - Small tweak of the audio logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
       
       - name: Install Qt ${{ matrix.qt-version }}
         if: ${{ matrix.vfx-platform == 'CY2024' }}
@@ -268,7 +268,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
         
       - name: Install Python dependencies
         run: |
@@ -432,7 +432,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
 
       - name: Install Qt ${{ matrix.qt-version }}
         if: matrix.vfx-platform == 'CY2024'
@@ -453,7 +453,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
 
       - name: Patch Qt ${{ matrix.qt-version }}
         if: matrix.arch-type == 'x86_64' && matrix.vfx-platform == 'CY2023'
@@ -724,7 +724,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
 
       - name: Install Qt ${{ matrix.qt-version }}
         if: ${{ matrix.vfx-platform == 'CY2024' }}
@@ -744,7 +744,7 @@ jobs:
           tools: 'tools_qtcreator'
           set-env: 'true'
           tools-only: 'false'
-          aqtversion: '==3.1.*'
+          aqtversion: '==3.2.*'
 
       - name: Install Python dependencies
         run: |

--- a/src/lib/audio/QTAudioRenderer/QTAudioRenderer.cpp
+++ b/src/lib/audio/QTAudioRenderer/QTAudioRenderer.cpp
@@ -462,9 +462,7 @@ namespace IPCore
         const AudioRenderer::DeviceState& state = deviceState();
 
         if (data && (m_audioRenderer.isPlaying())
-            && (maxLenInBytes >= m_bytesPerSample)
-            && ((m_audioOutput->state() == QAudio::ActiveState)
-                || (m_audioOutput->state() == QAudio::IdleState)))
+            && (maxLenInBytes >= m_bytesPerSample))
         {
             const int bufferSize = m_audioOutput->bufferSize();
 
@@ -782,8 +780,7 @@ namespace IPCore
 
     qint64 QTAudioIODevice::bytesAvailable() const
     {
-
-        return QIODevice::bytesAvailable();
+        return m_thread.audioOutput()->bufferSize() + QIODevice::bytesAvailable();
     }
 
     //----------------------------------------------------------------------
@@ -1055,13 +1052,15 @@ namespace IPCore
 
         if (AudioRenderer::debug)
         {
+            int periodSize = (int)bufferSize() / m_format.bytesPerFrame();
             TwkUtil::Log("QTAudioOutput")
                 << "play session:setup: startSample =" << m_thread.startSample()
                 << " shift=" << s->shift()
                 << " isPlaying=" << (int)s->isPlaying()
                 << " isScrubbingAudio=" << (int)s->isScrubbingAudio()
                 << " audioOutput state=" << (int)state()
-                << " audioOutput bufferSize=" << (int)bufferSize();
+                << " audioOutput bufferSize=" << (int)bufferSize()
+                << " audioOutput periodSize=" << (int)(periodSize);
         }
     }
 

--- a/src/lib/audio/QTAudioRenderer/QTAudioRenderer/QTAudioRenderer.h
+++ b/src/lib/audio/QTAudioRenderer/QTAudioRenderer/QTAudioRenderer.h
@@ -146,6 +146,8 @@ namespace IPCore
             return m_lastDeviceLatency;
         }
 
+        QTAudioOutput* audioOutput() const { return m_audioOutput; }
+
     protected:
         virtual void run();
 


### PR DESCRIPTION
### Feature/Qt6 - Small tweak of the audio logic

### Linked issues
n/a

### Summarize your change.
I removed the conditions to check the state of the QAudioSink object because it does not make sense in Qt 6. In Qt 6, when we call the `start `method on the QAudioSink object, The code starts transferring audio data from the device to the system's audio output right away and changes the device state afterwards (while in Qt 5, the state was changed first, and then the audio data was read). Therefore, it does not make sense to check the state in the `readData` callback because even if the state is STOPPED, we want to start reading the audio data.

The audio cache/processing seems to behave just like the main branch with those changes. I tested it on Windows and MacOS.


### Describe the reason for the change.
Fix audio on Windows and the new logic makes more sense based on how Qt 6 works now.

### Describe what you have tested and on which operating system.
Windows and MacOS