### PR TITLE
SG-38113: Add stand-alone Clear All Frames

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -1619,7 +1619,7 @@ class: AnnotateMinorMode : MinorMode
 
     method: clearSlot (void; bool checked)
     {
-        clearPaint(_currentNode, sourceFrame(frame()));
+        clearPaint(_currentNode, _currentNodeInfo.frame);
         updateFrameDependentState();
         redraw();
     }
@@ -1639,6 +1639,7 @@ class: AnnotateMinorMode : MinorMode
                 let annotatedFrames = findAnnotatedFrames(node);
                 for_each(frame; annotatedFrames)
                 {
+                    clearPaint(node, frame);
                     clearPaint(node, sourceFrame(frame));
                 }
             }


### PR DESCRIPTION
### [SG-38113](https://jira.autodesk.com/browse/SG-38113): Add stand-alone Clear All Frames

### Summarize your change.

Update the Annotation package to be able to clear all annotations on the timeline. To handle this new feature, a dropdown menu was added to the Clear button in the Draw panel to differentiate between clearing annotations on the current frame and clearing all annotations on the timeline. The Annotations menu was also updated to display both option. To prevent users from clearing all the annotations on the timeline by accident, an alert panel was added to confirm the user's intention.

### Describe the reason for the change.

This feature is required if we wish RV to be functionally on par with Creative Review Web with respect to Annotation related features.

### Describe what you have tested and on which operating system.

This feature was tested on macOS 15.5.

### If possible, provide screenshots.


https://github.com/user-attachments/assets/d1c7aaad-92c5-4b93-a696-368f2f976dbe