### PR TITLE
SG-39413: Add BMD SDI support for 120Hz

### DIFF
--- a/src/plugins/output/BlackMagicDevices/DeckLinkVideoDevice.cpp
+++ b/src/plugins/output/BlackMagicDevices/DeckLinkVideoDevice.cpp
@@ -229,6 +229,13 @@ namespace BlackMagicDevices
          bmdMode8K4320p48},
         {8192, 4320, 1.0, 48.00, "4320p (8192x4320) DCI 8K 48Hz",
          bmdMode8kDCI48},
+        {1920, 1080, 1.0, 120.00, "1080p 120Hz", bmdModeHD1080p120},
+        {2048, 1080, 1.0, 120.00, "1080p (2048x1080) DCI 2K 120Hz",
+         bmdMode2kDCI120},
+        {3840, 2160, 1.0, 120.00, "2160p (3840x2160) UHD 4K 120Hz",
+         bmdMode4K2160p120},
+        {4096, 2160, 1.0, 120.00, "4096p (4096x2160) DCI 4K 120Hz",
+         bmdMode4kDCI120},
         {0, 0, 1.0, 00.00, NULL, bmdModeHD720p50},
     };
 


### PR DESCRIPTION
### [SG-39413](https://jira.autodesk.com/browse/SG-39413): Add BMD SDI support for 120Hz

### Summarize your change.

Add 120Hz SDI format support to the BMD SDI path for 1080p, DCI 2K, UHD 4K, and DCI 4K. Note that the formats were added at the end of the list to follow #652 comment about user preferences based on format indexes.

### Describe the reason for the change.

These missing formats were supported by the Blackmagic DeckLink SDK but had never beed added to RV until today.

### Describe what you have tested and on which operating system.

The video formats were added based on the DeckLink SDK documentation. However, since we don't have access to the monitor needed to test them, no tests were performed.