### PR TITLE
feat: SG-43397: Default sequences replaced when comparing media from FPTR (Take 2)

### DIFF
--- a/src/lib/app/RvApp/Options.cpp
+++ b/src/lib/app/RvApp/Options.cpp
@@ -498,6 +498,8 @@ namespace Rv
         presentFormat = (char*)"";
         presentData = (char*)"";
 
+        addSourceToDefaultView = true;
+
 #ifdef PLATFORM_DARWIN
         fontSize1 = 13;
         fontSize2 = 10;
@@ -533,6 +535,7 @@ namespace Rv
                 inSource = true;
                 sources.resize(sources.size() + 1);
                 sources.back().singleSource = true;
+                sources.back().addSourceToDefaultView = true;
 
                 SourceArgs& a = sources.back();
 

--- a/src/lib/app/RvApp/RvApp/Options.h
+++ b/src/lib/app/RvApp/RvApp/Options.h
@@ -45,6 +45,7 @@ namespace Rv
                 , hasuncrop(false)
                 , singleSource(false)
                 , noMovieAudio(false)
+                , addSourceToDefaultView(true)
             {
                 cutIn = (std::numeric_limits<int>::max)();
                 cutOut = (std::numeric_limits<int>::max)();
@@ -68,6 +69,7 @@ namespace Rv
             float stereoRightOffset;
             int cutIn;
             int cutOut;
+            bool addSourceToDefaultView;
             std::string fcdl;
             std::string lcdl;
             std::string flut;
@@ -349,6 +351,8 @@ namespace Rv
         int presentAudio;
         int fontSize1;
         int fontSize2;
+
+        bool addSourceToDefaultView;
 
         SendExternalEventVector sendEvents;
     };

--- a/src/lib/app/RvApp/RvGraph.cpp
+++ b/src/lib/app/RvApp/RvGraph.cpp
@@ -371,7 +371,16 @@ namespace Rv
             copy(m_newSources.begin(), m_newSources.end(),
                  inputs.begin() + layer->inputs().size());
             HOP_ZONE(HOP_ZONE_COLOR_12);
-            layer->setInputs(inputs);
+
+            if (Rv::Options::sharedOptions().addSourceToDefaultView)
+            {
+                layer->setInputs(inputs);
+            }
+            else
+            {
+                cout << "INFO: Disabled adding sources to default views"
+                     << endl;
+            }
         }
 
         m_newSources.clear();

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -509,6 +509,11 @@ namespace Rv
 
             new Function(c, "rvioSetup", rvioSetup, None, Return, "void", End),
 
+            new Function(c, "setConnectNewSourcesToDefaultViews",
+                         setConnectNewSourcesToDefaultViews, None, Return,
+                         "void", Parameters, new Param(c, "enable", "bool"),
+                         End),
+
             EndArguments);
     }
 
@@ -2365,6 +2370,12 @@ namespace Rv
     {
         // Note: This is no longer relevant in RV Open Source but kept to
         // maintain backward compatibility.
+    }
+
+    NODE_IMPLEMENTATION(setConnectNewSourcesToDefaultViews, void)
+    {
+        bool enable = NODE_ARG(0, bool);
+        Rv::Options::sharedOptions().addSourceToDefaultView = enable;
     }
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/MuUICommands.h
+++ b/src/lib/app/RvCommon/RvCommon/MuUICommands.h
@@ -90,6 +90,7 @@ namespace Rv
     NODE_DECLARATION(rvioSetup, void);
     NODE_DECLARATION(javascriptMuExport, void);
     NODE_DECLARATION(framebufferPixelValue, Mu::Vector4f);
+    NODE_DECLARATION(setConnectNewSourcesToDefaultViews, void);
 
 } // namespace Rv
 


### PR DESCRIPTION
**DO NOT MERGE YET - THIS WORK FROM BEN IS INCOMPLETE**

This is a cleanup PR: I took over Ben Chamberland's PR 545. 

The text below was his github PR comments, verbatim. This work may be incomplete, needs to be tested, reviewed.


### Summarize your change.

This When a user opens media from Flow Production Tracking, and then compares it to another piece of media in Flow Production Tracking, the default sequences are overwritten. Meaning, the user can no longer access the clips that they initially opened from FPTR. This can interrupt workflows.

If this change is implemented, along with another PR into OpenRV, users will have the option to enable a parameter in `Flow Production Tracking / Session Prefs` that will prevent this from happening.

This PR, paired with a PR in Commercial RV, will resolve this issue. The changes made in this PR include a command that modifies a global preference to prevent media from being overwritten while comparing media. 

### Describe the reason for the change.

User wanted to be able to compare media without overwriting the original media. 

### Describe what you have tested and on which operating system.

MacOS 14.5 Sonoma
