### PR TITLE
Add High DPI Display support to RV

### DIFF
--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -250,7 +250,9 @@ int utf8Main(int argc, char* argv[])
     XInitThreads();
 #endif
 
-    const bool noHighDPISupport = getenv("RV_QT_HDPI_SUPPORT") == nullptr;
+    // Now supporting high DPI displays by default
+    // Setting the following environment variable, disable the high DPI support
+    const bool noHighDPISupport = getenv("RV_NO_QT_HDPI_SUPPORT") != nullptr;
     if (noHighDPISupport)
     {
         qunsetenv("QT_SCALE_FACTOR");

--- a/src/bin/nsapps/RV/main.cpp
+++ b/src/bin/nsapps/RV/main.cpp
@@ -298,11 +298,6 @@ int main(int argc, char* argv[])
     setenv("QT_QUICK_BACKEND", "software",
            0 /* changeFlag : Do not change the existing value */);
 
-    // Qt 5.12.1 specific
-    // Prevent Mac from automatically scaling app pixel coordinates in OpenGL
-    setenv("QT_MAC_WANTS_BEST_RESOLUTION_OPENGL_SURFACE", "0",
-           0); /* changeFlag : Do not change the existing value */
-
     // Prevent usage of native sibling widgets on Mac. This attribute can be
     // removed if GLView is changed to inherit from QOpenGLWidget.
     QApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
@@ -312,9 +307,16 @@ int main(int argc, char* argv[])
     // Device.
     QApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
 
-    const bool noHighDPISupport = getenv("RV_QT_HDPI_SUPPORT") == nullptr;
+    // Now supporting high DPI displays by default
+    // Setting the following environment variable, disable the high DPI support
+    const bool noHighDPISupport = getenv("RV_NO_QT_HDPI_SUPPORT") != nullptr;
     if (noHighDPISupport)
     {
+        // Prevent Mac from automatically scaling app pixel coordinates in
+        // OpenGL
+        setenv("QT_MAC_WANTS_BEST_RESOLUTION_OPENGL_SURFACE", "0",
+               0); /* changeFlag : Do not change the existing value */
+
         unsetenv("QT_SCALE_FACTOR");
         unsetenv("QT_SCREEN_SCALE_FACTORS");
         unsetenv("QT_AUTO_SCREEN_SCALE_FACTOR");

--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -335,7 +335,8 @@ namespace Rv
         int t = y + h;
 
         // are the extents of the read region out of bounds?
-        if (x < 0 || y < 0 || r > width() || t > height())
+        if (x < 0 || y < 0 || r > width() * devicePixelRatio()
+            || t > height() * devicePixelRatio())
             return false;
 
         return true;
@@ -865,6 +866,11 @@ namespace Rv
         }
 
         return false;
+    }
+
+    float GLView::devicePixelRatio() const
+    {
+        return videoDevice() ? videoDevice()->devicePixelRatio() : 1.0f;
     }
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -512,6 +512,9 @@ namespace Rv
             new Function(c, "showDiagnostics", showDiagnostics, None, Return,
                          "void", End),
 
+            new Function(c, "devicePixelRatio", devicePixelRatio, None, Return,
+                         "float", End),
+
             EndArguments);
     }
 
@@ -2377,6 +2380,22 @@ namespace Rv
         Session* s = Session::currentSession();
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         doc->showDiagnostics();
+    }
+
+    NODE_IMPLEMENTATION(devicePixelRatio, float)
+    {
+        float devicePixelRatio = 1.0f;
+
+        const Session* s = Session::currentSession();
+        const RvDocument* doc =
+            reinterpret_cast<RvDocument*>(s->opaquePointer());
+
+        if (doc != nullptr && doc->view() != nullptr)
+        {
+            devicePixelRatio = doc->view()->devicePixelRatio();
+        }
+
+        NODE_RETURN(devicePixelRatio);
     }
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/GLView.h
+++ b/src/lib/app/RvCommon/RvCommon/GLView.h
@@ -64,6 +64,10 @@ namespace Rv
 
         QImage readPixels(int x, int y, int w, int h);
 
+        // Device pixel ratio for high DPI displays
+        // For reference: https://doc.qt.io/qt-6/highdpi.html
+        float devicePixelRatio() const;
+
     public slots:
         void eventProcessingTimeout();
 

--- a/src/lib/app/RvCommon/RvCommon/MuUICommands.h
+++ b/src/lib/app/RvCommon/RvCommon/MuUICommands.h
@@ -91,6 +91,7 @@ namespace Rv
     NODE_DECLARATION(javascriptMuExport, void);
     NODE_DECLARATION(framebufferPixelValue, Mu::Vector4f);
     NODE_DECLARATION(showDiagnostics, void);
+    NODE_DECLARATION(devicePixelRatio, float);
 
 } // namespace Rv
 

--- a/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
@@ -59,6 +59,8 @@ namespace Rv
         virtual size_t width() const;
         virtual size_t height() const;
 
+        virtual Resolution internalResolution() const;
+
         virtual void open(const StringVector&);
         virtual void close();
         virtual bool isOpen() const;
@@ -72,6 +74,12 @@ namespace Rv
             return Capabilities(capabilities()) == NoCapabilities;
         }
 
+        virtual void setPhysicalDevice(VideoDevice* d);
+
+        // Device pixel ratio for high DPI displays
+        // For reference: https://doc.qt.io/qt-6/highdpi.html
+        float devicePixelRatio() const override { return m_devicePixelRatio; }
+
     protected:
         QTGLVideoDevice(const std::string& name, QOpenGLWidget* view);
 
@@ -79,6 +87,7 @@ namespace Rv
         int m_x;
         int m_y;
         float m_refresh;
+        float m_devicePixelRatio{1.0f};
         QOpenGLWidget* m_view;
         QTTranslator* m_translator;
     };

--- a/src/lib/app/TwkApp/TwkApp/VideoDevice.h
+++ b/src/lib/app/TwkApp/TwkApp/VideoDevice.h
@@ -628,6 +628,9 @@ namespace TwkApp
 
         virtual void setPhysicalDevice(VideoDevice* d) { m_physicalDevice = d; }
 
+        // Device pixel ratio for high DPI displays
+        virtual float devicePixelRatio() const { return 1.0f; }
+
     protected:
         void setCapabilities(unsigned int caps) { m_capabilities = caps; }
 

