### PR TITLE
Add Clang14 fallback for make_pyside6.cmake

### DIFF
--- a/src/build/make_pyside6.py
+++ b/src/build/make_pyside6.py
@@ -99,7 +99,9 @@ def prepare() -> None:
 
         def get_fallback_clang_filename_suffix(version):
             major_minor_version_str = ".".join(version[:2])
-            if major_minor_version_str == "17.0":
+            if major_minor_version_str == "14.0":
+                return "14.0.3-based-macos-universal.7z"
+            elif major_minor_version_str == "17.0":
                 return "17.0.1-based-macos-universal.7z"
             return None
 


### PR DESCRIPTION
### Add Clang14 fallback for make_pyside6.cmake

### Linked issues
n/a

### Summarize your change.

Add a fallback to download the right version of libclang for PySide6 when using Clang 14.

### Describe the reason for the change.

The mirror does not have all the versions of libclang, therefore we need a fallback for Clang 14.

### Describe what you have tested and on which operating system.
MacOS Ventura using Clang 14

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.