### PR TITLE
Qt6: Disable stereo shutter glass support 

### DIFF
--- a/src/lib/app/RvCommon/RvCommon/RvTopViewToolBar.h
+++ b/src/lib/app/RvCommon/RvCommon/RvTopViewToolBar.h
@@ -157,7 +157,10 @@ namespace Rv
         QAction* m_scanlineStereoAction;
         QAction* m_leftStereoAction;
         QAction* m_rightStereoAction;
-        QAction* m_shutterStereoAction;
+        // Shutter mode gone since Qt6/QOpenGLWidget. No customer
+        // demand for it. Maybe fix & re-enable if customers demand it and
+        // leaving existing code in case customers want to revive it.
+        // QAction* m_shutterStereoAction;
         QAction* m_swapStereoAction;
         QActionVector m_stereoActions;
         QAction* m_channelMenuAction;

--- a/src/lib/app/RvCommon/RvCommon/RvTopViewToolBar.h
+++ b/src/lib/app/RvCommon/RvCommon/RvTopViewToolBar.h
@@ -94,7 +94,7 @@ namespace Rv
         void scanlineStereo();
         void leftStereo();
         void rightStereo();
-        void shutterStereo();
+        // void shutterStereo();
         void swapEyes();
 
         void channelMenuUpdate();

--- a/src/lib/app/RvCommon/RvPreferences.cpp
+++ b/src/lib/app/RvCommon/RvPreferences.cpp
@@ -90,7 +90,7 @@ namespace Rv
     static const char* StereoRight = "right";
     static const char* StereoChecker = "checker";
     static const char* StereoScanline = "scanline";
-    static const char* StereoHardware = "hardware";
+    // static const char* StereoHardware = "hardware";
     static const char* Solid0 = "black";
     static const char* Solid18 = "grey18";
     static const char* Solid50 = "grey50";
@@ -539,10 +539,10 @@ namespace Rv
                 n = 6;
             else if (s == StereoScanline)
                 n = 7;
-            else if (s == StereoHardware)
-                n = 8;
+            //            else if (s == StereoHardware)
+            //                n = 8;
             else if (s == StereoLumAnaglyph)
-                n = 9;
+                n = 8;
         }
 
         m_ui.stereoModeCombo->setCurrentIndex(n);
@@ -1040,8 +1040,8 @@ namespace Rv
             opts.stereoMode = (char*)StereoChecker;
         if (s == StereoScanline)
             opts.stereoMode = (char*)StereoScanline;
-        if (s == StereoHardware)
-            opts.stereoMode = (char*)StereoHardware;
+        //        if (s == StereoHardware)
+        //            opts.stereoMode = (char*)StereoHardware;
         if (s == StereoLeft)
             opts.stereoMode = (char*)StereoLeft;
         if (s == StereoRight)
@@ -1461,10 +1461,10 @@ namespace Rv
         case 7:
             stereo = (char*)StereoScanline;
             break;
+            //        case 8:
+            //            stereo = (char*)StereoHardware;
+            //            break;
         case 8:
-            stereo = (char*)StereoHardware;
-            break;
-        case 9:
             stereo = (char*)StereoLumAnaglyph;
             break;
         }

--- a/src/lib/app/RvCommon/RvTopViewToolBar.cpp
+++ b/src/lib/app/RvCommon/RvTopViewToolBar.cpp
@@ -231,7 +231,7 @@ namespace Rv
         m_scanlineStereoAction = m->addAction("  Scanline");
         m_leftStereoAction = m->addAction("  Left Only");
         m_rightStereoAction = m->addAction("  Right Only");
-        m_shutterStereoAction = m->addAction("  Shutter");
+        // m_shutterStereoAction = m->addAction("  Shutter");
         m_monoStereoAction->setCheckable(true);
         m_anaglyphStereoAction->setCheckable(true);
         m_lumanaglyphStereoAction->setCheckable(true);
@@ -241,7 +241,7 @@ namespace Rv
         m_scanlineStereoAction->setCheckable(true);
         m_leftStereoAction->setCheckable(true);
         m_rightStereoAction->setCheckable(true);
-        m_shutterStereoAction->setCheckable(true);
+        // m_shutterStereoAction->setCheckable(true);
         m_monoStereoAction->setData(QString("off"));
         m_anaglyphStereoAction->setData(QString("anaglyph"));
         m_lumanaglyphStereoAction->setData(QString("lumanaglyph"));
@@ -251,7 +251,7 @@ namespace Rv
         m_scanlineStereoAction->setData(QString("scanline"));
         m_leftStereoAction->setData(QString("left"));
         m_rightStereoAction->setData(QString("right"));
-        m_shutterStereoAction->setData(QString("hardware"));
+        //        m_shutterStereoAction->setData(QString("hardware"));
         m->addSeparator();
         m_swapStereoAction = m->addAction("Swap Eyes");
         m_swapStereoAction->setCheckable(true);
@@ -268,7 +268,7 @@ namespace Rv
         m_stereoActions.push_back(m_scanlineStereoAction);
         m_stereoActions.push_back(m_leftStereoAction);
         m_stereoActions.push_back(m_rightStereoAction);
-        m_stereoActions.push_back(m_shutterStereoAction);
+        // m_stereoActions.push_back(m_shutterStereoAction);
 
         connect(m, SIGNAL(aboutToShow()), this, SLOT(stereoMenuUpdate()));
         connect(m_monoStereoAction, SIGNAL(triggered()), this,
@@ -289,8 +289,8 @@ namespace Rv
                 SLOT(leftStereo()));
         connect(m_rightStereoAction, SIGNAL(triggered()), this,
                 SLOT(rightStereo()));
-        connect(m_shutterStereoAction, SIGNAL(triggered()), this,
-                SLOT(shutterStereo()));
+        // connect(m_shutterStereoAction, SIGNAL(triggered()), this,
+        //         SLOT(shutterStereo()));
         connect(m_swapStereoAction, SIGNAL(triggered()), this,
                 SLOT(swapEyes()));
 
@@ -880,7 +880,7 @@ namespace Rv
 
     void RvTopViewToolBar::rightStereo() { setStereo("right"); }
 
-    void RvTopViewToolBar::shutterStereo() { setStereo("hardware"); }
+    // void RvTopViewToolBar::shutterStereo() { setStereo("hardware"); }
 
     void RvTopViewToolBar::swapEyes()
     {


### PR DESCRIPTION
### Summarize your change.

Hardware Stereo Shutter mode gone since Qt6/QOpenGLWidget. 
(eg: nvidia glasses circa 2011)

### Describe the reason for the change.

There is apparently no customer demand for it, and review of stereo footage is apparently done using other methods regardless. We're leaving existing code in case customers want to revive it.

### Describe what you have tested and on which operating system.

Tested on macOS,  simply commented out the few lines of code required to make this option available in the UI. Most of the code to enable the feature is found in DisplayStereoIPNode, which we have not touched.

### Add a list of changes, and note any that might need special attention during the review.

n/a

### If possible, provide screenshots.