### PR TITLE
Add hold and ghost

### DIFF
--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-sixteen.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-sixteen.md
@@ -441,6 +441,12 @@ Paint nodes are used primarily to store per frame annotations. Below *id* is the
 | pen: *id* : *frame* : *user* .cap | int | 1 | The cap style of the stroke:NoCap = 0; SquareCap = 1; RoundCap = 2; |
 | pen: *id* : *frame* : *user* .splat | int | 1 |  |
 | pen: *id* : *frame* : *user* .mode | int | 1 | Drawing mode of the stroke (Default if missing is 0):RenderOverMode = 0; RenderEraseMode = 1; |
+| pen: *id* : *frame* : *user* .startFrame | int | 1 | The first frame on which the pen stroke should be displayed |
+| pen: *id* : *frame* : *user* .duration | int | 1 | The number of frames on which the pen stroke should be displayed |
+| pen: *id* : *frame* : *user* .hold | int | 1 | Enable holding strokes based on their duration and startFrame properties |
+| pen: *id* : *frame* : *user* .ghost | int | 1 | Enable ghosting strokes based on their duration, startFrame, ghostBefore and ghostAfter properties |
+| pen: *id* : *frame* : *user* .ghostBefore | int | 1 | The number of frames on which to display the ghosted stroke before the actual stroke |
+| pen: *id* : *frame* : *user* .ghostAfter | int | 1 | The number of frames on which to display the ghosted stroke after the actual stroke |
 | text: *id* : *frame* : *user* .position | float[2] | 1 | Location of the text in the normalized coordinate system |
 | text: *id* : *frame* : *user* .color | float[4] | 1 | The color of the text |
 | text: *id* : *frame* : *user* .spacing | float | 1 | The spacing of the text |
@@ -451,6 +457,12 @@ Paint nodes are used primarily to store per frame annotations. Below *id* is the
 | text: *id* : *frame* : *user* .text | string | 1 | Content of the text |
 | text: *id* : *frame* : *user* .origin | string | 1 | The origin of the text box. The position property will store the location of the origin, but the origin can be on any corner of the text box or centered in between. The valid possible values for origin are top-left, top-center, top-right, center-left, center-center, center-right, bottom-left, bottom-center, bottom-right, and the empty string (which is the default for backwards compatibility). |
 | text: *id* : *frame* : *user* .debug | int | 1 | (unused) |
+| text: *id* : *frame* : *user* .startFrame | int | 1 | The first frame on which the text box should be displayed |
+| text: *id* : *frame* : *user* .duration | int | 1 | The number of frames on which the text box should be displayed |
+| text: *id* : *frame* : *user* .hold | int | 1 | Enable holding text boxes based on their duration and startFrame properties |
+| text: *id* : *frame* : *user* .ghost | int | 1 | Enable ghosting strokes based on their duration, startFrame, ghostBefore and ghostAfter properties |
+| text: *id* : *frame* : *user* .ghostBefore | int | 1 | The number of frames on which to display the ghosted stroke before the actual stroke |
+| text: *id* : *frame* : *user* .ghostAfter | int | 1 | The number of frames on which to display the ghosted stroke after the actual stroke |
 
 ## RVPrimaryConvert
 

--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/PaintIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/PaintIPNode.h
@@ -41,11 +41,7 @@ namespace IPCore
         class LocalCommand
         {
         public:
-            LocalCommand()
-                : ghostColor(Color(0.0))
-            {
-            }
-
+            LocalCommand() = default;
             virtual ~LocalCommand() = default;
 
             int startFrame{};
@@ -57,7 +53,7 @@ namespace IPCore
             int eye{-1};
 
             bool ghostOn{};
-            TwkMath::Col4f ghostColor;
+            TwkMath::Col4f ghostColor{Color(0.0)};
         };
 
         class LocalPolyLine
@@ -98,8 +94,6 @@ namespace IPCore
         void propertyChanged(const Property* proprety) override;
         void readCompleted(const std::string& typeName,
                            unsigned int version) override;
-
-        void clearAll();
 
     protected:
         void compilePenComponent(Component*);

--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/PaintIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/PaintIPNode.h
@@ -1,16 +1,15 @@
 //
-//  Copyright (c) 2009 Tweak Software.
-//  All rights reserved.
+// Copyright (C) 2025 Autodesk, Inc. All Rights Reserved.
 //
-//  SPDX-License-Identifier: Apache-2.0
-//
+// SPDX-License-Identifier: Apache-2.0
 //
 #ifndef __IPGraph__PaintIPNode__h__
 #define __IPGraph__PaintIPNode__h__
