### PR TITLE
Fix icons not showing up in the RvFileDialog on Windows (compared to Qt5)

### DIFF
--- a/src/lib/app/RvCommon/FileTypeTraits.cpp
+++ b/src/lib/app/RvCommon/FileTypeTraits.cpp
@@ -121,7 +121,9 @@ namespace Rv
             return provider.icon(QFileIconProvider::Folder);
         }
 
-#if defined(RV_VFX_CY2024)
+    
+#ifndef PLATFORM_WINDOWS
+    #if defined(RV_VFX_CY2024)
         // Adding more heuristics to find the right icon for a file based on the
         // MIME type. The following heuristics should work for Qt 5, but in
         // order to keep the same behavior as before, this code will only run
@@ -134,13 +136,18 @@ namespace Rv
         // be image-png)
         QIcon icon = QIcon::fromTheme(mime.iconName());
         if (!icon.isNull())
+        {
             return icon;
+        }
 
         // Search for an icon based on the MIME generic type. (e.g. for a PNG,
         // it would be image-x-generic)
         icon = QIcon::fromTheme(mime.genericIconName());
         if (!icon.isNull())
+        {
             return icon;
+        }
+    #endif
 #endif
 
         return provider.icon(info);

--- a/src/lib/app/RvCommon/RvFileDialog.cpp
+++ b/src/lib/app/RvCommon/RvFileDialog.cpp
@@ -21,6 +21,9 @@
 #include <TwkUtil/PathConform.h>
 #include <iostream>
 #include <stl_ext/string_algo.h>
+#if defined(RV_VFX_CY2024)
+#include <QStyledItemDelegate>
+#endif
 #include <QtCore/QDir>
 #include <QtCore/QSet>
 #include <QtGui/QtGui>
@@ -60,6 +63,52 @@ namespace Rv
     //----------------------------------------------------------------------
 
     //----------------------------------------------------------------------
+
+#if defined(RV_VFX_CY2024)
+#ifdef PLATFORM_WINDOWS
+    // On Windows, there is an issue with the default delegate for QTreeView and the option to alternate 
+    // the background color of the rows. The issue is that the background is painted on top of the icon, 
+    // which is not the expected behavior. The workaround is to use a custom deletegate to make sure 
+    // that the background of the row is painted BEFORE the icon.
+    class RvFileDelegate : public QStyledItemDelegate
+    {
+        public:
+            using QStyledItemDelegate::QStyledItemDelegate;
+
+            void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
+            {
+                QStyleOptionViewItem opt = option;
+                initStyleOption(&opt, index);
+
+                QStyle* style = opt.widget ? opt.widget->style() : QApplication::style();
+
+                // The first thing to paint is the background.
+                style->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter, opt.widget);
+
+                // Draw the highlight if the item is selected.
+                if (opt.state & QStyle::State_Selected)
+                {
+                    painter->fillRect(opt.rect, opt.palette.highlight());
+                }
+                
+                // After the background, the icon should be painted.
+                QVariant decoration = index.data(Qt::DecorationRole);
+                QRect iconRect = style->subElementRect(QStyle::SE_ItemViewItemDecoration, &opt, opt.widget);
+                if (decoration.canConvert<QIcon>())
+                {
+                    QIcon icon = qvariant_cast<QIcon>(decoration);
+                    icon.paint(painter, iconRect, Qt::AlignCenter, QIcon::Normal, QIcon::On);
+                }
+
+                // Once the background and icon are painted, we can draw the text.
+                QString text = index.data(Qt::DisplayRole).toString();
+                QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &opt, opt.widget);
+                painter->setPen(opt.palette.color((opt.state & QStyle::State_Selected) ? QPalette::HighlightedText : QPalette::Text));
+                painter->drawText(textRect, opt.displayAlignment, text);
+            }
+    };
+#endif 
+#endif
 
     RvFileDialog::RvFileDialog(QWidget* parent, FileTypeTraits* traits,
                                Role role, Qt::WindowFlags flags,
@@ -242,6 +291,12 @@ namespace Rv
         m_detailMediaModel->setShowHiddenFiles(showHiddenFiles);
         m_detailFileModel->setShowHiddenFiles(showHiddenFiles);
         m_columnModel->setShowHiddenFiles(showHiddenFiles);
+
+#if defined(RV_VFX_CY2024)
+#ifdef PLATFORM_WINDOWS
+        m_detailTree->setItemDelegate(new RvFileDelegate(m_detailTree));
+#endif
+#endif
 
         m_ui.viewStack->addWidget(m_columnView);
         m_ui.viewStack->addWidget(m_detailTree);


### PR DESCRIPTION
### Feature/qt6 - Fix icons not showing up in the RvFileDialog (compared to Qt5)

**Note that I've re-created that PR since Qt 6 branch is now part of the main branch.**

### Linked issues
n/a

### Summarize your change.
On Windows, I added a custom delegate for the QTreeView because it seems there is an issue (or changes in Qt 6) with the `alternatingRowColors` options in Qt 6's `QAbstractItemView`. The alternating background is painted **over** the icon which results in the _missing_ icons.

The custom delegate paints the elements in this order: 
1. Background
2. Highlights
3. Icon
4. Text

### Describe the reason for the change.
After comparing the RvFileDialog between the Qt 5 and Qt 6 version of RV, the icons were still missing on Windows.

### Describe what you have tested and on which operating system.
Windows

### If possible, provide screenshots.
![image](https://github.com/user-attachments/assets/1bc7edc0-4817-4fc4-a567-a63c0290052a)
