### PR TITLE
Add basic difference compare mode to Live Review.

### DIFF
--- a/src/plugins/rv-packages/otio_reader/compare_hook.py
+++ b/src/plugins/rv-packages/otio_reader/compare_hook.py
@@ -34,7 +34,14 @@ def hook_function(
             )
 
         case "difference":
-            pass
+            sequence_group = argument_map["sequence"]
+            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[
+                0
+            ]
+            composite_property = f"{sequence}.composite"
+            effectHook.set_rv_effect_props(
+                composite_property, {"inputBlendModes": ["difference"]}
+            )
 
         case "angular_mask":
             angle_in_radians = in_timeline.angular_mask["angle_in_radians"]


### PR DESCRIPTION
### Summarize your change.

This PR adds basic difference compare mode to Live Review. It works in conjunction with live_review.py in Commercial RV.

For now, we implement difference and reverse-difference modes; however what we really need is absolute difference. However, this requires more important changes in both the online LiveReview site and RV itself; so for now we do what we can to support this mode.  This issue will be revisited once LiveReview has time to address this issue on their side.

### Describe the reason for the change.

Users want to be able to see differences when comparing clips during a live review compare session.


### Describe what you have tested and on which operating system.

On macOS. For the LiveReview site, used Chrome/Firefox. (Safari has an issue with the difference blend mode, which still needs to be addressed)

### Add a list of changes, and note any that might need special attention during the review.

Really nothing special here. 

### If possible, provide screenshots.