-#include <iostream>
 #include <IPCore/IPNode.h>
 #include <IPCore/PaintCommand.h>
+#include <TwkMath/Color.h>
 #include <map>
+#include <vector>
 
 namespace IPCore
 {
@@ -39,36 +38,68 @@ namespace IPCore
         //  Paint:: commands + per-command state local to this node.
         //
 
-        struct LocalPolyLine : public Paint::PolyLine
+        class LocalCommand
         {
-            int eye;
+        public:
+            LocalCommand()
+                : ghostColor(Color(0.0))
+            {
+            }
+
+            virtual ~LocalCommand() = default;
+
+            int startFrame{};
+            int duration{};
+            int ghost{};
+            int hold{};
+            int ghostAfter{};
+            int ghostBefore{};
+            int eye{-1};
+
+            bool ghostOn{};
+            TwkMath::Col4f ghostColor;
         };
 
-        struct LocalText : public Paint::Text
+        class LocalPolyLine
+            : public Paint::PolyLine
+            , public LocalCommand
         {
-            int eye;
+        public:
+            LocalPolyLine() = default;
         };
 
-        typedef TwkMath::Vec4f Vec4;
-        typedef TwkMath::Vec3f Vec3;
-        typedef TwkMath::Vec2f Vec2;
-        typedef TwkMath::Box2f Box2;
-        typedef TwkMath::Mat44f Matrix;
-        typedef TwkMath::Col4f Color;
-        typedef std::vector<Vec2> PointVector;
-        typedef std::vector<std::string> FrameVector;
-        typedef std::map<Component*, LocalPolyLine> PenMap;
-        typedef std::map<Component*, LocalText> TextMap;
-        typedef std::map<int, Components> FrameMap;
+        class LocalText
+            : public Paint::Text
+            , public LocalCommand
+        {
+        public:
+            LocalText() = default;
+        };
+
+        using Vec4 = TwkMath::Vec4f;
+        using Vec3 = TwkMath::Vec3f;
+        using Vec2 = TwkMath::Vec2f;
+        using Box2 = TwkMath::Box2f;
+        using Matrix = TwkMath::Mat44f;
+        using Color = TwkMath::Col4f;
+        using PointVector = std::vector<Vec2>;
+        using FrameVector = std::vector<std::string>;
+        using LocalCommands = std::vector<LocalCommand*>;
+        using PenMap = std::map<Component*, LocalPolyLine>;
+        using TextMap = std::map<Component*, LocalText>;
+        using FrameMap = std::map<int, Components>;
 
         PaintIPNode(const std::string& name, const NodeDefinition* def,
                     IPGraph* graph, GroupIPNode* group);
         virtual ~PaintIPNode();
 
-        virtual IPImage* evaluate(const Context&);
+        IPImage* evaluate(const Context& context) override;
 
-        virtual void propertyChanged(const Property*);
-        virtual void readCompleted(const std::string&, unsigned int);
+        void propertyChanged(const Property* proprety) override;
+        void readCompleted(const std::string& typeName,
+                           unsigned int version) override;
+
+        void clearAll();
 
     protected:
         void compilePenComponent(Component*);
@@ -78,10 +109,12 @@ namespace IPCore
     private:
         PenMap m_penStrokes;
         TextMap m_texts;
+        LocalCommands m_commands;
         Paint::PushFrameBuffer m_pushFBO;
         Paint::PopFrameBuffer m_popFBO;
         FrameMap m_frameMap;
         Component* m_tag;
+        std::mutex m_commandsMutex;
     };
 
 } // namespace IPCore

