### PR TITLE
Added sample window if diagnostics are empty

### DIFF
--- a/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
+++ b/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
@@ -51,4 +51,7 @@ namespace Rv
             PyGILState_Release(gstate);
         }
     }
+
+    int ImGuiPythonBridge::nbCallbacks() { return (int)s_callbacks.size(); }
+
 } // namespace Rv

--- a/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.h
+++ b/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.h
@@ -17,6 +17,7 @@ namespace Rv
         static void registerCallback(PyObject* callable);
         static void unregisterCallback(PyObject* callable);
         static void callCallbacks();
+        static int nbCallbacks();
 
         struct PyObjectDeleter
         {

--- a/src/lib/app/RvCommon/DiagnosticsView.cpp
+++ b/src/lib/app/RvCommon/DiagnosticsView.cpp
@@ -275,7 +275,7 @@ namespace Rv
             "than building your own Qt user interface.");
         ImGui::TextWrapped(
             "From your Python plugin, you simply need to register a "
-            "diagnsotics callback, and from the callback, call ImGui/ImPlot "
+            "diagnostics callback, and from the callback, call ImGui/ImPlot "
             "functios to display your data.");
         ImGui::TextWrapped(
             "Note that there is no need to implement backends for handling "

--- a/src/lib/app/RvCommon/DiagnosticsView.cpp
+++ b/src/lib/app/RvCommon/DiagnosticsView.cpp
@@ -285,10 +285,16 @@ namespace Rv
         ImGui::TextWrapped("");
         ImGui::TextWrapped("---------------------------------------------");
         ImGui::TextWrapped("");
+        ImGui::TextWrapped("import pyimgui as imgui");
+        ImGui::TextWrapped("import pyimplot as implot");
+        ImGui::TextWrapped("");
         ImGui::TextWrapped("def __init__( self ):");
         ImGui::TextWrapped(
             "   commands.register_diagnostics_callback( self.my_callback )");
         ImGui::TextWrapped("");
+        ImGui::TextWrapped("def __del__( self ):");
+        ImGui::TextWrapped(
+            "   commands.unregister_diagnostics_callback( self.my_callback )");
         ImGui::TextWrapped("");
         ImGui::TextWrapped("def my_callback( self ):");
         ImGui::TextWrapped("   imgui.begin( \"Example Window\" )");

--- a/src/lib/app/RvCommon/DiagnosticsView.cpp
+++ b/src/lib/app/RvCommon/DiagnosticsView.cpp
@@ -306,7 +306,7 @@ namespace Rv
         ImGui::TextLinkOpenURL("ImGui Python bindings",
                                "https://github.com/pthom/imgui_bundle/blob/"
                                "main/external/imgui/bindings/pybind_imgui.cpp");
-        ImGui::TextLinkOpenURL("ImPlot", "https://github.com/ocornut/imgui");
+        ImGui::TextLinkOpenURL("ImPlot", "https://github.com/pthom/implot");
         ImGui::SameLine();
         ImGui::TextWrapped("and");
         ImGui::SameLine();

--- a/src/lib/app/RvCommon/DiagnosticsView.cpp
+++ b/src/lib/app/RvCommon/DiagnosticsView.cpp
@@ -276,10 +276,10 @@ namespace Rv
         ImGui::TextWrapped(
             "From your Python plugin, you simply need to register a "
             "diagnostics callback, and from the callback, call ImGui/ImPlot "
-            "functios to display your data.");
+            "functions to display your data.");
         ImGui::TextWrapped(
             "Note that there is no need to implement backends for handling "
-            "keyboard/mouse and graphics; this part is alredy done for you.");
+            "keyboard/mouse and graphics; this part is already done for you.");
         ImGui::TextWrapped("");
         ImGui::TextWrapped("Hello World example:");
         ImGui::TextWrapped("");
@@ -303,7 +303,7 @@ namespace Rv
         ImGui::SameLine();
         ImGui::TextWrapped("and");
         ImGui::SameLine();
-        ImGui::TextLinkOpenURL("ImGui Python Bindings",
+        ImGui::TextLinkOpenURL("ImGui Python bindings",
                                "https://github.com/pthom/imgui_bundle/blob/"
                                "main/external/imgui/bindings/pybind_imgui.cpp");
         ImGui::TextLinkOpenURL("ImPlot", "https://github.com/ocornut/imgui");
@@ -315,8 +315,8 @@ namespace Rv
             "https://github.com/pthom/imgui_bundle/blob/main/external/implot/"
             "bindings/pybind_implot.cpp");
         ImGui::TextWrapped("");
-        ImGui::TextWrapped(
-            "Comprehensive Python examples of how to create GUIs can be found");
+        ImGui::TextWrapped("Comprehensive Python examples of how to create "
+                           "interactive interfaces can be found");
         ImGui::TextLinkOpenURL(
             "here (ImGui)",
             "https://github.com/pthom/imgui_bundle/blob/main/bindings/"

--- a/src/lib/app/RvCommon/DiagnosticsView.cpp
+++ b/src/lib/app/RvCommon/DiagnosticsView.cpp
@@ -264,6 +264,82 @@ namespace Rv
             &fontCfg);
     }
 
