### PR TITLE
Onion Skin Management

### DIFF
--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/PaintIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/PaintIPNode.h
@@ -42,11 +42,13 @@ namespace IPCore
         struct LocalPolyLine : public Paint::PolyLine
         {
             int eye;
+            Color baseColor;
         };
 
         struct LocalText : public Paint::Text
         {
             int eye;
+            Color baseColor;
         };
 
         typedef TwkMath::Vec4f Vec4;

--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -38,6 +38,13 @@ namespace IPCore
         declareProperty<IntProperty>("paint.show", 1);
         declareProperty<StringProperty>("paint.exclude");
         declareProperty<StringProperty>("paint.include");
+        declareProperty<IntProperty>("paint.onionShow", 0);
+        declareProperty<IntProperty>("paint.onionBeforeFrame", 5);
+        declareProperty<IntProperty>("paint.onionAfterFrame", 5);
+        declareProperty<Vec4fProperty>("paint.onionBeforeColor",
+                                       Vec4f(1, 0, 0, 1));
+        declareProperty<Vec4fProperty>("paint.onionAfterColor",
+                                       Vec4f(0, 1, 0, 1));
 
         m_tag = createComponent("tag");
     }
@@ -80,6 +87,7 @@ namespace IPCore
         const int eye = eyeP && eyeP->size() ? eyeP->front() : 2;
 
         p.width = width;
+        p.baseColor = color;
         p.color = color;
         p.brush = brush;
         p.debug = debug;
@@ -148,6 +156,7 @@ namespace IPCore
         p.scale = 1.0 / 80.0 / 10.0 * scale;
         p.pos = pos;
         p.spacing = space;
+        p.baseColor = color;
         p.color = color;
         p.font = font;
         p.text = text;
@@ -342,6 +351,29 @@ namespace IPCore
         IPNode::readCompleted(typeName, version);
     }
 
