### PR TITLE
Update gc.cmake to work with non-RHEL distros

### DIFF
--- a/cmake/dependencies/gc.cmake
+++ b/cmake/dependencies/gc.cmake
@@ -20,7 +20,7 @@ SET(_install_dir
     ${RV_DEPS_BASE_DIR}/${_target}/install
 )
 
-IF(RV_TARGET_LINUX)
+IF(RHEL_VERBOSE)
   SET(_lib_dir
       ${_install_dir}/lib64
   )


### PR DESCRIPTION
Unlike all the other dependency cmake files, this one was using RV_TARGET_LINUX rather than RHEL_VERBOSE to determine if the lib directory should be "lib64". This caused issues building under non-RHEL distros like ubuntu.
