### PR TITLE
Use mirrors to download Qt and sha1 checksum

### DIFF
--- a/.github/configurations/aqt-settings.ini
+++ b/.github/configurations/aqt-settings.ini
@@ -1,0 +1,17 @@
+[aqt]
+# Using this mirror instead of download.qt.io because of timeouts in CI
+# Below is the default URL of the mirror
+# baseurl: https://download.qt.io
+baseurl: https://qt.mirror.constant.com
+
+[requests]
+# Mirrors require sha1 instead of sha256
+hash_algorithm: sha1
+
+[mirrors]
+trusted_mirrors:
+    https://qt.mirror.constant.com
+fallbacks:
+    https://qt.mirror.constant.com
+    https://mirrors.ocf.berkeley.edu
+    https://download.qt.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,11 @@ jobs:
           mkdir -p "${{ github.workspace }}/deps"
 
       - name: Install Qt ${{ matrix.qt-version }}
-        uses: jurplel/install-qt-action@v4
+        # uses: jurplel/install-qt-action@v4 (the original, but older)
+        uses: jdpurcell/install-qt-action@062a85c2e9d5b22d2ffbc0172bcb451eea924ffe # the fork
+        env:
+          # **NOTE** This should probably be changed once download.qt.io connectivity issues are fixed.
+          AQT_CONFIG: ${{ github.workspace }}/.github/configurations/aqt-settings.ini
         with:
           version: '${{ matrix.qt-version }}'
           host: 'linux'
@@ -270,10 +274,16 @@ jobs:
       - name: Prepare Qt folder
         run: |
           mkdir -p "${{ github.workspace }}/deps"
+          ls -al ${{ github.workspace }}
+          ls -al ${{ github.workspace }}/.github/configurations
 
       - name: Install Qt ${{ matrix.qt-version }}
         if: matrix.arch-type == 'x86_64'
-        uses: jurplel/install-qt-action@v4
+        # uses: jurplel/install-qt-action@v4 (the original, but older)
+        uses: jdpurcell/install-qt-action@062a85c2e9d5b22d2ffbc0172bcb451eea924ffe # the fork
+        env:
+          # **NOTE** This should probably be changed once download.qt.io connectivity issues are fixed.
+          AQT_CONFIG: ${{ github.workspace }}/.github/configurations/aqt-settings.ini
         with:
           version: '${{ matrix.qt-version }}'
           host: 'mac'
@@ -505,7 +515,11 @@ jobs:
         shell: msys2 {0}
 
       - name: Install Qt ${{ matrix.qt-version }}
-        uses: jurplel/install-qt-action@v4
+        # uses: jurplel/install-qt-action@v4 (the original, but older)
+        uses: jdpurcell/install-qt-action@062a85c2e9d5b22d2ffbc0172bcb451eea924ffe # the fork
+        env:
+          # **NOTE** This should probably be changed once download.qt.io connectivity issues are fixed.
+          AQT_CONFIG: ${{ github.workspace }}/.github/configurations/aqt-settings.ini
         with:
           version: '${{ matrix.qt-version }}'
           host: 'windows'


### PR DESCRIPTION
### Use mirrors to download Qt and sha1 checksum

### Linked issues
n/a

### Summarize your change.
Added a setting file for AQT which tells AQT to use mirrors first for download and use sha1 checksum since mirrors uses sha1.

### Describe the reason for the change.
This PR fixes the issues with the CI because download.qt.io has connectivity issues since yesterday.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.