### PR TITLE
Fix regression because getStringProperty(name) may throw exception

### DIFF
--- a/src/lib/app/mu_rvui/extra_commands.mu
+++ b/src/lib/app/mu_rvui/extra_commands.mu
@@ -809,14 +809,8 @@ Return list of node names in the given group, with type equal to the given type.
         node  = if group eq nil then innode else group,
         name  = "%s.ui.name" % node;
 
-    let prop = getStringProperty(name);
-
-    if (!prop.empty())
-        return prop.front();
-    
-    return node;
+    return if propertyExists(name) then getStringProperty(name).front() else node;
 }
-
 
 \: isViewNode (bool; string name)
 {


### PR DESCRIPTION
### Summarize your change.

Fixes #38915, a small regression I introduced. where getStringProperty() may throw an exception if the property does not exist. That particular small change in my other PR was actually not quite needed anyway, since we changed the ui name dupe check algorithm which went from O(n^2-or-3) to O(n log(n)).

### Describe the reason for the change.

This was a regression in the automated tests. I just added the old code back.

### Describe what you have tested and on which operating system.

macOS. I just added back the old mu code.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.