### PR TITLE
Finalize port of QTabletEvent to Qt6 and fix tablet eraser issue

### DIFF
--- a/src/lib/app/RvCommon/QTTranslator.cpp
+++ b/src/lib/app/RvCommon/QTTranslator.cpp
@@ -1084,39 +1084,27 @@ namespace Rv
         const int ytilt = event->yTilt();
         const int z = event->z();
 
-        TabletEvent::TabletKind kind;
-        TabletEvent::TabletDevice device;
-
         string n;
-
-        // NOTE_QT: There is no equivalent to QTabletEvent::FourDMouse. Might
-        // need custom class or use generic mouse type.
 
 #if defined(RV_VFX_CY2023)
         switch (event->deviceType())
         {
         case QTabletEvent::NoDevice:
-            device = TabletEvent::NoTableDevice;
             n = "generic-tablet-device-";
             break;
         case QTabletEvent::Puck:
-            device = TabletEvent::PuckDevice;
             n = "puck-";
             break;
         case QTabletEvent::Stylus:
-            device = TabletEvent::StylusDevice;
             n = "stylus-";
             break;
         case QTabletEvent::Airbrush:
-            device = TabletEvent::AirBrushDevice;
             n = "airbrush-";
             break;
         case QTabletEvent::FourDMouse:
-            device = TabletEvent::FourDMouseDevice;
             n = "mouse4D-";
             break;
         case QTabletEvent::RotationStylus:
-            device = TabletEvent::RotationStylusDevice;
             n = "rotating-stylus-";
             break;
         default:
@@ -1126,70 +1114,73 @@ namespace Rv
         switch (event->pointerType())
         {
         case QTabletEvent::UnknownPointer:
-            kind = TabletEvent::UnknownTabletKind;
             break;
         case QTabletEvent::Pen:
-            kind = TabletEvent::PenKind;
             n += "pen-";
             break;
         case QTabletEvent::Cursor:
-            kind = TabletEvent::CursorKind;
             n += "cursor-";
             break;
         case QTabletEvent::Eraser:
-            kind = TabletEvent::EraserKind;
             n += "eraser-";
             break;
         }
 #else
+
+        // Note: In Qt6, QTabletEvent::FourDMouse and QTabletEvent::RotationStylus have been removed
+        // and replaced with QInputDevice::DeviceType::Puck and QInputDevice::DeviceType::Stylus respectively.
+
         switch (event->deviceType())
         {
         case QInputDevice::DeviceType::Unknown:
-            device = TabletEvent::NoTableDevice;
             n = "generic-tablet-device-";
             break;
-        case QInputDevice::DeviceType::Puck:
-            device = TabletEvent::PuckDevice;
-            n = "puck-";
+        case QInputDevice::DeviceType::Mouse:
+            n = "mouse-";
+            break;
+        case QInputDevice::DeviceType::TouchScreen:
+            n = "touchscreen-";
+            break;
+        case QInputDevice::DeviceType::TouchPad:
+            n = "touchpad-";
             break;
         case QInputDevice::DeviceType::Stylus:
-            device = TabletEvent::StylusDevice;
             n = "stylus-";
             break;
         case QInputDevice::DeviceType::Airbrush:
-            device = TabletEvent::AirBrushDevice;
             n = "airbrush-";
             break;
-            // TODO_QT: FourDMouse is not available anymore.
-            //   case QInputDevice::DeviceType::Mouse:
-            //       device = TabletEvent::FourDMouseDevice;
-            //       n = "mouse4D-";
-            //       break;
-            // TODO_QT: RotationStylus is not available anymore.
-            //   case QTabletEvent::RotationStylus:
-            //       device = TabletEvent::RotationStylusDevice;
-            //       n = "rotating-stylus-";
-            //       break;
+        case QInputDevice::DeviceType::Puck:
+            n = "puck-";
+            break;
+        case QInputDevice::DeviceType::Keyboard:
+            n = "keyboard-";
+            break;
+        case QInputDevice::DeviceType::AllDevices:
         default:
             break;
         }
 
         switch (event->pointerType())
         {
-        case QPointingDevice::PointerType::Unknown:
-            kind = TabletEvent::UnknownTabletKind;
+        case QPointingDevice::PointerType::Generic:
+            n += "generic-";
+            break;
+        case QPointingDevice::PointerType::Finger:
+            n += "finger-";
             break;
         case QPointingDevice::PointerType::Pen:
-            kind = TabletEvent::PenKind;
             n += "pen-";
             break;
+        case QPointingDevice::PointerType::Eraser:
+            n += "eraser-";
+            break;
         case QPointingDevice::PointerType::Cursor:
-            kind = TabletEvent::CursorKind;
             n += "cursor-";
             break;
-        case QPointingDevice::PointerType::Eraser:
-            kind = TabletEvent::EraserKind;
-            n += "eraser-";
+        case QPointingDevice::PointerType::Unknown:
+        case QPointingDevice::PointerType::AllPointerTypes:
+        default:
             break;
         }
 #endif
@@ -1228,8 +1219,7 @@ namespace Rv
         }
 
         TabletEvent e(n, m_node, modifiers(mods), m_x, m_y, m_width, m_height,
-                      // m_lastx, m_lasty,
-                      m_pushx, m_pushy, buttons(), kind, device, gx, gy,
+                      m_pushx, m_pushy, buttons(), gx, gy,
                       pressure, tpressure, rot, xtilt, ytilt, z);
 
         sendEvent(e);

