### PR TITLE
Fix 2x mute audio issues

### DIFF
--- a/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
+++ b/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
@@ -563,15 +563,20 @@ namespace Rv
 
     void RvBottomViewToolBar::audioSliderChanged(int value)
     {
-        // turn off mute first
-        audioMuteTriggered(false);
-        m_muteAction->setChecked(false);
-
-        float v = float(value) / 99.0;
+        const float v = float(value) / 99.0;
         FloatPropertyEditor editor(m_session->graph(),
                                    m_session->currentFrame(),
                                    "#RVSoundTrack.audio.volume");
-        editor.setValue(v);
+
+        // Has the volume changed?
+        if (v != editor.value())
+        {
+            // Turn off the mute audio first
+            audioMuteTriggered(false);
+            m_muteAction->setChecked(false);
+
+            editor.setValue(v);
+        }
     }
 
     void RvBottomViewToolBar::setVolumeIcon()

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -363,11 +363,21 @@ namespace IPCore
 
         DisplayGroupIPNode* displayGroup = primaryDisplayGroup();
         const VideoDevice* d = displayGroup ? displayGroup->imageDevice() : 0;
+        const auto isMuted = m_mute ? m_mute->front() : false;
 
         initializeIPTree(modules);
 
         if (d)
+        {
             setPrimaryDisplayGroup(d);
+        }
+
+        // Preserve the mute audio state that we had before the reset.
+        // Note that IPGraph::reset() is called when clearing an RV session
+        if (m_mute)
+        {
+            m_mute->front() = isMuted;
+        }
     }
 
     void IPGraph::clear()


### PR DESCRIPTION
### Fix 2x mute audio issues

### Linked issues
NA

### Describe the reason for the change.
I have identified two problematic behaviours with the Mute Audio functionality in RV:

**Problematic Behaviour#1:** 
When clearing an RV session, the RV audio is automatically unmuted. It should not.

**Problematic Behaviour#2:** 
When programmatically muting the RV audio, the RV audio is automatically unmuted the first time you access the RV audio UI without even changing anything. It should not.

### Summarize your change.

**Problematic Behaviour#1:**
In IPGraph::reset(): 
Preserve the mute audio state that we had before the reset.
Note that IPGraph::reset() is called when clearing an RV session

**Problematic Behaviour#2:** 
In RvBottomViewToolBar::audioSliderChanged():
The idea is to unmute the RV audio whenever someone changes the RV audio volume.
However this method is always called the first time the RV audio UI is invoked (even without changing anything) causing the RV audio to be unmuted.
Now unmuting ONLY if the volume has actually changed.

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.