### PR TITLE
Fix issue with PyOpenGL-accelerate on MacOS x86_64

### DIFF
--- a/cmake/dependencies/patch/pyopengl-accelerate.patch
+++ b/cmake/dependencies/patch/pyopengl-accelerate.patch
@@ -1,0 +1,12 @@
+diff --git a/accelerate/src/vbo.pyx b/accelerate/src/vbo.pyx
+index 13f9e99d..6e92c059 100644
+--- a/accelerate/src/vbo.pyx
++++ b/accelerate/src/vbo.pyx
+@@ -1,6 +1,7 @@
+ """Cython-coded VBO implementation"""
+ #cython: language_level=3
+ import ctypes, weakref
++from ctypes import c_long as long
+ from OpenGL_accelerate.formathandler cimport FormatHandler
+ from OpenGL import error
+ from OpenGL._bytes import bytes,unicode

--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -254,6 +254,41 @@ EXTERNALPROJECT_ADD(
   USES_TERMINAL_BUILD TRUE
 )
 
+# ##############################################################################################################################################################
+# This is temporary until the patch gets into the official PyOpenGL repo.      #
+# ##############################################################################################################################################################
+# Only for Apple Intel. Windows and Linux uses the requirements.txt file to install PyOpenGL-accelerate.
+IF(APPLE
+   AND RV_TARGET_APPLE_X86_64
+)
+  MESSAGE(STATUS "Patching PyOpenGL and building PyOpenGL from source")
+  SET(_patch_pyopengl_command
+      patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patch/pyopengl-accelerate.patch
+  )
+
+  EXTERNALPROJECT_ADD(
+    pyopengl_accelerate
+    URL "https://github.com/mcfletch/pyopengl/archive/refs/tags/release-3.1.8.tar.gz"
+    URL_MD5 "d7a9e2f8c2d981b58776ded865b3e22a"
+    DOWNLOAD_NAME release-3.1.8.tar.gz
+    DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/pyopengl_accelerate
+    PATCH_COMMAND ${_patch_pyopengl_command}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND "${_python3_executable}" -m pip install ./accelerate
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/pyopengl_accelerate/.pip_installed
+    BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/pyopengl_accelerate/setup.py
+    DEPENDS ${${_python3_target}-requirements-flag}
+    BUILD_IN_SOURCE TRUE
+    USES_TERMINAL_BUILD TRUE
+  )
+
+  # Ensure pyopengl_accelerate is built as part of the dependencies target
+  ADD_DEPENDENCIES(dependencies pyopengl_accelerate)
+ENDIF()
+# ##############################################################################################################################################################
+
 SET(${_python3_target}-requirements-flag
     ${_install_dir}/${_python3_target}-requirements-flag
 )

--- a/src/build/requirements.txt
+++ b/src/build/requirements.txt
@@ -5,10 +5,14 @@ setuptools              # License: MIT License
 # We need to use the main branch of the OTIO Github repo since the latest release available as a Pypi package is missing some features we need for Live Review
 git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO@main#egg=OpenTimelineIO # License: Other/Proprietary License (Modified Apache 2.0 License)
 PyOpenGL                # License: BSD License (BSD)
+
+# MacOS only - PyOpenGL_accelerate is built from source in python3.cmake as a workaround until the fix
+# is merged in the main branch.
+# See https://github.com/mcfletch/pyopengl/issues/147 and https://github.com/mcfletch/pyopengl/pull/146
+
 # PyOpenGL_accelerate as issue with native arm64 build on MacOS.
 # Use PyOpenGL_accelerate only on x86_64 platform.
-PyOpenGL_accelerate ; platform_machine=='x86_64' # License: BSD License (BSD)
-
+PyOpenGL_accelerate ; (platform_system=='Windows' or platform_system=='Linux') and platform_machine=='x86_64' # License: BSD License (BSD)
 
 # Those are installed by the src/build/make_python.py script, adding them here to list their licenses.
 


### PR DESCRIPTION
### Fix issue with PyOpenGL-accelerate on MacOS x86_64

### Linked issues
NA

### Describe the reason for the change.
To fix build break on mac intel: PyOpenGL-accelerate

### Summarize your change.
This is a cherry pick from a fix from the OpenRV main branch.
For reference: https://github.com/AcademySoftwareFoundation/OpenRV/commit/36a92db3a5f2f863a247b568bb594d2df25ae443

### Describe what you have tested and on which operating system.
Successfully testes on mac intel

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.