### PR TITLE
Add fallback version when clang download fails

### DIFF
--- a/src/build/make_pyside6.py
+++ b/src/build/make_pyside6.py
@@ -80,18 +80,36 @@ def prepare() -> None:
     # PySide6 requires Clang 13+.
     print("Setting up Clang...")
     clang_filename_suffix = ""
+    fallback_clang_filename_suffix = None
 
     system = platform.system()
     if system == "Darwin":
-        clang_version_search = re.search(
-            "version (\d+)\.(\d+)\.(\d+)",
-            os.popen("clang --version").read(),
-        )
-        clang_version_str = ".".join(clang_version_search.groups())
-        if clang_version_str == "17.0.0":
-            # The 17.0.0 version does not exist on the Qt server
-            clang_version_str = "17.0.1"
-        clang_filename_suffix = clang_version_str + "-based-macos-universal.7z"
+
+        def get_clang_version():
+            version_output = os.popen("clang --version").read()
+            version_search = re.search(r"version (\d+)\.(\d+)\.(\d+)", version_output)
+            if version_search:
+                return version_search.groups()
+            print(f"ERROR: Could not extract clang --version")
+            return None
+
+        def get_clang_filename_suffix(version):
+            version_str = ".".join(version)
+            return f"{version_str}-based-macos-universal.7z"
+
+        def get_fallback_clang_filename_suffix(version):
+            major_minor_version_str = ".".join(version[:2])
+            if major_minor_version_str == "17.0":
+                return "17.0.1-based-macos-universal.7z"
+            return None
+
+        clang_version = get_clang_version()
+        if clang_version:
+            clang_filename_suffix = get_clang_filename_suffix(clang_version)
+            fallback_clang_filename_suffix = get_fallback_clang_filename_suffix(
+                clang_version
+            )
+
     elif system == "Linux":
         clang_filename_suffix = "19.1.0-based-linux-Rhel8.8-gcc10.3-x86_64.7z"
     elif system == "Windows":
@@ -99,13 +117,28 @@ def prepare() -> None:
 
     download_url = LIBCLANG_URL_BASE + clang_filename_suffix
     libclang_zip = os.path.join(TEMP_DIR, "libclang.7z")
-    if os.path.exists(libclang_zip) is False:
-        download_file(download_url, libclang_zip)
+
     # if we have a failed download, clean it up and redownload.
     # checking for False since it can return None when archive doesn't have a CRC
-    elif verify_7z_archive(libclang_zip) is False:
+    if os.path.exists(libclang_zip) and verify_7z_archive(libclang_zip) is False:
         os.remove(libclang_zip)
-        download_file(download_url, libclang_zip)
+
+    # download it if necessary
+    if os.path.exists(libclang_zip) is False:
+        download_ok = download_file(download_url, libclang_zip)
+        if not download_ok and fallback_clang_filename_suffix:
+            fallback_download_url = LIBCLANG_URL_BASE + fallback_clang_filename_suffix
+            print(
+                f"WARNING: Could not download or version does not exist: {download_url}"
+            )
+            print(
+                f"WARNING: Attempting to fallback on known version: {fallback_download_url}..."
+            )
+            download_ok = download_file(fallback_download_url, libclang_zip)
+        if not download_ok:
+            print(
+                f"ERROR: Could not download or version does not exist: {download_url}"
+            )
 
     # clean up previous failed extraction
     libclang_tmp = os.path.join(TEMP_DIR, "libclang-tmp")

--- a/src/build/utils.py
+++ b/src/build/utils.py
@@ -231,6 +231,8 @@ def download_file(url, file_path):
     """
     Download a file with HTTP or HTTPS.
 
+    Returns True if the HTTP request succeeded, False otherwise
+
     param: url: url to download
     param file_path: destination file path
     """
@@ -250,6 +252,8 @@ def download_file(url, file_path):
                 current += len(chunk)
                 file.write(chunk)
                 print(f"{current} / {total} ({round((current / total) * 100)}%)")
+
+    return req.ok
 
 
 def get_cygpath_windows(cygpath: str) -> str:


### PR DESCRIPTION
### Add fallback version when clang download fails

### Linked issues
NA

### Describe the reason for the change.

Fix a build break with the macOS build of Open RV when using the very latest version of Xcode/clang released a couple of days ago.

### Summarize your change.

This commit fixes an issue with the very latest version of Xcode/clang where the clang binary matching the new version is not available on the Qt mirror site. This commit adds a fall back mechanism so that a known version of clang can be used if the specific clang version binary matching the Xcode/clang is not available from the Qt mirror site.

### Describe what you have tested and on which operating system.
Successfully tested on macOS using the latest version of Xcode/clang : clang 17.0.13 which doesn't have a matching binary on the Qt mirror site.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.