--- a/src/lib/ip/IPBaseNodes/OverlayIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/OverlayIPNode.cpp
@@ -144,15 +144,12 @@ namespace IPCore
     namespace
     {
 
-        static void initializeOutline(Paint::PolyLine& outline,
-                                      const Vec2f* points, size_t npoints,
-                                      TwkPaint::Color oc, float outlineWidth,
-                                      const string& brush)
+        void initializeOutline(Paint::PolyLine& outline, const Vec2f* points,
+                               size_t npoints, TwkPaint::Color oc,
+                               float outlineWidth, const string& brush)
         {
             // these polyline owns the memory of their own points
-            outline.points = new Vec2f[npoints];
-            memcpy((void*)outline.points, (void*)points,
-                   npoints * sizeof(Vec2f));
+            outline.points.assign(points->begin(), points->end());
             outline.ownPoints = true;
 
             outline.npoints = npoints;

--- a/src/lib/ip/IPCore/IPCore/IPImage.h
+++ b/src/lib/ip/IPCore/IPCore/IPImage.h
@@ -1,6 +1,6 @@
 //******************************************************************************
-// Copyright (c) 2006 Tweak Inc.
-// All rights reserved.
+//
+// Copyright (C) 2025 Autodesk, Inc. All Rights Reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -109,26 +109,26 @@ namespace IPCore
     class IPImage
     {
     public:
-        typedef Shader::Expression Expression;
-        typedef TwkFB::FrameBuffer FrameBuffer;
-        typedef TwkMath::Vec4f Vec4;
-        typedef TwkMath::Vec3f Vec3;
-        typedef TwkMath::Vec2f Vec2;
-        typedef TwkMath::Box2f Box2;
-        typedef TwkMath::Mat33f Matrix33;
-        typedef TwkMath::Mat44f Matrix;
-        typedef TwkMovie::MovieInfo MovieInfo;
-        typedef TwkMath::Col4f Color;
-        typedef std::stringstream ShaderStream;
-        typedef stl_ext::replacement_allocator<const FrameBuffer*> FBAlloc;
-        typedef std::vector<const FrameBuffer*, FBAlloc> FBVector;
-        typedef std::vector<const Paint::Command*> PaintCommands;
-        typedef std::vector<IPImage*> IPImageVector;
-        typedef std::map<std::string, std::string> TagMap;
-        typedef Shader::Function::ResourceUsage ResourceUsage;
-        typedef TwkApp::VideoDevice VideoDevice;
-        typedef TwkApp::VideoDevice::Margins Margins;
-        typedef unsigned int HashValue;
+        using Expression = Shader::Expression;
+        using FrameBuffer = TwkFB::FrameBuffer;
+        using Vec4 = TwkMath::Vec4f;
+        using Vec3 = TwkMath::Vec3f;
+        using Vec2 = TwkMath::Vec2f;
+        using Box2 = TwkMath::Box2f;
+        using Matrix33 = TwkMath::Mat33f;
+        using Matrix = TwkMath::Mat44f;
+        using MovieInfo = TwkMovie::MovieInfo;
+        using Color = TwkMath::Col4f;
+        using ShaderStream = std::stringstream;
+        using FBAlloc = stl_ext::replacement_allocator<const FrameBuffer*>;
+        using FBVector = std::vector<const FrameBuffer*, FBAlloc>;
+        using PaintCommands = std::vector<Paint::Command*>;
+        using IPImageVector = std::vector<IPImage*>;
+        using TagMap = std::map<std::string, std::string>;
+        using ResourceUsage = Shader::Function::ResourceUsage;
+        using VideoDevice = TwkApp::VideoDevice;
+        using Margins = TwkApp::VideoDevice::Margins;
+        using HashValue = unsigned int;
 
         //
         //  NOTE: if you add/change a RenderType and/or RenderDestination

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -2715,7 +2715,7 @@ namespace IPCore
                 glEnable(GL_BLEND);
                 glBlendEquation(GL_FUNC_ADD);
                 // src is assumed premultiplied
-                glBlendFunc(GL_ONE,GL_ONE_MINUS_SRC_ALPHA);
+                glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
                 break;
             case IPImage::Add:
                 glEnable(GL_BLEND);

--- a/src/lib/ip/IPCore/PaintCommand.cpp
+++ b/src/lib/ip/IPCore/PaintCommand.cpp
@@ -5,6 +5,7 @@
 //  SPDX-License-Identifier: Apache-2.0
 //
 //
+#include "IPBaseNodes/PaintIPNode.h"
 #include <IPCore/PaintCommand.h>
 #include <TwkMath/Function.h>
 #include <TwkGLF/GL.h>
@@ -378,6 +379,12 @@ namespace IPCore
 
             // set uniforms
             Color pcolor = color;
+            const auto* localCommand =
+                dynamic_cast<const PaintIPNode::LocalCommand*>(this);
+            bool isGhostOn =
+                (localCommand != nullptr) ? localCommand->ghostOn : false;
+            pcolor = isGhostOn ? localCommand->ghostColor : color;
+
             glPipeline->setUniformFloat("uniformColor", 4, &(pcolor[0]));
             float coffset[2] = {50, 50};
             if (mode == CloneMode)

--- a/src/lib/ip/IPCore/PaintCommand.cpp
+++ b/src/lib/ip/IPCore/PaintCommand.cpp
@@ -378,7 +378,7 @@ namespace IPCore
             }
 
             // set uniforms
-            Color pcolor = color;
+            Color pcolor;
             const auto* localCommand =
                 dynamic_cast<const PaintIPNode::LocalCommand*>(this);
             bool isGhostOn =
@@ -429,20 +429,42 @@ namespace IPCore
             glState->useGLProgram(defaultGLProgram());
         }
 
-        void PolyLine::hash(ostream& o) const
+        void PolyLine::hash(ostream& ostream) const
         {
-            o << (void*)points << npoints << width << smoothingWidth << splat
-              << widths << color << brush << join << cap << mode << debug;
+            for (const auto& point : points)
+            {
+                ostream << point;
+            }
+
+            ostream << npoints << width << smoothingWidth << splat;
+
+            for (const auto& width : widths)
+            {
+                ostream << width;
+            }
+
+            ostream << color << brush << join << cap << mode << debug;
         }
 
         PolyLine::HashValue PolyLine::hashValue() const
         {
-            ostringstream o;
+            ostringstream ostream;
 
-            o << (void*)points << npoints << width << smoothingWidth << splat
-              << widths << color << brush << join << cap << mode << debug;
+            for (const auto& point : points)
+            {
+                ostream << point;
+            }
 
-            std::string id = o.str();
+            ostream << npoints << width << smoothingWidth << splat;
+
+            for (const auto& width : widths)
+            {
+                ostream << width;
+            }
+
+            ostream << color << brush << join << cap << mode << debug;
+
+            std::string id = ostream.str();
 
             boost::hash<string> string_hash;
             size_t v = string_hash(id);
@@ -461,7 +483,7 @@ namespace IPCore
         {
             path.clear();
 
-            if (widths)
+            if (!widths.empty())
             {
                 for (size_t i = 0; i < npoints; i++)
                     path.add(points[i], widths[i]);
@@ -689,7 +711,14 @@ namespace IPCore
             if (!f->initialized())
                 f->init();
             f->setSize(ptsize);
-            f->setColor(color.x, color.y, color.z, color.w);
+
+            Color textColor;
+            const auto* localCommand =
+                dynamic_cast<const PaintIPNode::LocalCommand*>(this);
+            bool isGhostOn =
+                (localCommand != nullptr) ? localCommand->ghostOn : false;
+            textColor = isGhostOn ? localCommand->ghostColor : color;
+            f->setColor(textColor.x, textColor.y, textColor.z, textColor.w);
 
             const float w = fbo->width();
             const float h = fbo->height();

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -91,8 +91,8 @@ def hook_function(
                     "duration": duration,
                     "hold": is_hold,
                     "ghost": is_ghost,
-                    "ghostBefore": 3,
-                    "ghostAfter": 3,
+                    "ghostBefore": 5,
+                    "ghostAfter": 5,
                 },
             )
 

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -12,6 +12,24 @@ import opentimelineio as otio
 from rv import commands, extra_commands
 
 
+def calculate_next_available_start_time(in_timeline, frame):
+    annotations = []
+
+    for layer in in_timeline.layers:
+        if layer.name == "Paint":
+            time_range = layer.layer_range
+            start_time = int(time_range.start_time.value)
+            annotations.append(start_time)
+
+    annotations.sort()
+
+    for start_time in annotations:
+        if start_time > frame:
+            return start_time
+
+    return None
+
+
 def hook_function(
     in_timeline: otio.schemadef.Annotation.Annotation, argument_map: dict | None = None
 ) -> None:
@@ -38,6 +56,26 @@ def hook_function(
             # Set properties on the paint component of the RVPaint node
             effectHook.set_rv_effect_props(paint_component, {"nextId": stroke_id + 1})
 
+            is_hold = argument_map["effect_metadata"]["hold"]
+            is_ghost = argument_map["effect_metadata"]["ghost"]
+
+            start_time = int(time_range.start_time.value)
+            end_time = int(start_time + time_range.duration.value)
+
+            if is_hold:
+                next_available_start_time = calculate_next_available_start_time(
+                    in_timeline, frame
+                )
+                if next_available_start_time is not None:
+                    duration = next_available_start_time - start_time
+                else:
+                    source = argument_map.get("src")
+                    media_info = commands.sourceMediaInfo(source)
+                    end_frame = int(media_info["endFrame"])
+                    duration = end_frame - start_time
+            else:
+                duration = end_time - start_time
+
             # Add and set properties on the pen component of the RVPaint node
             effectHook.add_rv_effect_props(
                 pen_component,
@@ -49,6 +87,12 @@ def hook_function(
                     "cap": 1,
                     "splat": 0,
                     "mode": 0 if layer.type == "COLOR" else 1,
+                    "startFrame": start_time,
+                    "duration": duration,
+                    "hold": is_hold,
+                    "ghost": is_ghost,
+                    "ghostBefore": 3,
+                    "ghostAfter": 3,
                 },
             )
 

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -56,8 +56,9 @@ def hook_function(
             # Set properties on the paint component of the RVPaint node
             effectHook.set_rv_effect_props(paint_component, {"nextId": stroke_id + 1})
 
-            is_hold = argument_map["effect_metadata"]["hold"]
-            is_ghost = argument_map["effect_metadata"]["ghost"]
+            metadata = argument_map.get("effect_metadata")
+            is_hold = metadata.get("hold")
+            is_ghost = metadata.get("ghost")
 
             start_time = int(time_range.start_time.value)
             end_time = int(start_time + time_range.duration.value)

--- a/src/plugins/rv-packages/otio_reader/annotation_schema.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_schema.py
@@ -54,13 +54,14 @@ class Annotation(otio.schema.Effect):
 
     def __str__(self) -> str:
         return (
-            f"Annotation({self.name}, {self.effect_name}, {self.visible}, "
-            f"{self.layers})"
+            f"Annotation({self.name}, {self.effect_name}, {self.metadata}, "
+            f"{self.layers}), {self.visible}"
         )
 
     def __repr__(self) -> str:
         return (
             f"otio.schema.Annotation(name={self.name!r}, "
             f"effect_name={self.effect_name!r}, "
+            f"metadata={self.metadata!r}, "
             f"visible={self.visible!r}, layers={self.layers!r})"
         )

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -398,7 +398,7 @@ def _create_timeline(tl, context=None):
     with set_context(
         context,
         global_start_time=tl.global_start_time,
-        **_get_global_transform(tl, context)
+        **_get_global_transform(tl, context),
     ):
         stack = create_rv_node_from_otio(tl.tracks, context)
 
@@ -612,12 +612,13 @@ def _create_movieproc(time_range, kind="blank"):
 
 def _add_effects(it, last_result, context=None):
     for effect in it.effects:
-        result = create_rv_node_from_otio(effect, context)
+        with set_context(context, effect_metadata=effect.metadata):
+            result = create_rv_node_from_otio(effect, context)
 
-        if result:
-            commands.setNodeInputs(result, [last_result])
-            _add_metadata_to_node(effect, result)
-            last_result = result
+            if result:
+                commands.setNodeInputs(result, [last_result])
+                _add_metadata_to_node(effect, result)
+                last_result = result
 
     return last_result
 


### PR DESCRIPTION
### Add hold and ghost

### Summarize your change.

This PR adds hold and ghost in the PaintIPNode based on the implementation in Create and the cherry-pick in [shotgun-rv](https://git.autodesk.com/media-and-entertainment/shotgun-rv/pull/1262) that was never merged. The following properties were added to enabled the feature in RV: `startFrame`, `duration`, `hold`, `ghost`, `ghostBefore` and `ghostAfter`. The Open RV documentation reflects this addition in the Paint node.

Hold and ghost can be enable on both polylines and text boxes. To hold annotations, a `duration` property was needed to know the number of frames on which the annotation should be held from the specified `startFrame`. To ghost annotations, a `ghostBefore` and `ghostAfter` properties were added to set the number of frames on which the ghosted annotation should be displayed before and after the actual annotation. The opacity to apply on ghosted annotations was also updated to match the web app instead of Create to make the annotations more visible the closer they are to the actual annotation, and the more transparent the further they are. Note that some code that was part of the cherry-pick was to fix some thread safeness issues, without being directly related to the hold and ghost feature, but more generally for the PaintIPNode. This code is also part of this PR to make sure everything is on par with what should have been merged back then, but I can remove it, if it makes this PR too hard to review.

Since this was added as a feature for Live Review, the annotation schema, the annotation hook and the otio reader are also updated in this PR. The `hold` and `ghost` properties are received for now as part of the annotation metadata. To access the values in the annotation hook, the context in the otio reader needed to be added the metadata propertyof OTIO effects. In the annotation hook, all the new properties to enable hold and ghost were added. The `duration` property is calculated so that a held annotation will stay on the frames until the next annotated frame or the end of the media. For ghosted annotations and "normal" annotations, the duration is simply the specified OTIO time range, which is normally 1, but it could be any other values.

To see the complete implementation of hold and ghost in the Live Review plugin, and some screen recordings, please refer to this other [PR](https://git.autodesk.com/media-and-entertainment/rv/pull/362). Also note that a playback issue is currently present when enabling `ghost` where the first frame without any annotation will completely freeze until the next annotated frame. However, the ghost feature is working as expected when scrubbing on the timeline. Held annotations and "normal" annotations are not affected by this issue.

### Describe the reason for the change.

RV is missing the hold and ghost feature that is needed for Live Review.

### Describe what you have tested and on which operating system.
All the test were done on macos between RV and the web app during a Live Review session.