+    void DiagnosticsView::showHelpWindow()
+    {
+        ImGui::Begin("ImGui/ImPlot Help");
+        ImGui::TextWrapped("The diagnostics window uses the easy-to-learn Dear "
+                           "ImGui and ImPlot APIs and their python bindings.");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped(
+            "Adding your own diagnostics info is quick and easy, much easier "
+            "than building your own Qt user interface.");
+        ImGui::TextWrapped(
+            "From your Python plugin, you simply need to register a "
+            "diagnsotics callback, and from the callback, call ImGui/ImPlot "
+            "functios to display your data.");
+        ImGui::TextWrapped(
+            "Note that there is no need to implement backends for handling "
+            "keyboard/mouse and graphics; this part is alredy done for you.");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped("Hello World example:");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped("---------------------------------------------");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped("def __init__( self ):");
+        ImGui::TextWrapped(
+            "   commands.register_diagnostics_callback( self.my_callback )");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped("def my_callback( self ):");
+        ImGui::TextWrapped("   imgui.begin( \"Example Window\" )");
+        ImGui::TextWrapped("   imgui.text( \"Hello World!\" )");
+        ImGui::TextWrapped("   imgui.end()");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped("---------------------------------------------");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped("Full reference for Dear ImGui and Implot and their "
+                           "bindings can be found here:");
+        ImGui::TextLinkOpenURL("ImGui", "https://github.com/ocornut/imgui");
+        ImGui::SameLine();
+        ImGui::TextWrapped("and");
+        ImGui::SameLine();
+        ImGui::TextLinkOpenURL("ImGui Python Bindings",
+                               "https://github.com/pthom/imgui_bundle/blob/"
+                               "main/external/imgui/bindings/pybind_imgui.cpp");
+        ImGui::TextLinkOpenURL("ImPlot", "https://github.com/ocornut/imgui");
+        ImGui::SameLine();
+        ImGui::TextWrapped("and");
+        ImGui::SameLine();
+        ImGui::TextLinkOpenURL(
+            "ImPlot Python bindings",
+            "https://github.com/pthom/imgui_bundle/blob/main/external/implot/"
+            "bindings/pybind_implot.cpp");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped(
+            "Comprehensive Python examples of how to create GUIs can be found");
+        ImGui::TextLinkOpenURL(
+            "here (ImGui)",
+            "https://github.com/pthom/imgui_bundle/blob/main/bindings/"
+            "imgui_bundle/demos_python/demos_immapp/imgui_demo.py");
+        ImGui::SameLine();
+        ImGui::TextWrapped("and");
+        ImGui::SameLine();
+        ImGui::TextLinkOpenURL(
+            "here (ImPlot)",
+            "https://github.com/pthom/imgui_bundle/blob/main/bindings/"
+            "pyodide_web_demo/examples/demo_implot_stock.py");
+        ImGui::TextWrapped("");
+        ImGui::TextWrapped(
+            "Finally, several good additional resources for ImGui and its "
+            "add-ons are easily found online, including video tutorials.");
+        ImGui::TextWrapped("A good interactive reference manual can be found");
+        ImGui::SameLine();
+        ImGui::TextLinkOpenURL("here",
+                               "https://pthom.github.io/imgui_manual_online/"
+                               "manual/imgui_manual.html");
+        ImGui::End();
+    }
+
     void DiagnosticsView::paintGL()
     {
         QOpenGLWidget::paintGL();
@@ -277,6 +353,13 @@ namespace Rv
         ImGuiID dockspace_id = ImGui::GetID("DiagnosticsDockSpace");
         ImVec2 dockspace_size = ImGui::GetContentRegionAvail();
         ImGui::DockSpaceOverViewport(dockspace_id);
+
+        bool forceShowHelp = false;
+        if ((Rv::ImGuiPythonBridge::nbCallbacks() == 0) || forceShowHelp)
+        {
+            showHelpWindow();
+        }
+
         Rv::ImGuiPythonBridge::callCallbacks();
 
         // Render ImGui Frame

--- a/src/lib/app/RvCommon/RvCommon/DiagnosticsView.h
+++ b/src/lib/app/RvCommon/RvCommon/DiagnosticsView.h
@@ -33,6 +33,7 @@ namespace Rv
         void initializeGL() override;
         void paintGL() override;
 
+        void showHelpWindow();
         void applyStyle();
         void handleMenuBar();
         void resetDockSpace();


### PR DESCRIPTION

### Summarize your change.

When no python plugin registers diagnostics callbacks, and the callback window is open, show an ImGui window with instructions on how to make your first diagnostics info panel

### Describe the reason for the change.

An empty diagnostics window is really boring and pointless and full of question marks from users.

### Describe what you have tested and on which operating system.

macOS.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

<img width="737" alt="image" src="https://github.com/user-attachments/assets/ec4bf156-0888-4d94-a1d4-1aae1f02c504" />
