### PR TITLE
Windows - Make sure the right Python is used in Windows Debug

### DIFF
--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -54,7 +54,7 @@ def test_python_distribution(python_home: str) -> None:
         print(f"Moving {python_home} to {tmp_python_home}")
         shutil.move(python_home, tmp_python_home)
 
-        python_validation_args = get_python_interpreter_args(tmp_python_home) + [
+        python_validation_args = get_python_interpreter_args(tmp_python_home, VARIANT) + [
             "-c",
             "\n".join(
                 [
@@ -133,7 +133,7 @@ def prepare() -> None:
     os.environ["CLANG_INSTALL_DIR"] = libclang_install_dir
 
     # PySide2 build requires a version of numpy lower than 1.23
-    install_numpy_args = get_python_interpreter_args(PYTHON_OUTPUT_DIR) + [
+    install_numpy_args = get_python_interpreter_args(PYTHON_OUTPUT_DIR, VARIANT) + [
         "-m",
         "pip",
         "install",
@@ -202,7 +202,7 @@ def build() -> None:
     Run the build step of the build. It compile every target of the project.
     """
     python_home = PYTHON_OUTPUT_DIR
-    python_interpreter_args = get_python_interpreter_args(python_home)
+    python_interpreter_args = get_python_interpreter_args(python_home, VARIANT)
 
     pyside_build_args = python_interpreter_args + [
         os.path.join(SOURCE_DIR, "setup.py"),

--- a/src/build/make_pyside6.py
+++ b/src/build/make_pyside6.py
@@ -54,7 +54,7 @@ def test_python_distribution(python_home: str) -> None:
         print(f"Moving {python_home} to {tmp_python_home}")
         shutil.move(python_home, tmp_python_home)
 
-        python_validation_args = get_python_interpreter_args(tmp_python_home) + [
+        python_validation_args = get_python_interpreter_args(tmp_python_home, VARIANT) + [
             "-c",
             "\n".join(
                 [
@@ -168,7 +168,7 @@ def prepare() -> None:
     os.environ["CLANG_INSTALL_DIR"] = libclang_install_dir
 
     # PySide6 build requires numpy 1.26.3
-    install_numpy_args = get_python_interpreter_args(PYTHON_OUTPUT_DIR) + [
+    install_numpy_args = get_python_interpreter_args(PYTHON_OUTPUT_DIR, VARIANT) + [
         "-m",
         "pip",
         "install",
@@ -237,7 +237,7 @@ def build() -> None:
     Run the build step of the build. It compile every target of the project.
     """
     python_home = PYTHON_OUTPUT_DIR
-    python_interpreter_args = get_python_interpreter_args(python_home)
+    python_interpreter_args = get_python_interpreter_args(python_home, VARIANT)
 
     pyside_build_args = python_interpreter_args + [
         os.path.join(SOURCE_DIR, "setup.py"),

--- a/src/build/make_python.py
+++ b/src/build/make_python.py
@@ -130,13 +130,18 @@ def get_python_interpreter_args(python_home: str, variant : str) -> List[str]:
         os.path.join(python_home, "bin", python_name_pattern)
     )
 
-    # sort put python# before python#-config
+    # sort put python# before python#-config, prioritize debug on Windows debug builds
     python_interpreters = sorted(
         [
             p
             for p in python_interpreters
             if os.path.islink(p) is False and os.access(p, os.X_OK)
-        ]
+        ],
+        key=lambda p: (
+            "-config" in os.path.basename(p),  # config variants last
+            not ("_d" in os.path.basename(p) and platform.system() == "Windows" and variant.lower() == "debug"),  # prioritize _d on Windows debug
+            os.path.basename(p)  # alphabetical
+        )
     )
 
     if not python_interpreters or os.path.exists(python_interpreters[0]) is False:

--- a/src/build/make_python.py
+++ b/src/build/make_python.py
@@ -112,7 +112,7 @@ except Exception as e:
 '''
 
 
-def get_python_interpreter_args(python_home: str) -> List[str]:
+def get_python_interpreter_args(python_home: str, variant : str) -> List[str]:
     """
     Return the path to the python interpreter given a Python home
 
@@ -221,7 +221,7 @@ def patch_python_distribution(python_home: str) -> None:
                 print(f"Copying {lib_path} to the python home")
                 shutil.copy(lib_path, os.path.join(python_home, "libs"))
 
-    python_interpreter_args = get_python_interpreter_args(python_home)
+    python_interpreter_args = get_python_interpreter_args(python_home, VARIANT)
 
     # -I : isolate Python from the user's environment
     python_interpreter_args.append("-I")
@@ -290,7 +290,7 @@ def test_python_distribution(python_home: str) -> None:
         print(f"Moving {python_home} to {tmp_python_home}")
         shutil.move(python_home, tmp_python_home)
 
-        python_interpreter_args = get_python_interpreter_args(tmp_python_home)
+        python_interpreter_args = get_python_interpreter_args(tmp_python_home, VARIANT)
 
         # Note: We need to build opentimelineio from sources in Windows+Debug
         #       because the official wheel links with the release version of


### PR DESCRIPTION
### Windows - Make sure the right Python is used in Windows Debug

### Linked issues
n/a

### Summarize your change.
Added the build type as parameter for `get_python_interpreter_args` to make sure that the right Python is returned. The change has no effect on other platform because the other platforms does not have a debug prefix for Python Debug.

### Describe the reason for the change.
Currently, the Python Release executable is **always** used in Windows Debug to install `numpy` and that causes issue with Nanobind since Nanobind is using Python Debug. The issue has been there for a long time

### Describe what you have tested and on which operating system.
Windows

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.