--- a/src/lib/app/mu_rvui/HUD.mu
+++ b/src/lib/app/mu_rvui/HUD.mu
@@ -252,17 +252,18 @@ class: ImageInfo : Widget
             bg = state.config.bgErr;
         }
 
-        gltext.size(state.config.infoTextSize);
+        let devicePixelRatio = devicePixelRatio();
+        gltext.size(state.config.infoTextSize*devicePixelRatio);
         setupProjection(domain.x, domain.y, event.domainVerticalFlip());
 
-        let margin  = state.config.bevelMargin,
-            x       = _x + margin,
-            y       = _y + margin,
-            wrap    = if (_wrap) then 80 else 0,
+        let margin  = state.config.bevelMargin*devicePixelRatio,
+            x       = _x*devicePixelRatio + margin,
+            y       = _y*devicePixelRatio + margin,
+            wrap    = if (_wrap) then 80*devicePixelRatio else 0,
             tbox    = drawNameValuePairs(expandNameValuePairs(attrs, wrap),
                                          fg, bg, x, y, margin)._0,
             emin    = vec2f(_x, _y),
-            emax    = emin + tbox + vec2f(margin*2.0, 0.0);
+            emax    = emin + (tbox + vec2f(margin*2.0, 0.0))/devicePixelRatio;
 
         if (_inCloseArea)
         {
@@ -376,6 +377,7 @@ class: InfoStrip : Widget
             w      = domain.x,
             h      = domain.y,
             pinfo  = state.pixelInfo,
+            devicePixelRatio = devicePixelRatio(),
             attrs  = sourceAttributes(if (pinfo neq nil && !pinfo.empty()) 
                                           then pinfo.front().name
                                           else nil);
@@ -389,7 +391,7 @@ class: InfoStrip : Widget
         //  Don't allow the widget to be dragged off the window or
         //  into the top/bottom margin.
         //
-        _y = max(min(_y, h - 30 - margins()[2]), margins()[3]);
+        _y = max(min(_y, h/devicePixelRatio - 30 - margins()[2]), margins()[3]);
 
         if (attrs eq nil)  return;
 
@@ -415,8 +417,8 @@ class: InfoStrip : Widget
 
         state.filestripX1 = 0;
 
-        int textSize = 20;
-        if (_scaleWithResolution)
+        let textSize = 20.0*devicePixelRatio;
+        if (_scaleWithResolution && devicePixelRatio==1.0)
         {
             int baseResolution = 1280;
             int fontSize = 20;
@@ -428,15 +430,15 @@ class: InfoStrip : Widget
         setupProjection(w, h, event.domainVerticalFlip());
 
         let b      = gltext.bounds(filename),
-            margin = state.config.bevelMargin,
+            margin = state.config.bevelMargin*devicePixelRatio,
             m2     = margin,
             md     = margin / 2,
             tw     = b[2],
             th     = b[3],
             x      = w - tw,
-            y      = _y + md;
+            y      = _y*devicePixelRatio + md;
 
-        state.filestripX1 = y + th + 5;
+        state.filestripX1 = y + th + 5*devicePixelRatio;
         glPushAttrib(GL_ENABLE_BIT | GL_POLYGON_BIT);
         glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
         glEnable(GL_BLEND);
@@ -449,8 +451,8 @@ class: InfoStrip : Widget
                                 fg, bg,
                                 circleGlyph, bg * .7);
 
-        updateBounds(vec2f(x - margin, y - md),
-                        vec2f(x + tw, y + th + md));
+        updateBounds(vec2f(x - margin, y - md)/devicePixelRatio,
+                     vec2f(x + tw, y + th + md)/devicePixelRatio);
 
         if (_inCloseArea)
         {
@@ -535,7 +537,8 @@ class: ProcessInfo : Widget
             return;
         }
 
-        gltext.size(state.config.infoTextSize);
+        let devicePixelRatio = devicePixelRatio();
+        gltext.size(state.config.infoTextSize*devicePixelRatio);
         setupProjection(domain.x, domain.y, event.domainVerticalFlip());
 
         (string,string)[] pairs;
@@ -543,9 +546,9 @@ class: ProcessInfo : Widget
         pairs.push_back((" ", "%s" % message));
         pairs.push_back((p._name, " "));
 
-        let margin  = state.config.bevelMargin,
-            x       = _x + margin,
-            y       = _y + margin,
+        let margin  = state.config.bevelMargin*devicePixelRatio,
+            x       = _x*devicePixelRatio + margin,
+            y       = _y*devicePixelRatio + margin,
             bgbar   = (fg + bg) / 4.0,
             fgbar   = (fg + bg) / 2.0,
             barsize = gltext.bounds("          ")[2] * 8,
@@ -563,7 +566,7 @@ class: ProcessInfo : Widget
             px   = x + nw + md,
             py   = y + th * 1 + fd + th/2,
             emin = vec2f(_x, _y),
-            emax = emin + tbox + vec2f(margin*2.0, 0.0);
+            emax = emin + (tbox + vec2f(margin*2.0, 0.0))/devicePixelRatio;
 
         let bwidth = barsize * pcent * .01;
 
@@ -601,10 +604,10 @@ class: ProcessInfo : Widget
         // touch memory space of the Buttons array, we just update its 
         // x/y/w/h/pid content, member-by-member, which still is not 
         // 100% ideal, but safe and harmless enough, and we won't crash.
-        _buttons[0]._x = pcx + 4;
-        _buttons[0]._y = pcy;
-        _buttons[0]._w = rad * 2;
-        _buttons[0]._h = rad * 2;
+        _buttons[0]._x = (pcx + 4)/devicePixelRatio;
+        _buttons[0]._y = (pcy)/devicePixelRatio;
+        _buttons[0]._w = (rad * 2)/devicePixelRatio;
+        _buttons[0]._h = (rad * 2)/devicePixelRatio;
         _buttons[0]._callback = killProcess(p,);
 
         gltext.writeAt(pcx + 3.0 * rad, pcy, "%-3.1f%%" % pcent);
@@ -1206,16 +1209,17 @@ class: SourceDetails : Widget
             bg = state.config.bgErr;
         }
 
