### PR TITLE
Fix typo in Stereo Disassembly rv package name changed from "Stereo Disassmbly"

### DIFF
--- a/src/plugins/rv-packages/stereo_disassembly/PACKAGE
+++ b/src/plugins/rv-packages/stereo_disassembly/PACKAGE
@@ -1,4 +1,4 @@
-package: Stereo Disassmbly
+package: Stereo Disassembly
 author: Autodesk, Inc.
 organization: Autodesk, Inc.
 version: 1.3
@@ -48,7 +48,7 @@ description: |
   <div class="paragraph"><p>Four menu items provide access to various functions of the package:</p></div>
   <div class="sect3">
   <h4 id="_em_image_stereo_disassembly_add_disassembly_node_em"><em>Image/Stereo/Disassembly-Add Disassembly Node</em></h4>
-  <div class="paragraph"><p>Selecting this menu item will cause RV to examine the currently visible sources, and for each, if it does not already have a StereoDisassmbly node, add one.  Note that the node will be added "internally" (in the RVLinearizePipelineGroup within the Source), so the new node will not be visible in the Session manager, and any view using this Source will see the result of the "disassembly".</p></div>
+  <div class="paragraph"><p>Selecting this menu item will cause RV to examine the currently visible sources, and for each, if it does not already have a StereoDisassembly node, add one.  Note that the node will be added "internally" (in the RVLinearizePipelineGroup within the Source), so the new node will not be visible in the Session manager, and any view using this Source will see the result of the "disassembly".</p></div>
   </div>
   <div class="sect3">
   <h4 id="_em_image_stereo_disassembly_remove_disassembly_node_em"><em>Image/Stereo/Disassembly-Remove Disassembly Node</em></h4>

--- a/src/plugins/rv-packages/stereo_disassembly/stereo_disassembly_help.asciidoc
+++ b/src/plugins/rv-packages/stereo_disassembly/stereo_disassembly_help.asciidoc
@@ -25,7 +25,7 @@ This experimental package enables you to load stereo media with both eyes in the
 Four menu items provide access to various functions of the package:
 
 ==== 'Image/Stereo/Disassembly-Add Disassembly Node' ====
-Selecting this menu item will cause RV to examine the currently visible sources, and for each, if it does not already have a StereoDisassmbly node, add one.  Note that the node will be added "internally" (in the RVLinearizePipelineGroup within the Source), so the new node will not be visible in the Session Manager, and any view using this Source will see the result of the "disassembly".
+Selecting this menu item will cause RV to examine the currently visible sources, and for each, if it does not already have a StereoDisassembly node, add one.  Note that the node will be added "internally" (in the RVLinearizePipelineGroup within the Source), so the new node will not be visible in the Session Manager, and any view using this Source will see the result of the "disassembly".
 
 ==== 'Image/Stereo/Disassembly-Remove Disassembly Node' ====
 Remove StereoDisassembly nodes from all visible sources.

--- a/src/plugins/rv-packages/stereo_disassembly/stereo_disassembly_help.html
+++ b/src/plugins/rv-packages/stereo_disassembly/stereo_disassembly_help.html
@@ -612,7 +612,7 @@ asciidoc.install();
 <div class="paragraph"><p>Four menu items provide access to various functions of the package:</p></div>
 <div class="sect3">
 <h4 id="_em_image_stereo_disassembly_add_disassembly_node_em"><em>Image/Stereo/Disassembly-Add Disassembly Node</em></h4>
-<div class="paragraph"><p>Selecting this menu item will cause RV to examine the currently visible sources, and for each, if it does not already have a StereoDisassmbly node, add one.  Note that the node will be added "internally" (in the RVLinearizePipelineGroup within the Source), so the new node will not be visible in the Session Manager, and any view using this Source will see the result of the "disassembly".</p></div>
+<div class="paragraph"><p>Selecting this menu item will cause RV to examine the currently visible sources, and for each, if it does not already have a StereoDisassembly node, add one.  Note that the node will be added "internally" (in the RVLinearizePipelineGroup within the Source), so the new node will not be visible in the Session Manager, and any view using this Source will see the result of the "disassembly".</p></div>
 </div>
 <div class="sect3">
 <h4 id="_em_image_stereo_disassembly_remove_disassembly_node_em"><em>Image/Stereo/Disassembly-Remove Disassembly Node</em></h4>


### PR DESCRIPTION
### Summarize your change.
While scanning the packages, I came across this type and did a code base scan of the instances of this typo and updated the affected files.

### Describe the reason for the change.
To make it clearer to search for the associated files related to this package

### Describe what you have tested and on which operating system.
Windows 11 build from latest main branch

### Add a list of changes, and note any that might need special attention during the review.
`src/plugins/rv-packages/stereo_disassembly/PACKAGE` : 1,51
`src/plugins/rv-packages/stereo_disassembly/stereo_disassembly_help.asciidoc` : 28
`src/plugins/rv-packages/stereo_disassembly/stereo_disassembly_help.html` : 615 