+    static Vec4f onionSkinColor(const Vec4f& colorIn, const Vec4f& colorBase,
+                                const Vec4f& colorBefore,
+                                const Vec4f& colorAfter, float alpha, int i,
+                                int frame)
+    {
+        Vec4f color;
+        if (i < frame)
+        {
+            color = colorBefore;
+            color[3] = color[3] * alpha * colorBase[3];
+        }
+        else if (i > frame)
+        {
+            color = colorAfter;
+            color[3] = color[3] * alpha * colorBase[3];
+        }
+        else
+        {
+            color = colorBase;
+        }
+        return color;
+    }
+
     IPImage* PaintIPNode::evaluate(const Context& context)
     {
         IPImage* head = 0;
@@ -356,50 +388,96 @@ namespace IPCore
         IntProperty* showP = property<IntProperty>("paint", "show");
         StringProperty* incP = property<StringProperty>("paint", "include");
         StringProperty* excP = property<StringProperty>("paint", "exclude");
+        IntProperty* onionShowP = property<IntProperty>("paint", "onionShow");
+        IntProperty* onionBFP =
+            property<IntProperty>("paint", "onionBeforeFrame");
+        IntProperty* onionAFP =
+            property<IntProperty>("paint", "onionAfterFrame");
+        Vec4fProperty* onionBCP =
+            property<Vec4fProperty>("paint", "onionBeforeColor");
+        Vec4fProperty* onionACP =
+            property<Vec4fProperty>("paint", "onionAfterColor");
 
         bool showPaint = !showP || showP->empty() || showP->front() == 1;
 
         if (showPaint)
         {
-            if (m_frameMap.count(frame) != 0)
+            bool onionShow =
+                onionShowP && !onionShowP->empty() && onionShowP->front() == 1;
+            int rb, ra;
+            Vec4f cb, ca;
+            if (onionShow)
             {
-                Components& comps = m_frameMap[frame];
-                size_t s = comps.size();
+                rb = onionBFP && !onionBFP->empty() ? onionBFP->front() : 0;
+                ra = onionAFP && !onionAFP->empty() ? onionAFP->front() : 0;
+                rb = std::max(0, rb + 1);
+                ra = std::max(0, ra + 1);
+                cb = onionBCP && onionBCP->size() ? onionBCP->front()
+                                                  : Vec4f(1, 0, 0, 1);
+                ca = onionACP && onionACP->size() ? onionACP->front()
+                                                  : Vec4f(0, 1, 0, 1);
+            }
+            else
+            {
+                rb = 0;
+                ra = 0;
+                cb = Vec4f(1, 0, 0, 1);
+                ca = Vec4f(0, 1, 0, 1);
+            }
 
-                for (size_t q = 0; q < s; q++)
+            for (size_t i = frame - rb; i <= frame + ra; i++)
+            {
+                if (m_frameMap.count(i) != 0)
                 {
-                    Component* c = comps[q];
-                    int numProps = c->properties().size();
+                    float alpha =
+                        i < frame
+                            ? (rb > 0 ? 1.0f - (frame - i) / float(rb) : 1.0f)
+                            : (ra > 0 ? 1.0f - (i - frame) / float(ra) : 1.0f);
 
-                    if (m_penStrokes.count(c) >= 1)
+                    Components& comps = m_frameMap[i];
+                    size_t s = comps.size();
+
+                    for (size_t q = 0; q < s; q++)
                     {
-                        if (numProps == 0)
-                        {
-                            m_penStrokes.erase(c);
-                        }
-                        else
-                        {
-                            LocalPolyLine& pl = m_penStrokes[c];
+                        Component* c = comps[q];
+                        int numProps = c->properties().size();
 
-                            if (pl.eye == 2 || (pl.eye == context.eye))
+                        if (m_penStrokes.count(c) >= 1)
+                        {
+                            if (numProps == 0)
                             {
-                                head->commands.push_back(&pl);
+                                m_penStrokes.erase(c);
+                            }
+                            else
+                            {
+                                LocalPolyLine& pl = m_penStrokes[c];
+
+                                if (pl.eye == 2 || (pl.eye == context.eye))
+                                {
+                                    pl.color =
+                                        onionSkinColor(pl.color, pl.baseColor,
+                                                       cb, ca, alpha, i, frame);
+                                    head->commands.push_back(&pl);
+                                }
                             }
                         }
-                    }
-                    else if (m_texts.count(c) >= 1)
-                    {
-                        if (numProps == 0)
+                        else if (m_texts.count(c) >= 1)
                         {
-                            m_texts.erase(c);
-                        }
-                        else
-                        {
-                            LocalText& t = m_texts[c];
-
-                            if (t.eye == 2 || (t.eye == context.eye))
+                            if (numProps == 0)
                             {
-                                head->commands.push_back(&t);
+                                m_texts.erase(c);
+                            }
+                            else
+                            {
+                                LocalText& t = m_texts[c];
+
+                                if (t.eye == 2 || (t.eye == context.eye))
+                                {
+                                    t.color =
+                                        onionSkinColor(t.color, t.baseColor, cb,
+                                                       ca, alpha, i, frame);
+                                    head->commands.push_back(&t);
+                                }
                             }
                         }
                     }

--- a/src/plugins/rv-packages/annotate/drawpane.ui
+++ b/src/plugins/rv-packages/annotate/drawpane.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>100</width>
-    <height>444</height>
+    <height>589</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -35,7 +35,16 @@
    <property name="spacing">
     <number>1</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
     <number>4</number>
    </property>
    <item>
@@ -59,7 +68,16 @@
       <property name="spacing">
        <number>0</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -495,7 +513,16 @@
       <property name="spacing">
        <number>1</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -568,6 +595,131 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="onionCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>9</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string>OnionSkin Drawing</string>
+     </property>
+     <property name="text">
+      <string>OnionSkin</string>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+     <property name="shortcut">
+      <string>Ctrl+S</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="onionSkinBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string/>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="onionAfterSpinBox">
+          <property name="toolTip">
+           <string>OnionSkin Number of Frames After</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QSpinBox" name="onionBeforeSpinBox">
+          <property name="toolTip">
+           <string>OnionSkin Number of Frames Before</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QPushButton" name="onionBeforeButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>OnionSkin Color Before</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QPushButton" name="onionAfterButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>OnionSkin Color After</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="historyBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -588,7 +740,16 @@
       <property name="spacing">
        <number>0</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>


### PR DESCRIPTION
NOTE: This is a take-over of the following PR for the excellent work from @mamouth13 found here: https://github.com/AcademySoftwareFoundation/OpenRV/pull/498

### Summarize your change.

This implements onion skin management. From the original PR text: 

Added 5 properties into the PaintIPNode node:

onionShow : enabled/disabled the drawing of onionSkin (default is false).
onionBeforeFrame: the number of frames BEFORE a stroke on which the onionSkins will be drawn (default is 5).
onionAfterFrame: the number of frames AFTER a stroke on which the onionSkins will be drawn (default is 5).
onionBeforeColor: the color used to draw onionSkin BEFORE (default is red).
onionAfterColor: the color used to draw onionSkin AFTER (default is green).
Paint::PolyLine and Paint::Text now manage those new properties and draw onionSkin on previous / next frames with the appropriate fading out colors.

Modified the annotate rv-package:

Modified drawpane.ui to add the appropriate Ui to manage the above new properties.
Modified annotate_mode.mu to properly handle the colorChooser with those new Ui. 

### Describe the reason for the change.

There is no change from the original PR - except for resolving merge conflicts and bringing up to date with the latest OpenRV main.

### Describe what you have tested and on which operating system.

macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

![image](https://github.com/user-attachments/assets/a50c1864-b063-4135-834d-f027a490e102)