-        gltext.size(state.config.infoTextSize);
+        let devicePixelRatio = devicePixelRatio();
+        gltext.size(state.config.infoTextSize*devicePixelRatio);
         setupProjection(domain.x, domain.y, event.domainVerticalFlip());
 
-        let margin  = state.config.bevelMargin,
-            x       = _x + margin,
-            y       = _y + margin,
+        let margin  = state.config.bevelMargin*devicePixelRatio,
+            x       = _x*devicePixelRatio + margin,
+            y       = _y*devicePixelRatio + margin,
             tbox    = drawNameValuePairs(expandNameValuePairs(details),
                                          fg, bg, x, y, margin)._0,
             emin    = vec2f(_x, _y),
-            emax    = emin + tbox + vec2f(margin*2.0, 0.0);
+            emax    = emin + (tbox + vec2f(margin*2.0, 0.0))/devicePixelRatio;
 
         if (_inCloseArea)
         {

--- a/src/lib/app/mu_rvui/commands.mud
+++ b/src/lib/app/mu_rvui/commands.mud
@@ -1766,5 +1766,10 @@ For a device in a module return the ID string for one of the ModuleNameID, Devic
 or VideoAndDataFormatID. This is currently used to locate settings for display profiles.
 """
 
+devicePixelRatio """
+Return the device pixel ratio for high DPI displays.
+For reference: https://doc.qt.io/qt-6/highdpi.html
+"""
+
 }
 }

--- a/src/lib/app/mu_rvui/glyph.mu
+++ b/src/lib/app/mu_rvui/glyph.mu
@@ -524,12 +524,13 @@ operator: & (Glyph; Glyph a, Glyph b)
                     string[] descriptors)
 {
     let m  = margins(),
+        devicePixelRatio=devicePixelRatio(),
         bsize = (h - m[2] - m[3]) / descriptors.size(),
         inregion = -1;
 
     for_index (i; descriptors)
     {
-        gltext.size(20);
+        gltext.size(20*devicePixelRatio);
 
         let y0 = bsize * i + margin + m[3],
             x0 = m[0] + margin,

--- a/src/lib/app/mu_rvui/inspector.mu
+++ b/src/lib/app/mu_rvui/inspector.mu
@@ -399,7 +399,7 @@ class: Inspector : Widget
         let domain = event.subDomain(),
             p      = event.relativePointer(),
             m      = state.config.bevelMargin,
-            tri    = vec2f(_widW - 32, domain.y-0.7*m),
+            tri    = vec2f(_widW/devicePixelRatio() - 32, domain.y-0.7*m),
             pc     = p - tri,
             d      = mag(pc),
             near   = d < 9;
@@ -488,14 +488,13 @@ class: Inspector : Widget
 
     method: _drawCross (void; Point p, float t)
     {
-        let x0 = Vec2(2, 0),
-            x1 = Vec2(7, 0),
-            y0 = Vec2(0, 2),
-            y1 = Vec2(0, 7);
+        let devicePixelRatio = devicePixelRatio(),
+            x0 = Vec2(2*devicePixelRatio, 0),
+            x1 = Vec2(7*devicePixelRatio, 0),
+            y0 = Vec2(0, 2*devicePixelRatio),
+            y1 = Vec2(0, 7*devicePixelRatio);
 
-       float f = t/2.0;
-
-        glLineWidth(3.0);
+        glLineWidth(3.0*devicePixelRatio);
 
         glColor(0.5-t,0.5-t,0.5-t,1);
 
@@ -506,7 +505,7 @@ class: Inspector : Widget
         glVertex(p - y0); glVertex(p - y1);
         glEnd();
 
-        glLineWidth(1.0);
+        glLineWidth(1.0*devicePixelRatio);
         glColor(0.5+t,0.5+t,0.5+t,1);
 
         glBegin(GL_LINES);
@@ -527,7 +526,9 @@ class: Inspector : Widget
             initializeNoPoint(this);
         }
 
-        let pinfo = imagesAtPixel(_colorPointEvent, nil, true).front(),
+        let isRenderEvent = event.name() == "render",
+            devicePixelRatio = (if isRenderEvent then devicePixelRatio() else 1.0),
+            pinfo = imagesAtPixel(_colorPointEvent, nil, true).front(),
             sName = sourceNameWithoutFrame(pinfo.name),
             sp = getSourcePixel(pinfo, sName, frame());
 
@@ -536,22 +537,22 @@ class: Inspector : Widget
         let domain = event.domain(),
             bg     = state.config.bg,
             fg     = state.config.fg,
-            margin = state.config.bevelMargin,
+            margin = state.config.bevelMargin*devicePixelRatio,
             m2     = margin,
             md     = margin / 2,
-            p      = imageToEventSpace(sName, _colorPointImage), // + Vec2(50,50),
+            p      = imageToEventSpace(sName, _colorPointImage)*devicePixelRatio,
             c      = if _showFBColor then _fbColor else _currentColor;
 
         if (event.domainVerticalFlip()) p.y = domain.y - 1 - p.y;
 
-        gltext.size(state.config.inspectorTextSize);
+        gltext.size(state.config.inspectorTextSize * devicePixelRatio);
 
         if (_colorSampling && (frame() != _colorFrame || _inputsChanged || _graphStateChanged || _glReadPending))
         {
             if (_showFBColor)
             {
                 float[] pixels;
-                glReadPixels(_colorPointEvent.x, _colorPointEvent.y, 1, 1, GL_RGBA, pixels);
+                glReadPixels(_colorPointEvent.x*devicePixelRatio, _colorPointEvent.y*devicePixelRatio, 1, 1, GL_RGBA, pixels);
                 _fbColor = Color(pixels[0], pixels[1], pixels[2], pixels[3]);
                 c = _fbColor;
             }
@@ -674,7 +675,7 @@ class: Inspector : Widget
             emin = vec2f(x, y) - vec2f(margin, margin),
             emax = emin + tbox + vec2f(margin*2.0, 0.0);
 
-        this.updateBounds(emin, emax);
+        this.updateBounds(emin/devicePixelRatio, emax/devicePixelRatio);
 
         glColor(bg);
         glPushAttrib(GL_ENABLE_BIT);
@@ -704,21 +705,21 @@ class: Inspector : Widget
         if (_pointerStyle == PointerStyleBox)
         {
             glColor(bg);
-            let offset = 2;
-            glLineWidth(2.0);
+            let offset = 2*devicePixelRatio;
+            glLineWidth(2.0*devicePixelRatio);
             drawRect(GL_LINE_LOOP,
                     p+Vec2( offset,  offset),
                     p+Vec2( offset, -offset),
                     p+Vec2(-offset, -offset),
                     p+Vec2(-offset,  offset));
-            offset = 4;
+            offset = 4*devicePixelRatio;
             glColor(0.8*fg);
             drawRect(GL_LINE_LOOP,
                     p+Vec2( offset,  offset),
                     p+Vec2( offset, -offset),
                     p+Vec2(-offset, -offset),
                     p+Vec2(-offset,  offset));
-            glLineWidth(1.0);
+            glLineWidth(1.0*devicePixelRatio);
         }
         else
         if (_pointerStyle == PointerStyleCross)
@@ -751,7 +752,7 @@ class: Inspector : Widget
         //  Menu triangle
 
         glColor((if _nearTriangle then 0.9 else 0.7)*fg);
-        draw (triangleGlyph, x + _widW - 52, tbox.y + y - 1.7*margin , 90.0, 8.0, false);
+        draw (triangleGlyph, x + _widW - 52*devicePixelRatio, tbox.y + y - 1.7*margin , 90.0, 8.0*devicePixelRatio, false);
 
         if (_inCloseArea || (_containsPointer && _closeButtonStyle == CloseButtonAlways))
         {

--- a/src/lib/app/mu_rvui/rvtypes.mu
+++ b/src/lib/app/mu_rvui/rvtypes.mu
@@ -526,7 +526,8 @@ class: Widget : MinorMode
 
     method: requiredMarginValue (float; )
     {
-        let vs = viewSize();
+        let vs = viewSize(),
+            devicePixelRatio = devicePixelRatio();
 
         if (_whichMargin == -1)
         //
@@ -540,28 +541,28 @@ class: Widget : MinorMode
         //  Left margin
         //
         {
-            return _x + _w;
+            return (_x + _w)*devicePixelRatio;
         }
         else if (_whichMargin == 1)
         // 
         //  Right margin
         //
         {
-            return vs.x - _x;
+            return vs.x - _x*devicePixelRatio;
         }
         else if (_whichMargin == 2)
         // 
         //  Top margin
         //
         {
-            return vs.y - _y;
+            return vs.y - _y*devicePixelRatio;
         }
         else if (_whichMargin == 3)
         // 
         //  Bottom margin
         //
         {
-            return _y + _h;
+            return (_y + _h)*devicePixelRatio;
         }
 
         return 0.0;

--- a/src/lib/app/mu_rvui/rvui.mu
+++ b/src/lib/app/mu_rvui/rvui.mu
@@ -4771,9 +4771,12 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
 \: drawFeedback (void; Event event)
 {
     State state = data();
-    gltext.size(20);
 
     if (state.feedbackText eq nil) return;
+
+    let devicePixelRatio = devicePixelRatio(),
+        textsize = 20 * devicePixelRatio;
+    gltext.size(textsize);
 
     let d  = event.domain(),
         w  = d.x,
@@ -4794,8 +4797,10 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     let m = margins();
-    drawTextWithCartouche(m[0] + 20, h-20-sb[3] - m[2], state.feedbackText,
-                          20, fg, bg,
+    drawTextWithCartouche(m[0]*devicePixelRatio + textsize,
+                          h-textsize-sb[3] - m[2]*devicePixelRatio,
+                          state.feedbackText,
+                          textsize, fg, bg,
                           state.feedbackGlyph, gc);
     glDisable(GL_BLEND);
 
@@ -4898,7 +4903,7 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
         attrs    = getCurrentAttributes(),
         srcs     = sources(),
         noAttrs  = attrs == nil || attrs.empty(),
-        textsize = 20,
+        textsize = 20 * devicePixelRatio(),
         colorscl = 0.75,
         fstatus  = currentFrameStatus();
 

--- a/src/lib/app/mu_rvui/timeline.mu
+++ b/src/lib/app/mu_rvui/timeline.mu
@@ -147,22 +147,24 @@ class: Timeline : Widget
 
     method: renderLocations (Locations; Event event)
     {
-        let d            = event.domain(),
-            drawControls = _settings.showVCRButtons && (_controlSize * 14 < d.x),
-            tbounds      = gltext.bounds("||||"),
-            t            = floor(5 + 8 + 5 + tbounds[3] + 0.5); //floor(_vm0 + _tlh + vm1 + mxb[3] + 0.5),
+        let d                = event.domain(),
+            isRenderEvent    = event.name() == "render",
+            devicePixelRatio = (if isRenderEvent then devicePixelRatio() else 1.0),
+            drawControls     = _settings.showVCRButtons && (_controlSize * 14 * devicePixelRatio < d.x),
+            tbounds          = gltext.bounds("||||"),
+            t                = floor((5 + 8 + 5)*devicePixelRatio + tbounds[3] + 0.5); //floor(_vm0 + _tlh + vm1 + mxb[3] + 0.5),
 
         return Locations(d,
-                         d.x - (if drawControls then _controlSize * 6 else 0), // window width
-                         d.y,            // window height
+                         d.x - (if drawControls then _controlSize * devicePixelRatio * 6 else 0), // window width
+                         d.y,                   // window height
                          drawControls,
-                         8, // timeline height
+                         8*devicePixelRatio,    // timeline height
                          tbounds,
-                         100,  // horizontal margin
-                         100,  // vertical margin
+                         100*devicePixelRatio,  // horizontal margin
+                         100*devicePixelRatio,  // vertical margin
                          0,
-                         5, // bottom  margin
-                         5, // top margin
+                         5*devicePixelRatio,    // bottom  margin
+                         5*devicePixelRatio,    // top margin
                          t,
                          if _settings.drawAtTopOfView then floor(d.y - t + 0.5) else 0);
     }
@@ -178,8 +180,6 @@ class: Timeline : Widget
             fe = frameEnd();
 
         return (x - X0) / (X1 - X0) * (fe - fs + 1) + fs;
-        //_phantomFrame = /*floor*/
-            //((fromRelativeX(_phantomFrameXrelative, d.x) - _X0) / (_X1 - _X0) * (fe - fs + 1) + fs);
     }
 
     method: handleLeave (void; Event event)
@@ -194,7 +194,8 @@ class: Timeline : Widget
     {
         let gp = event.pointer(),
             p  = event.relativePointer(),
-            modified = false;
+            modified = false,
+            devicePixelRatio = devicePixelRatio();
 
         if (contains (gp))
         {
@@ -211,7 +212,11 @@ class: Timeline : Widget
                 modified = true;
                 redraw();
             }
-            if (    gp.x >= _ipCapX-4 &&  gp.x <= _ipCapX+4 &&
+
+            // The remaining comparisons are done in device pixels so adjust gp accordingly
+            gp *= devicePixelRatio;
+            
+            if (    gp.x >= _ipCapX-4 && gp.x <= _ipCapX+4 &&
                     gp.y >= _Ybot-2   && gp.y <= _Ytop+2)
             {
                 deb ("in inCap\n");
@@ -613,7 +618,7 @@ class: Timeline : Widget
         else
         {
             drawInMargin (-1);
-	    vec4f m = vec4f{-1.0, -1.0, -1.0, -1.0};
+            vec4f m = vec4f{-1.0, -1.0, -1.0, -1.0};
             m[whichMargin()] = 0;
             setMargins (m, true);
         }
@@ -636,7 +641,7 @@ class: Timeline : Widget
         {
             drawInMargin (whichMargin());
 
-	    vec4f m = vec4f{-1.0, -1.0, -1.0, -1.0};
+            vec4f m = vec4f{-1.0, -1.0, -1.0, -1.0};
             m[oldMargin] = 0;
             setMargins (m, true);
         }
@@ -1085,8 +1090,8 @@ class: Timeline : Widget
 
         _settings = Settings();
 
-	_sequenceBoundariesDirty = true;
-	_sequenceBoundaries = int[]();
+        _sequenceBoundariesDirty = true;
+        _sequenceBoundaries = int[]();
 
         setFrameDisplayFormat (_settings.frameDisplayFormat);
 
@@ -1106,22 +1111,23 @@ class: Timeline : Widget
         if (isCurrentFrameIncomplete()) updateBounds(vec2f(0,0), vec2f(0,0));
 
         State state = data();
-        gltext.size(state.config.tlFrameTextSize);
+        let devicePixelRatio = devicePixelRatio();
+        gltext.size(state.config.tlFrameTextSize * devicePixelRatio);
 
-        _vm0 =  if (_settings.drawAtTopOfView) then 5 else 5;  // vertical margin
-        _tlh = 8;                            // timeline height
+        _vm0 =  if (_settings.drawAtTopOfView) then 5*devicePixelRatio else 5*devicePixelRatio; // vertical margin
+        _tlh = 8*devicePixelRatio; // timeline height
 
         let d   = event.domain(),
             f   = frame(),
             s   = _frameFunc(f),
             sb  = gltext.bounds(s),             // size of frame string
             mxb = gltext.bounds("||||"),
-            vm1 = 5,
+            vm1 = 5*devicePixelRatio,
             t   = floor (_vm0 + _tlh + vm1 + mxb[3] + 0.5);
 
         _Y0  = if (_settings.drawAtTopOfView) then d.y - t else 0;
 
-        updateBounds(vec2f(0,_Y0), vec2f(d.x,_Y0+t));
+        updateBounds(vec2f(0,_Y0)/devicePixelRatio, vec2f(d.x,_Y0+t)/devicePixelRatio);
         event.reject();
     }
 
@@ -1151,7 +1157,8 @@ class: Timeline : Widget
             _pointerInInOutRegion = false;
         }
         State state = data();
-        gltext.size(state.config.tlFrameTextSize);
+        let devicePixelRatio = devicePixelRatio();
+        gltext.size(state.config.tlFrameTextSize * devicePixelRatio);
 
         let loc = renderLocations(event);
         let {d, w, h, drawControls, tlh, mxb, hm0, hm1, thm1, vm0, vm1, t, Y} = loc;
@@ -1205,7 +1212,8 @@ class: Timeline : Widget
 
         \: drawInfoTab (void; int frame, float xframe, string text)
         {
-            gltext.size(config.tlFrameTextSize * .75);
+            let devicePixelRatio = devicePixelRatio();
+            gltext.size(config.tlFrameTextSize * devicePixelRatio * .75);
 
             let mediaName   = text,
                 mediaBounds = gltext.bounds(mediaName),
@@ -1238,7 +1246,7 @@ class: Timeline : Widget
             gltext.writeAt(mediaX, mediaY - 4, mediaName);
 
             //glDisable(GL_BLEND);
-            gltext.size(config.tlFrameTextSize);
+            gltext.size(config.tlFrameTextSize * devicePixelRatio);
         }
 
 
@@ -1279,7 +1287,7 @@ class: Timeline : Widget
         //  presentation render (when event.name() == "render-output-device")
         //
 
-        if (event.name() == "render") updateBounds(vec2f(0,_Y0), vec2f(d.x,_Y0+t));
+        if (event.name() == "render") updateBounds(vec2f(0,_Y0)/devicePixelRatio, vec2f(d.x,_Y0+t)/devicePixelRatio);
 	else
 	//
 	//  OK this is a mess.  The problem is that the widget class still
@@ -1403,7 +1411,7 @@ class: Timeline : Widget
             glEnable(GL_POINT_SMOOTH);
             glEnable(GL_LINE_SMOOTH);
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            glLineWidth(1.5);
+            glLineWidth(1.5*devicePixelRatio);
 
             //
             //  In / Out points
@@ -1412,7 +1420,7 @@ class: Timeline : Widget
             if (_settings.showInOut)
             {
                 gltext.color(fg);
-                gltext.size(config.tlBoundsTextSize);
+                gltext.size(config.tlBoundsTextSize * devicePixelRatio);
 
                 let sin  = _frameFunc(fi),
                     sout = _frameFunc(fo),
@@ -1429,7 +1437,7 @@ class: Timeline : Widget
                                _Ytop + 3,
                                sout);
 
-                gltext.size(config.tlFrameTextSize);
+                gltext.size(config.tlFrameTextSize * devicePixelRatio);
             }
 
             //
@@ -1438,7 +1446,7 @@ class: Timeline : Widget
 
             if (cacheMode() != CacheOff)
             {
-                glLineWidth(3.0);
+                glLineWidth(3.0*devicePixelRatio);
                 glColor(lerp(config.tlCacheColor, config.tlCacheFullColor, vsecs));
                 glBegin(GL_LINES);
 
@@ -1452,12 +1460,12 @@ class: Timeline : Widget
                     let f0 = cachedRanges[i],
                         f1 = cachedRanges[i+1]+1;
 
-                    glVertex(xAtFrame(f0), _Ybot + 4);
-                    glVertex(xAtFrame(f1), _Ybot + 4);
+                    glVertex(xAtFrame(f0), _Ybot + 4*devicePixelRatio);
+                    glVertex(xAtFrame(f1), _Ybot + 4*devicePixelRatio);
                 }
 
                 glEnd();
-                glLineWidth(1.5);
+                glLineWidth(1.5*devicePixelRatio);
             }
 
             //
@@ -1466,7 +1474,7 @@ class: Timeline : Widget
 
             if (_displayAudioCache && (audioCacheMode() != CacheOff))
             {
-                glLineWidth(3.0);
+                glLineWidth(3.0*devicePixelRatio);
                 glColor(config.tlAudioCacheColor);
                 glBegin(GL_LINES);
 
@@ -1480,12 +1488,12 @@ class: Timeline : Widget
                     let f0 = cachedAudioRanges[i],
                         f1 = cachedAudioRanges[i+1]+1;
 
-                    glVertex(xAtFrame(f0), _Ybot + 6);
-                    glVertex(xAtFrame(f1), _Ybot + 6);
+                    glVertex(xAtFrame(f0), _Ybot + 6*devicePixelRatio);
+                    glVertex(xAtFrame(f1), _Ybot + 6*devicePixelRatio);
                 }
 
                 glEnd();
-                glLineWidth(1.5);
+                glLineWidth(1.5*devicePixelRatio);
             }
 
             //
@@ -1496,7 +1504,7 @@ class: Timeline : Widget
             _opCapX = hm0 + op * _tlw;
 
             glColor(config.tlInOutCapsColor);
-            glLineWidth(2);
+            glLineWidth(2*devicePixelRatio);
             glBegin(GL_LINES);
             glVertex(_ipCapX, _Ybot - 1);
             glVertex(_ipCapX, _Ytop + 1);
@@ -1505,7 +1513,7 @@ class: Timeline : Widget
             glEnd();
 
             glColor(fg);
-            glLineWidth(5);
+            glLineWidth(5*devicePixelRatio);
 
             if ((_pointerInInOutRegion &&
                 (fi != fs || fo != fe)) ||
@@ -1517,9 +1525,9 @@ class: Timeline : Widget
                 glEnd();
                 draw(triangleGlyph, _ipCapX-5, (_Ybot+_Ytop)/2.0, 0.0, 9.0, false);
                 glEnable(gl.GL_LINE_SMOOTH);
-                glLineWidth(1.5);
+                glLineWidth(1.5*devicePixelRatio);
                 draw(triangleGlyph, _ipCapX-6, (_Ybot+_Ytop)/2.0, 0.0, 9.0, true);
-                glLineWidth(5);
+                glLineWidth(5*devicePixelRatio);
 
             }
             if ((_pointerInInOutRegion &&
@@ -1532,9 +1540,9 @@ class: Timeline : Widget
                 glEnd();
                 draw(triangleGlyph, _opCapX+5, (_Ybot+_Ytop)/2.0, 180.0, 9.0, false);
                 glEnable(gl.GL_LINE_SMOOTH);
-                glLineWidth(1.5);
+                glLineWidth(1.5*devicePixelRatio);
                 draw(triangleGlyph, _opCapX+6, (_Ybot+_Ytop)/2.0, 180.0, 9.0, true);
-                glLineWidth(5);
+                glLineWidth(5*devicePixelRatio);
             }
 
             //
@@ -1544,7 +1552,7 @@ class: Timeline : Widget
             let mfs = markedFrames();
             glColor(config.tlMarkedColor);
 
-            glLineWidth(1.0);
+            glLineWidth(1.0*devicePixelRatio);
             glBegin(GL_LINES);
 
             for_each (mf; mfs)
@@ -1557,7 +1565,7 @@ class: Timeline : Widget
             }
 
             glEnd();
-            glLineWidth(1.5);
+            glLineWidth(1.5*devicePixelRatio);
 
             glPointSize(3.2);
             glBegin(GL_POINTS);
@@ -1659,7 +1667,7 @@ class: Timeline : Widget
             sw    = (sb[2] + sb[0]) / 2.0,
             sh    = -sb[1] + sb[3],
             sY    = _Ybot,
-            sYh   = sY + _tlh + 3,
+            sYh   = sY + _tlh + 3 * devicePixelRatio,
             ffilt = if playing then .1 else 1.0,
             fdiff = -sb[2] / 2.0 * ffilt + _frameTextOffset * (1.0 - ffilt),
             ftx   = xframeMid + fdiff;
@@ -1673,7 +1681,7 @@ class: Timeline : Widget
         glColor(fcol);
         gltext.color(fcol);
 
-        glLineWidth(2.0);
+        glLineWidth(2.0*devicePixelRatio);
         glBegin(GL_LINES);
         glVertex(xframe, sY - 1);
         glVertex(xframe, sYh - 2);
@@ -1683,10 +1691,10 @@ class: Timeline : Widget
         if (_settings.showFrameDirection)
         {
             let fwd    = inc() > 0,
-                xg     = if fwd then xframeMid - fdiff + 8.0 else ftx - 6.0,
+                xg     = if fwd then xframeMid - fdiff + 8.0*devicePixelRatio else ftx - 6.0,
                 yg     = sYh + (-mxb[1] + mxb[3]) / 2.0,
                 angle  = if fwd then 180.0 else 0.0,
-                radius = 8.0;
+                radius = 8.0 * devicePixelRatio;
 
             if (playing)
             {
@@ -1725,7 +1733,7 @@ class: Timeline : Widget
 
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-            glLineWidth(1.0);
+            glLineWidth(1.0*devicePixelRatio);
             glColor(fcol);
             glBegin(GL_LINES);
             glVertex(xframe1, sY - 1);
@@ -1733,7 +1741,7 @@ class: Timeline : Widget
             glEnd();
         }
 
-        glLineWidth(1.5);
+        glLineWidth(1.5*devicePixelRatio);
 
         if (_drag && _settings.showInputName)
         {
@@ -1751,7 +1759,7 @@ class: Timeline : Widget
             gltext.writeAtNL(10, _Ytop + 3, "%d" % (f - fi + 1));
         }
 
-        gltext.size(config.tlBoundsTextSize);
+        gltext.size(config.tlBoundsTextSize * devicePixelRatio);
         gltext.writeAtNL(10, _Ybot, _totalFunc(fo-fi+1));
 
         //
@@ -1816,8 +1824,8 @@ class: Timeline : Widget
 
         if (drawControls)
         {
-            let vcr_h  = _controlSize,
-                vcr_w  = _controlSize * 6,
+            let vcr_h  = _controlSize * devicePixelRatio,
+                vcr_w  = _controlSize * devicePixelRatio * 6,
                 vcr_x0 = d.x - vcr_w,
                 vcr_x1 = vcr_x0 + vcr_w,
                 vcr_y0 = 0,
@@ -1881,7 +1889,7 @@ class: Timeline : Widget
             glyphElement(4, advanceGlyph, 180, false);
 
             glColor(.15,.15,.15,1);
-            glLineWidth(1.0);
+            glLineWidth(1.0*devicePixelRatio);
             glyphElement(0, advanceGlyph, 0, true);
             glyphElement(1, triangleGlyph, 0, true);
             glyphElement(2, xformedGlyph(squareGlyph, 0, 0.8), 0, true);

--- a/src/lib/app/mu_rvui/wipes.mu
+++ b/src/lib/app/mu_rvui/wipes.mu
@@ -127,7 +127,8 @@ class: Wipe : MinorMode
 
         State state = data();
         let domain  = event.domain(),
-            p       = state.pointerPosition;
+            p       = state.pointerPosition,
+            devicePixelRatio = devicePixelRatio();
 
         _cornerEdit = false;
         _drawManip = false;
@@ -156,6 +157,8 @@ class: Wipe : MinorMode
             let param   = "%s.stencil.visibleBox" % tformNode,
                 vals    = getFloatProperty(param),
                 corners = imageGeometryByTag(i.tags[0]._0, i.tags[0]._1);
+
+            for_index (c; corners) corners[c] /= devicePixelRatio;
 
             if (i.inside)
             {
@@ -197,15 +200,15 @@ class: Wipe : MinorMode
             _sourceName      = sourceNameWithoutFrame(info.name);
             _sourcePoint     = state.pointerPosition;
             _nearEdge        = 0;
-            _grabPoint       = _manipPoint._1;
-	    _grabPointNorm   = eventToImageSpace(_sourceName, _grabPoint, true);
+            _grabPoint       = _manipPoint._1*devicePixelRatio;
+            _grabPointNorm   = eventToImageSpace(_sourceName, _grabPoint, true);
             _centerEdit      = !_cornerEdit;
             _currentEditNode = _manipPoint._2;
         }
         else if (info neq nil)
         {
             _sourceName    = sourceNameWithoutFrame(info.name);
-            _grabPoint     = Point(info.x, info.y);
+            _grabPoint     = Point(info.x*devicePixelRatio, info.y*devicePixelRatio);
 	    _grabPointNorm = eventToImageSpace(_sourceName, _grabPoint, true);
             _manipPoint    = (info, _grabPoint, editNode(tagValue(info.tags, "wipe")));
             _sourcePoint   = state.pointerPosition;
@@ -231,11 +234,7 @@ class: Wipe : MinorMode
             // this happens when the view changes for some reason
             //assert(_nearEdge != -1);
             if (_nearEdge == -1) print("wipes: _nearEdge == -1\n");
-        }
-        else
-        {
-            //print("nada\n");
-            ;
+
         }
 
         redraw();
@@ -272,10 +271,11 @@ class: Wipe : MinorMode
                 pp    = event.pointer(),
                 dp    = _downPoint,
                 ip    = pp - dp,
-                a     = _corners[0],
-                b     = _corners[1],
-                c     = _corners[2],
-                d     = _corners[3],
+                devicePixelRatio = devicePixelRatio(),
+                a     = _corners[0]/devicePixelRatio,
+                b     = _corners[1]/devicePixelRatio,
+                c     = _corners[2]/devicePixelRatio,
+                d     = _corners[3]/devicePixelRatio,
                 dx    = dot(ip, normalize(b - a)) * xs / mag(b - a),
                 dy    = dot(ip, normalize(d - a)) * ys / mag(d - a),
                 v0    = vals[0] + dx,
@@ -563,9 +563,10 @@ class: Wipe : MinorMode
         if (_cameraChange || !state.pointerInSession) return;
 
         let domain  = event.domain(),
+            devicePixelRatio = devicePixelRatio(),
             bg      = state.config.bg,
             fg      = state.config.fg,
-            p       = state.pointerPosition,
+            p       = state.pointerPosition*devicePixelRatio,
 	    ms      = margins();
 
 	if (p.x < ms[0] || p.x > domain.x - ms[1] || p.y > domain.y - ms[2] || p.y < ms[3]) return;
@@ -584,9 +585,6 @@ class: Wipe : MinorMode
 
 	    let infos = imagesAtPixel(_sourcePoint),
 	        name = sourceNameWithoutFrame(_manipPoint._0.name);
-
-            //if (_corners.empty()) _corners = imageGeometry(sourceNameWithoutFrame(_manipPoint._0.name));
-            //if (_corners.empty()) _corners = imageGeometry(infos.front().name);
 
 	    let ep = imageToEventSpace (name, _grabPointNorm, true);
 
@@ -628,7 +626,7 @@ class: Wipe : MinorMode
                 {
                     glPushMatrix();
                     glTranslate(ep.x, ep.y, 0.0);
-                    glScale(25.0, 25.0, 25.0);
+                    glScale(25.0*devicePixelRatio, 25.0*devicePixelRatio, 25.0*devicePixelRatio);
                     glRotate(rotang, 0, 0, 1);
                     glColor(bg * Color(1,1,1,.5));
                     circleGlyph(false);
@@ -637,7 +635,7 @@ class: Wipe : MinorMode
 
                     glPushMatrix();
                     glTranslate(ep.x, ep.y, 0.0);
-                    glScale(25.0, 25.0, 25.0);
+                    glScale(25.0*devicePixelRatio, 25.0*devicePixelRatio, 25.0*devicePixelRatio);
                     glRotate(rotang, 0, 0, 1);
                     glColor(fg);
                     translateIconGlyph(false);
@@ -650,7 +648,7 @@ class: Wipe : MinorMode
                 { 
                     glPushMatrix();
                     glTranslate(ep.x, ep.y, 0.0);
-                    glScale(25.0, 25.0, 25.0);
+                    glScale(25.0*devicePixelRatio, 25.0*devicePixelRatio, 25.0*devicePixelRatio);
                     glRotate(rotang, 0, 0, 1);
                     glColor(bg * Color(1,1,1,.25));
                     circleGlyph(false);
@@ -659,7 +657,7 @@ class: Wipe : MinorMode
 
                     glPushMatrix();
                     glTranslate(ep.x, ep.y, 0.0);
-                    glScale(25.0, 25.0, 25.0);
+                    glScale(25.0*devicePixelRatio, 25.0*devicePixelRatio, 25.0*devicePixelRatio);
                     glRotate(rotang, 0, 0, 1);
                     glColor(fg);
                     if ((_nearEdge & 1) == 0) translateXIconGlyph(false);
@@ -672,16 +670,16 @@ class: Wipe : MinorMode
                 }
                 
                 glColor(fg*0.5);
-                glPointSize(12.0);
+                glPointSize(12.0*devicePixelRatio);
                 glBegin(GL_POINTS); glVertex(ep); glEnd();
                 glColor(fg);
-                glPointSize(8.0);
+                glPointSize(8.0*devicePixelRatio);
                 glBegin(GL_POINTS); glVertex(ep); glEnd();
 
                 if (_showInfo)
                 {
                     (string,string)[] pairs;
-                    gltext.size(state.config.wipeInfoTextSize);
+                    gltext.size(state.config.wipeInfoTextSize*devicePixelRatio);
 
                     \: reverse ((string,string)[]; (string,string)[] s)
                     {
@@ -739,7 +737,7 @@ class: Wipe : MinorMode
                         ey = y + th * (state.pixelInfo.size() - 1) + fd + th/2 + 2.0;
 
                     glEnable(GL_POINT_SMOOTH);
-                    glPointSize(6.0);
+                    glPointSize(6.0*devicePixelRatio);
                     glBegin(GL_POINTS);
                     glColor(Color(.75,.75,.15,1));
                     glVertex(gx, gy);

--- a/src/lib/app/py_rvui/rv_commands_setup.py
+++ b/src/lib/app/py_rvui/rv_commands_setup.py
@@ -308,6 +308,7 @@ all_mu_commands = [
     "sourceMediaRepSwitchNode",
     "sourceMediaRepSourceNode",
     "sourceMediaRepsAndNodes",
+    "devicePixelRatio",
 ]
 
 

--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -1815,7 +1815,13 @@ namespace IPMu
         Vector2f inp = NODE_ARG(0, Vector2f);
         StringType::String* tagname = NODE_ARG_OBJECT(1, StringType::String);
         bool sourcesOnly = NODE_ARG(2, bool);
-        Box2f vp = s->renderer()->viewport();
+
+        // Note that the viewport is already taking the devicePixelRatio into
+        // account (High DPI display) whereas the input coordinates are in pixel
+        // space, so we need to adjust the viewport accordingly.
+        Box2f vp = s->renderer()->viewport()
+                   / s->renderer()->currentDevice()->devicePixelRatio();
+
         float x = (inp[0] - vp.min.x) / (vp.size().x - 1.0) * 2.0 - 1.0;
         float y = (inp[1] - vp.min.y) / (vp.size().y - 1.0) * 2.0 - 1.0;
         DynamicArray* array = new DynamicArray(atype, 1);

--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -696,7 +696,8 @@ class: AnnotateMinorMode : MinorMode
 
             let pinfo = imagesAtPixel(event.pointer(), "annotate").front(),
                 name  = pinfo.name,
-                ip    = event.pointer();
+                devicePixelRatio = devicePixelRatio(),
+                ip    = event.pointer()*devicePixelRatio;
 
             _pointer = ip;
             _pointerRadius = mag(imageToEventSpace(name, ip, true)
@@ -742,7 +743,7 @@ class: AnnotateMinorMode : MinorMode
 
         let pinfo  = state.pixelInfo.front(),
             sName  = sourceNameWithoutFrame(pinfo.name),
-            ip     = state.pointerPosition;
+            ip     = state.pointerPosition*devicePixelRatio();
 
         let pixels = framebufferPixelValue(ip.x, ip.y);
         let c = Color(pixels[0], pixels[1], pixels[2], pixels[3]);


### PR DESCRIPTION
### Add High DPI Display support to RV

### Linked issues
NA

### Describe the reason for the change.
Taking advantage of high DPI monitor capabilities for nicer RV UI and better media resolution.

### Summarize your change.
This PR is leveraging Qt's high DPI capability in RV:
https://doc.qt.io/qt-6/highdpi.html

It is pretty straightforward: a high DPI scaling factor is available on a per screen basis via the QScreen::devicePixelRatio().
On non high DPI monitors or display resolution, this devicePixelRatio is 1.0f.
On high DPI monitors and compatible resolutions, QScreen::devicePixelRatio() returns a high DPI scaling factor that needs to be applied both in X and Y.

Note that this is on a per screen basis because a computer system could have multiple monitors of various high DPI capabilities and resolutions.

In this commit, the float GLView::devicePixelRatio() method was added which effectively returns the QScreen::devicePixelRatio() for the Qt screen where the GLView is currently being rendered.
A new devicePixelRatio() RV command was also added so that the different UI elements in RV can be adapted to take this new high DPI scaling into account.

With this commit, we are now supporting high DPI displays by default
Setting the following environment variable, effectively disable the high DPI support in RV and restore the previous non high DPI capable functionality:
`export RV_NO_QT_HDPI_SUPPORT=1`

### Describe what you have tested and on which operating system.
Successfully tested on macOS with 4K external monitor set in 4K resolution to validate transitioning from a high DPI monitor (Retina Display) to a non high DPI monitor.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.
<img width="1020" alt="better_ui_and_media_resolution_with_high_dpi_support_in_rv" src="https://github.com/user-attachments/assets/d7100388-c73a-47d1-928c-052e51dbde00" />