--- a/src/lib/app/TwkApp/TwkApp/Event.h
+++ b/src/lib/app/TwkApp/TwkApp/Event.h
@@ -693,34 +693,14 @@ namespace TwkApp
     class TabletEvent : public PointerEvent
     {
     public:
-        enum TabletKind
-        {
-            UnknownTabletKind,
-            PenKind,
-            CursorKind,
-            EraserKind
-        };
-
-        enum TabletDevice
-        {
-            NoTableDevice,
-            PuckDevice,
-            StylusDevice,
-            AirBrushDevice,
-            FourDMouseDevice,
-            RotationStylusDevice
-        };
 
         TabletEvent(const std::string& name, const EventNode* sender,
                     unsigned int modifiers, int x, int y, int w, int h, int ox,
-                    int oy, unsigned int buttonStates, TabletKind kind,
-                    TabletDevice device, double gx, double gy, double pres,
+                    int oy, unsigned int buttonStates, double gx, double gy, double pres,
                     double tpres, double rot, int xtilt, int ytilt, int z = 0,
                     void* data = 0)
             : PointerEvent(name, sender, modifiers, x, y, w, h, ox, oy,
                            buttonStates, data)
-            , _kind(kind)
-            , _device(device)
             , _xFloat(gx)
             , _yFloat(gy)
             , _pressure(pres)
@@ -749,8 +729,6 @@ namespace TwkApp
         int z() const { return _z; }
 
     private:
-        TabletKind _kind;
-        TabletDevice _device;
         double _xFloat;
         double _yFloat;
         double _pressure;

--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -657,6 +657,15 @@ class: AnnotateMinorMode : MinorMode
     method: eraserPush (void; Event event)
     {
         updateCurrentNode();
+
+        // Save the current draw mode so we can restore it when we are done 
+        // erasing as long as it is not the eraser mode itself which could
+        // happen when pushing the eraser more than once
+        if (_currentDrawMode.name != _currentDrawMode.eraserMode.name)
+        {
+            _currentDrawMode.eraserMode.penMode = _currentDrawMode;
+        }
+
         _currentDrawMode = _currentDrawMode.eraserMode;
         updateDrawModeUI();
         push(event);


### PR DESCRIPTION
### Finalize port of QTabletEvent to Qt6 and fix tablet eraser issue

### Linked issues

NA

### Describe the reason for the change.

@cedrik-fuoco-adsk had already did the bulk of the work to port the QTTranslator from Qt5 to Qt6 but the QTabletEvent needed some attention because of the Qt6 refactoring with respect to its events handling.

### Summarize your change.

**TabletDevice and TabletKind were removed**

Rationale:
In RV, when handling a table event, we used to record the TabletDevice (ie stylus) and the TabletKind (ie pen or eraser) in the RV's TableEvent class.
In Qt6, QTabletEvent::FourDMouse and QTabletEvent::RotationStylus have been removed and replaced with QInputDevice::DeviceType::Puck and QInputDevice::DeviceType::Stylus respectively. 
So technically we would have had to create Qt version specific enums of TabletDevice and TabletKind.
However, they were NOT used anywhere. Note that the important part is the name of the event like for example "stylus-pen--drag". This is what packages such as annotation_mode.mu use to act on tablet events.
By getting rid of TabletDevice and TabletKind altogether in the RV codebase, we were able to minimize the differences between Qt5 and Qt6 with respect to Tablet Events.

**Added all the Qt6 supported in options for tablet device type and tablet pointer type**

Also in this commit:

**Fixed a legacy issue when using a tablet's stylus eraser and going pack to the pen:** 
When using the eraser, the code was correctly switching to the eraser mode but when the user was selecting the pen again, it was not automatically switching to the pen mode, it was still erasing. 

### Describe what you have tested and on which operating system.

Successfully tested on macOS with a Wacom Intuos tablet

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.