### PR TITLE
Bump to OpenRV 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.27)
 
 # These variables are parsed by sphinx for the documentation. One-line formatting facilitates parsing and readability.
 # cmake-format: off
-SET(RV_MAJOR_VERSION "2" CACHE STRING "RV's version major")
-SET(RV_MINOR_VERSION "2" CACHE STRING "RV's version minor")
+SET(RV_MAJOR_VERSION "3" CACHE STRING "RV's version major")
+SET(RV_MINOR_VERSION "0" CACHE STRING "RV's version minor")
 SET(RV_REVISION_NUMBER "0" CACHE STRING "RV's revision number")
 SET(RV_VERSION_YEAR "2025" CACHE STRING "RV's year of release.")
 # cmake-format: on


### PR DESCRIPTION
### Bump to OpenRV 3

### Linked issues
n/a

### Summarize your change.
Bump OpenRV to version 3.

### Describe the reason for the change.
Since feature/qt6 is now merged into main, let's bump OpenRV version to 3.