### PR TITLE
Fix build when using latest Xcode 16.3-clang 17

### DIFF
--- a/cmake/dependencies/boost.cmake
+++ b/cmake/dependencies/boost.cmake
@@ -4,79 +4,67 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# IMPORTANT: CMake minimum version need to be increased everytime Boost version is increased.
-#            e.g. CMake 3.27 is needed for Boost 1.82 to be found by FindBoost.cmake.
+# IMPORTANT: CMake minimum version need to be increased everytime Boost version is increased. e.g. CMake 3.27 is needed for Boost 1.82 to be found by
+# FindBoost.cmake.
 #
-#            Starting from CMake 3.30, FindBoost.cmake has been removed in favor of BoostConfig.cmake (Boost 1.70+).
-#            This behavior is covered by CMake policy CMP0167.
+# Starting from CMake 3.30, FindBoost.cmake has been removed in favor of BoostConfig.cmake (Boost 1.70+). This behavior is covered by CMake policy CMP0167.
 
 INCLUDE(ProcessorCount) # require CMake 3.15+
 PROCESSORCOUNT(_cpu_count)
 
-# Note: Boost 1.80 cannot be built with XCode 15 which is now the only XCode version available on macOS Sonoma without a hack. 
-# Boost 1.81+ has all the fixes required to be able to be built with XCode 15, however it is not VFX Platform CY2023 compliant which specifies Boost version 1.80. 
-# With the aim of making the OpenRV build on macOS smoother by default, OpenRV will use Boost 1.81 if XCode 15 or more recent.
-IF(RV_TARGET_DARWIN)
-  EXECUTE_PROCESS(
-    COMMAND xcrun clang --version
-    OUTPUT_VARIABLE CLANG_FULL_VERSION_STRING
-  )
-  STRING(
-    REGEX
-    REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${CLANG_FULL_VERSION_STRING}
-  )
-  IF(CLANG_VERSION_STRING VERSION_GREATER_EQUAL 15.0)
-    MESSAGE(STATUS "Clang version ${CLANG_VERSION_STRING} is not compatible with Boost 1.80, using Boost 1.81 instead. "
-                   "Install XCode 14.3.1 if you absolutely want to use Boost version 1.80 as per VFX reference platform CY2023"
+IF(RV_VFX_PLATFORM STREQUAL CY2023)
+  # Note: Boost 1.80 cannot be built with XCode 15 which is now the only XCode version available on macOS Sonoma without a hack. Boost 1.81+ has all the fixes
+  # required to be able to be built with XCode 15, however it is not VFX Platform CY2023 compliant which specifies Boost version 1.80. With the aim of making
+  # the OpenRV build on macOS smoother by default, OpenRV will use Boost 1.81 if XCode 15 or more recent.
+  IF(RV_TARGET_DARWIN)
+    EXECUTE_PROCESS(
+      COMMAND xcrun clang --version
+      OUTPUT_VARIABLE CLANG_FULL_VERSION_STRING
     )
-    SET(_BOOST_DETECTED_XCODE_15_ ON)
+    STRING(
+      REGEX
+      REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1" CLANG_VERSION_STRING ${CLANG_FULL_VERSION_STRING}
+    )
+    IF(CLANG_VERSION_STRING VERSION_GREATER_EQUAL 15.0)
+      MESSAGE(STATUS "Clang version ${CLANG_VERSION_STRING} is not compatible with Boost 1.80, using Boost 1.81 instead. "
+                     "Install XCode 14.3.1 if you absolutely want to use Boost version 1.80 as per VFX reference platform CY2023"
+      )
+      SET(_BOOST_DETECTED_XCODE_15_
+          ON
+      )
+    ENDIF()
   ENDIF()
 ENDIF()
 
 # Set some variables for VFX2024 since those value are used at two locations.
-SET(_BOOST_VFX2024_VERSION_ "1.82.0")
-SET(_BOOST_VFX2024_MAJOR_MINOR_VERSION_ "1_82")
-SET(_BOOST_VFX2024_DOWNLOAD_HASH_ "f7050f554a65f6a42ece221eaeec1660")
+SET(_BOOST_VFX2024_VERSION_
+    "1.82.0"
+)
+SET(_BOOST_VFX2024_MAJOR_MINOR_VERSION_
+    "1_82"
+)
+SET(_BOOST_VFX2024_DOWNLOAD_HASH_
+    "f7050f554a65f6a42ece221eaeec1660"
+)
 
-IF (NOT _BOOST_DETECTED_XCODE_15_)
+IF(NOT _BOOST_DETECTED_XCODE_15_)
   # XCode 14 and below.
-  RV_VFX_SET_VARIABLE(
-    _ext_boost_version
-    CY2023 "1.80.0"
-    CY2024 "${_BOOST_VFX2024_VERSION_}"
-  )
+  RV_VFX_SET_VARIABLE(_ext_boost_version CY2023 "1.80.0" CY2024 "${_BOOST_VFX2024_VERSION_}")
 
-  RV_VFX_SET_VARIABLE(
-    _major_minor_version
-    CY2023 "1_80"
-    CY2024 "${_BOOST_VFX2024_MAJOR_MINOR_VERSION_}"
-  )
+  RV_VFX_SET_VARIABLE(_major_minor_version CY2023 "1_80" CY2024 "${_BOOST_VFX2024_MAJOR_MINOR_VERSION_}")
 
-  RV_VFX_SET_VARIABLE(
-    _download_hash
-    CY2023 "077f074743ea7b0cb49c6ed43953ae95"
-    CY2024 "${_BOOST_VFX2024_DOWNLOAD_HASH_}"
-  )
+  RV_VFX_SET_VARIABLE(_download_hash CY2023 "077f074743ea7b0cb49c6ed43953ae95" CY2024 "${_BOOST_VFX2024_DOWNLOAD_HASH_}")
 ELSE()
   # XCode 15 and above. (Need Boost 1.81+)
   RV_VFX_SET_VARIABLE(
     _ext_boost_version
     # Use Boost 1.81.0 for VFX2023 (Boost 1.80.0 does not work with XCode 15)
-    CY2023 "1.81.0"
-    CY2024 "${_BOOST_VFX2024_VERSION_}"
+    CY2023 "1.81.0" CY2024 "${_BOOST_VFX2024_VERSION_}"
   )
 
-  RV_VFX_SET_VARIABLE(
-    _major_minor_version
-    CY2023 "1_81"
-    CY2024 "${_BOOST_VFX2024_MAJOR_MINOR_VERSION_}"
-  )
+  RV_VFX_SET_VARIABLE(_major_minor_version CY2023 "1_81" CY2024 "${_BOOST_VFX2024_MAJOR_MINOR_VERSION_}")
 
-  RV_VFX_SET_VARIABLE(
-    _download_hash
-    CY2023 "4bf02e84afb56dfdccd1e6aec9911f4b"
-    CY2024 "${_BOOST_VFX2024_DOWNLOAD_HASH_}"
-  )
+  RV_VFX_SET_VARIABLE(_download_hash CY2023 "4bf02e84afb56dfdccd1e6aec9911f4b" CY2024 "${_BOOST_VFX2024_DOWNLOAD_HASH_}")
 ENDIF()
 
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_BOOST" "${_ext_boost_version}" "" "")
@@ -230,10 +218,14 @@ LIST(
           OUTPUT_VARIABLE _boost_with_list
 )
 
-SET(__boost_arch__ x86)
+SET(__boost_arch__
+    x86
+)
 IF(APPLE)
   IF(RV_TARGET_APPLE_ARM64)
-    SET(__boost_arch__ arm)
+    SET(__boost_arch__
+        arm
+    )
   ENDIF()
 ENDIF()
 
@@ -251,8 +243,8 @@ EXTERNALPROJECT_ADD(
   BUILD_COMMAND
     # Ref.: https://www.boost.org/doc/libs/1_70_0/tools/build/doc/html/index.html#bbv2.builtin.features.cflags Ref.:
     # https://www.boost.org/doc/libs/1_76_0/tools/build/doc/html/index.html#bbv2.builtin.features.cflags
-    ./b2 -a -q toolset=${_toolset} cxxstd=${RV_CPP_STANDARD} variant=${_boost_variant} link=shared threading=multi architecture=${__boost_arch__} address-model=64
-    ${_boost_with_list} ${_boost_b2_options} -j${_cpu_count} install --prefix=${_install_dir}
+    ./b2 -a -q toolset=${_toolset} cxxstd=${RV_CPP_STANDARD} variant=${_boost_variant} link=shared threading=multi architecture=${__boost_arch__}
+    address-model=64 ${_boost_with_list} ${_boost_b2_options} -j${_cpu_count} install --prefix=${_install_dir}
   INSTALL_COMMAND echo "Boost was both built and installed in the build stage"
   BUILD_IN_SOURCE TRUE
   BUILD_ALWAYS FALSE

--- a/cmake/dependencies/png.cmake
+++ b/cmake/dependencies/png.cmake
@@ -13,7 +13,7 @@
 INCLUDE(ProcessorCount) # require CMake 3.15+
 PROCESSORCOUNT(_cpu_count)
 
-RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_PNG" "1.6.39" "" "")
+RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_PNG" "1.6.48" "" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
 SET(_download_url
@@ -21,19 +21,19 @@ SET(_download_url
 )
 
 SET(_download_hash
-    "a704977d681a40d8223d8b957fd41b29"
+    "be6cc9e411c26115db3b9eab1159a1d9"
 )
 
 SET(_libpng_lib_version
-    "16.39.0"
+    "16.48.0"
 )
 IF(NOT RV_TARGET_WINDOWS)
   RV_MAKE_STANDARD_LIB_NAME("png16" "${_libpng_lib_version}" "SHARED" "d")
 ELSE()
   RV_MAKE_STANDARD_LIB_NAME("libpng16" "${_libpng_lib_version}" "SHARED" "d")
 ENDIF()
-# The '_configure_options' list gets reset and initialized in 'RV_CREATE_STANDARD_DEPS_VARIABLES'
-# Future: The main branch of libpng has deprecated 'PNG_EXECUTABLES' in favor of 'PNG_TOOLS'.
+# The '_configure_options' list gets reset and initialized in 'RV_CREATE_STANDARD_DEPS_VARIABLES' Future: The main branch of libpng has deprecated
+# 'PNG_EXECUTABLES' in favor of 'PNG_TOOLS'.
 LIST(APPEND _configure_options "-DZLIB_ROOT=${RV_DEPS_ZLIB_ROOT_DIR}")
 LIST(APPEND _configure_options "-DPNG_EXECUTABLES=OFF")
 LIST(APPEND _configure_options "-DPNG_TESTS=OFF")
@@ -75,9 +75,8 @@ IF(NOT RV_TARGET_WINDOWS)
     PROPERTY IMPORTED_SONAME ${_libname}
   )
 ELSE()
-  # An import library (.lib) file is often used to resolve references to 
-  # functions and variables in a DLL, enabling the linker to generate code 
-  # for loading the DLL and calling its functions at runtime.
+  # An import library (.lib) file is often used to resolve references to functions and variables in a DLL, enabling the linker to generate code for loading the
+  # DLL and calling its functions at runtime.
   SET_PROPERTY(
     TARGET PNG::PNG
     PROPERTY IMPORTED_LOCATION "${_implibpath}"

--- a/cmake/dependencies/zlib.cmake
+++ b/cmake/dependencies/zlib.cmake
@@ -7,14 +7,14 @@
 INCLUDE(ProcessorCount) # require CMake 3.15+
 PROCESSORCOUNT(_cpu_count)
 
-RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_ZLIB" "1.2.13" "" "")
+RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_ZLIB" "1.3.1" "" "")
 
 SET(_download_url
     "https://github.com/madler/zlib/archive/refs/tags/v${_version}.zip"
 )
 
 SET(_download_hash
-    "fdedf0c8972a04a7c153dd73492d2d91"
+    "127b8a71a3fb8bebe89df1080f15fdf6"
 )
 
 SET(_install_dir

--- a/docs/build_system/config_macos.md
+++ b/docs/build_system/config_macos.md
@@ -6,6 +6,7 @@
 - [Summary](summary)
 - [Allow Terminal to update or delete other applications](allow_terminal)
 - [Install Xcode](install_xcode)
+- [Install CMake](install_cmake)
 - [Install Homebrew](install_homebrew)
 - [Install tools and build dependencies](install_tools_and_build_dependencies)
 - [Install Qt](install_qt)
@@ -16,8 +17,6 @@ OpenRV can be built for *x86_64* by changing the architecture of the terminal to
 ```bash
 arch -x86_64 $SHELL
 ```
-````arch -x86_64 $SHELL````
-
 **It is important to use that *x86_64* terminal for all the subsequent steps.**
 ````
 
@@ -33,6 +32,17 @@ From the App Store, download Xcode. Make sure that it is the source of the activ
 
 `xcode-select -p` should return `/Applications/Xcode.app/Contents/Developer`. If that is not the case, run `sudo xcode-select -s /Applications/Xcode.app`
 
+(install_cmake)=
+## Install CMake
+
+Homebrew's CMake could previously be used to build Open RV on macOS, but now it installs CMake version 4, which is too recent and causes dependency issues. An earlier version of CMake must be installed separately:
+[cmake-3.31.7-macos-universal.dmg](https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-macos-universal.dmg).
+
+Add the CMake tool to the PATH using the following command:
+```bash
+sudo "/Applications/CMake.app/Contents/bin/cmake-gui" --install=/usr/local/bin
+````
+
 (install_homebrew)=
 ## Install Homebrew
 
@@ -46,11 +56,10 @@ Make sure Homebrew's binary directory is in your PATH and that `brew` can be res
 Most of the build requirements can be installed by running the following brew install command:
 
 ```bash
-brew install cmake ninja readline sqlite3 xz zlib tcl-tk@8 autoconf automake libtool python yasm clang-format black meson nasm pkg-config glew
+brew install ninja readline sqlite3 xz zlib tcl-tk@8 autoconf automake libtool python@3.11 yasm clang-format black meson nasm pkg-config glew
 ```
 
-Make sure `python` resolves in your terminal. In some cases, depending on how the python formula is built, there is no `python` symbolic link.
-In that case, you can create one with this command `ln -s python3 $(dirname $(which python3))/python`.
+Make sure `xcode-select -p` still returns `/Applications/Xcode.app/Contents/Developer`. If that is not the case, run `sudo xcode-select -s /Applications/Xcode.app`
 
 (install_qt)=
 ## Install Qt
@@ -127,34 +136,20 @@ rvcfgd
 ````
 
 (build_openrv6)=
-### Build the dependencies
-
-From the Open RV directory, the following command will build the dependencies:
-
-````{tabs}
-```{code-tab} bash Release
-rvbuildt dependencies
-```
-```{code-tab} bash Debug
-rvbuildtd dependencies
-```
-````
-
-(build_openrv7)=
-### Build the main executable
+### Build Open RV
 
 From the Open RV directory, the following command will build the main executable:
 
 ````{tabs}
 ```{code-tab} bash Release
-rvbuildt main_executable
+rvbuild
 ```
 ```{code-tab} bash Debug
-rvbuildtd main_executable
+rvbuildd
 ```
 ````
 
-(build_openrv8)=
+(build_openrv7)=
 ### Opening Open RV executable
 
 ````{tabs}
@@ -165,4 +160,3 @@ Once the build is completed, the Open RV application can be found in the Open RV
 Once the build is completed, the Open RV application can be found in the Open RV directory under `_build_debug/stage/app/RV.app/Contents/MacOS/RV`.
 ```
 ````
-

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -30,6 +30,7 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
   RV_TOOLCHAIN=""
+  export PATH="/opt/homebrew/opt/python@3.11/libexec/bin:$PATH" 
 
 # Windows
 elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then

--- a/src/build/make_openssl.py
+++ b/src/build/make_openssl.py
@@ -182,6 +182,7 @@ def configure() -> None:
             configure_args.append(f"darwin64{ARCH}-cc")
         else:
             configure_args.append("darwin64-x86_64-cc")
+        configure_args.append("LDFLAGS=-headerpad_max_install_names")
     elif platform.system() == "Windows":
         configure_args.append("VC-WIN64A")
         configure_args.append("no-asm")

--- a/src/build/make_pyside6.py
+++ b/src/build/make_pyside6.py
@@ -88,6 +88,9 @@ def prepare() -> None:
             os.popen("clang --version").read(),
         )
         clang_version_str = ".".join(clang_version_search.groups())
+        if clang_version_str == "17.0.0":
+            # The 17.0.0 version does not exist on the Qt server
+            clang_version_str = "17.0.1"
         clang_filename_suffix = clang_version_str + "-based-macos-universal.7z"
     elif system == "Linux":
         clang_filename_suffix = "19.1.0-based-linux-Rhel8.8-gcc10.3-x86_64.7z"

--- a/src/lib/base/TwkMath/TwkMath/Mat33.h
+++ b/src/lib/base/TwkMath/TwkMath/Mat33.h
@@ -522,8 +522,7 @@ namespace TwkMath
     inline Vec2<T> Mat33<T>::transformDir(const Vec2<T>& d) const
     {
         assert(isAffine());
-        return Vec2<T>((m00 * this->v.x) + (m01 * this->v.y),
-                       (m10 * this->v.x) + (m11 * this->v.y));
+        return Vec2<T>((m00 * d.x) + (m01 * d.y), (m10 * d.x) + (m11 * d.y));
     }
 
     //******************************************************************************

--- a/src/lib/base/TwkMath/TwkMath/Plane.h
+++ b/src/lib/base/TwkMath/TwkMath/Plane.h
@@ -178,7 +178,7 @@ namespace TwkMath
         //	parallel.
         //
 
-        return normal == plane.normaml;
+        return normal == plane.normal;
     }
 
     template <typename T>

--- a/src/lib/mu/Mu/Mu/config.h
+++ b/src/lib/mu/Mu/Mu/config.h
@@ -368,8 +368,8 @@ namespace Mu
     typedef STLString<wchar_t>::Type UTF16String;
     typedef std::basic_string<wchar_t> stdUTF16String;
 #else
-    typedef STLString<unsigned short>::Type UTF16String;
-    typedef std::basic_string<unsigned short> stdUTF16String;
+    typedef STLString<char16_t>::Type UTF16String;
+    typedef std::basic_string<char16_t> stdUTF16String;
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
### Fix build when using latest Xcode 16.3-clang 17

### Linked issues
NA

### Describe the reason for the change.

The Open RV build got broken with the latest macOS Sequoia 15.5 + Xcode 16.3-clang17 + latest Homebrew.
This commit fixes these errors and also update the Open RV build instructions on macOS.

Note that this commit is not enough to successfully build Open RV with the latest macOS.
It is missing one template error which has been fixed in a separate repo and will be added to this PR once it is merged merged:
https://github.com/shotgunsoftware/openrv-pub/pull/21

### Summarize your change.

This commit fixes numerous legacy template errors that were not reported as such by previous versions of clang.
This commit also contains some changes in the Open RV build instructions on macOS in order to achieve a successful Open RV build on the latest macOS configuration. 

- Updated PNG from 16.39.0 to 16.48.0 to fix the following issue:
```
In file included from /Users/labergb/openrv_bernie/OpenRV/_build/RV_DEPS_PNG/src/scripts/intprefix.c:21:
/Users/labergb/openrv_bernie/OpenRV/_build/RV_DEPS_PNG/src/scripts/../pngpriv.h:524:16: fatal error: 'fp.h' file not found
  524 | #      include <fp.h>
```
We need this fix:
https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24
Which is in 1.6.48

- Updated zlib from 1.2.13 to 1.3.1 to fix the following issue:
```
In file included from /Users/labergb/openrv_bernie/OpenRV/_build/RV_DEPS_ZLIB/src/zutil.c:10:
In file included from /Users/labergb/openrv_bernie/OpenRV/_build/RV_DEPS_ZLIB/src/gzguts.h:21:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk/usr/include/stdio.h:61:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
/Users/labergb/openrv_bernie/OpenRV/_build/RV_DEPS_ZLIB/src/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Applications/Xcode.app/Contents/DeIn file included from /Users/labergb/openrv_bernie/OpenRV/_build/RV_DEPS_ZLIB/src/zutil.c:10:
```

We need this commit available in ZLIB 1.3.1:
https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9

Fix: Use char16_t instead of unsigned short to fix the following error:
```
In file included from /Users/labergb/openrv_bernie/OpenRV/src/lib/mu/Mu/UTF8.cpp:10:
In file included from /Users/labergb/openrv_bernie/OpenRV/src/lib/mu/Mu/Mu/UTF8.h:10:
In file included from /Users/labergb/openrv_bernie/OpenRV/src/lib/mu/Mu/Mu/config.h:9:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk/usr/include/c++/v1/string:821:42: error: implicit instantiation of undefined template 'std::char_traits<unsigned short>'
  821 |   static_assert(is_same<_CharT, typename traits_type::char_type>::value,
      |                                          ^
/Users/labergb/openrv_bernie/OpenRV/src/lib/mu/Mu/UTF8.cpp:62:17: note: in instantiation of template class 'std::basic_string<unsigned short, std::char_traits<unsigned short>, gc_allocator<unsigned short>>' requested here
   62 |     UTF16String UTF16convert(const Mu::String& s)
      |                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk/usr/include/c++/v1/__string/char_traits.h:45:8: note: template is declared here
   45 | struct char_traits;
      |        ^
In file included from /Users/labergb/openrv_bernie/OpenRV/src/lib/mu/Mu/UTF8.cpp:10:
```

### Describe what you have tested and on which operating system.
Successfully tested both on macOS 15.4.1 and macOS 15.5 which was released today.
XCode 16.3 and Qt 6.5.3 were used.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.