### PR TITLE
SG-39535: Update UI live review

### DIFF
--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-five.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-five.md
@@ -218,9 +218,8 @@ Some events will originate from RV itself. These include things like new-source 
 | before-play-start |  |  | Play mode will start |
 | mark-frame | frame |  | Frame was marked |
 | unmark-frame | frame |  | Frame was unmarked |
-| set-annotation-hold |  |  | Enable held annotation |
-| set-annotation-ghost |  |  | Enable ghosted annotation |
-| toggle-draw-panel |  |  | Toggle the draw panel of the annotation package |
+| update-hold-button |  |  | Update the checked state of the hold button |
+| update-ghost-button |  |  | Update the checked state of the ghost button |
 | pixel-block | Event.data() |  | A block of pixels was received from a remote connection |
 | graph-state-change |  |  | A property in the image processing graph changed |
 | graph-node-inputs-changed | nodename |  | Inputs of a top-level node added/removed/re-ordered |

--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-sixteen.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-sixteen.md
@@ -443,10 +443,6 @@ Paint nodes are used primarily to store per frame annotations. Below *id* is the
 | pen: *id* : *frame* : *user* .mode | int | 1 | Drawing mode of the stroke (Default if missing is 0):RenderOverMode = 0; RenderEraseMode = 1; |
 | pen: *id* : *frame* : *user* .startFrame | int | 1 | The first frame on which the pen stroke should be displayed |
 | pen: *id* : *frame* : *user* .duration | int | 1 | The number of frames on which the pen stroke should be displayed |
-| pen: *id* : *frame* : *user* .hold | int | 1 | Enable holding strokes based on their duration and startFrame properties |
-| pen: *id* : *frame* : *user* .ghost | int | 1 | Enable ghosting strokes based on their duration, startFrame, ghostBefore and ghostAfter properties |
-| pen: *id* : *frame* : *user* .ghostBefore | int | 1 | The number of frames on which to display the ghosted stroke before the actual stroke |
-| pen: *id* : *frame* : *user* .ghostAfter | int | 1 | The number of frames on which to display the ghosted stroke after the actual stroke |
 | text: *id* : *frame* : *user* .position | float[2] | 1 | Location of the text in the normalized coordinate system |
 | text: *id* : *frame* : *user* .color | float[4] | 1 | The color of the text |
 | text: *id* : *frame* : *user* .spacing | float | 1 | The spacing of the text |
@@ -459,10 +455,6 @@ Paint nodes are used primarily to store per frame annotations. Below *id* is the
 | text: *id* : *frame* : *user* .debug | int | 1 | (unused) |
 | text: *id* : *frame* : *user* .startFrame | int | 1 | The first frame on which the text box should be displayed |
 | text: *id* : *frame* : *user* .duration | int | 1 | The number of frames on which the text box should be displayed |
-| text: *id* : *frame* : *user* .hold | int | 1 | Enable holding text boxes based on their duration and startFrame properties |
-| text: *id* : *frame* : *user* .ghost | int | 1 | Enable ghosting strokes based on their duration, startFrame, ghostBefore and ghostAfter properties |
-| text: *id* : *frame* : *user* .ghostBefore | int | 1 | The number of frames on which to display the ghosted stroke before the actual stroke |
-| text: *id* : *frame* : *user* .ghostAfter | int | 1 | The number of frames on which to display the ghosted stroke after the actual stroke |
 
 ## RVPrimaryConvert
 
@@ -570,6 +562,10 @@ The session node is a great place to store centrally located information to easi
 | matte.heightVisible | float | 1 | Centralized setting for the fraction of the source height that is still visible from the matte used in all sources. |
 | matte.opacity | float | 1 | Centralized setting for the opacity of the matte used in all sources. 0 == clear 1 == opaque. |
 | matte.show | int | 1 | Centralized setting to turn on or off the matte used in all sources. 0 == OFF 1 == ON. |
+| paintEffects.hold | int | 1 | Centralized setting for enabling holding annotations based on their duration and startFrame properties |
+| paintEffects.ghost | int | 1 | Centralized setting for enabling ghosting annotations based on their duration, startFrame, ghostBefore and ghostAfter properties |
+| paintEffects.ghostBefore | int | 1 | Centralized setting for the number of frames on which to display the ghosted annotation before the actual annotation |
+| paintEffects.ghostAfter | int | 1 | Centralized setting for the number of frames on which to display the ghosted annotation after the actual annotation |
 
 ## RVSoundTrack
 

--- a/src/bin/imgtools/rvio/main.cpp
+++ b/src/bin/imgtools/rvio/main.cpp
@@ -36,7 +36,7 @@
 #include <IPBaseNodes/SourceIPNode.h>
 #include <IPCore/GroupIPNode.h>
 #include <IPCore/OutputGroupIPNode.h>
-#include <IPBaseNodes/PaintIPNode.h>
+#include <IPCore/SessionIPNode.h>
 #ifdef RVIO_HW
 #include <MovieRV_FBO/MovieRV_FBO.h>
 #else
@@ -130,33 +130,13 @@ namespace
 {
     void disableGhostOnAnnotations(IPCore::IPGraph& graph)
     {
-        const auto& nodes = graph.nodeMap();
-
-        for (const auto& nodeInfo : nodes)
+        auto* sessionNode = graph.sessionNode();
+        if (sessionNode != nullptr)
         {
-            const auto& node = nodeInfo.second;
-            auto* paintNode = dynamic_cast<IPCore::PaintIPNode*>(node);
-
-            if (paintNode != nullptr)
-            {
-                for (const auto& component : paintNode->components())
-                {
-                    if (std::regex_match(component->name(),
-                                         std::regex("(pen:.*|text:.*)")))
-                    {
-                        auto* property =
-                            component->property<TwkContainer::IntProperty>(
-                                "ghost");
-
-                        if (property != nullptr)
-                        {
-                            node->propertyWillChange(property);
-                            paintNode->setProperty(property, 0);
-                            node->propertyChanged(property);
-                        }
-                    }
-                }
-            }
+            sessionNode->setProperty<TwkContainer::IntProperty>(
+                "paintEffects.ghost", 0);
+            sessionNode->setProperty<TwkContainer::IntProperty>(
+                "paintEffects.hold", 0);
         }
     }
 } // namespace

--- a/src/lib/app/RvApp/RvApp/RvSession.h
+++ b/src/lib/app/RvApp/RvApp/RvSession.h
@@ -327,8 +327,6 @@ namespace Rv
         int loadCount();
         int loadTotal();
 
-        void updateAnnotationsUI();
-
         //
         //  Override
         //
@@ -387,6 +385,8 @@ namespace Rv
                                          int newFastAddSourceEnabled);
         void onGraphMediaSetEmpty();
         void onGraphNodeWillRemove(IPCore::IPNode* node);
+
+        void updateAnnotationsUI();
 
     private:
         UINameCache m_uiNameCache;

--- a/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
+++ b/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
@@ -161,6 +161,7 @@ namespace Rv
         a = addAction("");
         a->setIcon(QIcon(":/images/ghost.png"));
         a->setToolTip("Ghost");
+        a->setCheckable(true);
         b = dynamic_cast<QToolButton*>(widgetForAction(a));
         b->setProperty("tbstyle", QVariant(QString("left")));
         b->setToolButtonStyle(Qt::ToolButtonIconOnly);
@@ -180,6 +181,7 @@ namespace Rv
         a = addAction("");
         a->setIcon(QIcon(":/images/hold.png"));
         a->setToolTip("Hold");
+        a->setCheckable(true);
         b = dynamic_cast<QToolButton*>(widgetForAction(a));
         b->setProperty("tbstyle", QVariant(QString("right")));
         b->setToolButtonStyle(Qt::ToolButtonIconOnly);
@@ -485,11 +487,34 @@ namespace Rv
             {
                 bool isChecked = (contents == "1");
                 m_ghostAction->setChecked(isChecked);
+
+                if (m_session->filterLiveReviewEvents())
+                {
+                    m_ghostAction->setDisabled(true);
+                }
             }
             else if (name == "update-hold-button")
             {
                 bool isChecked = (contents == "1");
                 m_holdAction->setChecked(isChecked);
+
+                if (m_session->filterLiveReviewEvents())
+                {
+                    m_holdAction->setDisabled(true);
+                }
+            }
+            else if (name == "internal-sync-presenter-changed")
+            {
+                if (m_session->filterLiveReviewEvents())
+                {
+                    m_holdAction->setDisabled(true);
+                    m_ghostAction->setDisabled(true);
+                }
+                else
+                {
+                    m_holdAction->setDisabled(false);
+                    m_ghostAction->setDisabled(false);
+                }
             }
         }
 
@@ -534,14 +559,6 @@ namespace Rv
 
     void RvBottomViewToolBar::ghostTriggered(bool isChecked)
     {
-        if (m_session->filterLiveReviewEvents())
-        {
-            m_session->userGenericEvent("live-review-blocked-event", "");
-            return;
-        }
-
-        m_ghostAction->setCheckable(true);
-
         auto* sessionNode = m_session->graph().sessionNode();
         if (sessionNode != nullptr)
         {
@@ -555,14 +572,6 @@ namespace Rv
 
     void RvBottomViewToolBar::holdTriggered(bool isChecked)
     {
-        if (m_session->filterLiveReviewEvents())
-        {
-            m_session->userGenericEvent("live-review-blocked-event", "");
-            return;
-        }
-
-        m_holdAction->setCheckable(true);
-
         auto* sessionNode = m_session->graph().sessionNode();
         if (sessionNode != nullptr)
         {

--- a/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
+++ b/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
@@ -21,6 +21,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/regex.hpp>
 #include <TwkQtCoreUtil/QtConvert.h>
+#include <IPCore/IPNode.h>
+#include <IPCore/SessionIPNode.h>
 
 #include <RvApp/Options.h>
 
@@ -159,7 +161,6 @@ namespace Rv
         a = addAction("");
         a->setIcon(QIcon(":/images/ghost.png"));
         a->setToolTip("Ghost");
-        a->setCheckable(true);
         b = dynamic_cast<QToolButton*>(widgetForAction(a));
         b->setProperty("tbstyle", QVariant(QString("left")));
         b->setToolButtonStyle(Qt::ToolButtonIconOnly);
@@ -179,7 +180,6 @@ namespace Rv
         a = addAction("");
         a->setIcon(QIcon(":/images/hold.png"));
         a->setToolTip("Hold");
-        a->setCheckable(true);
         b = dynamic_cast<QToolButton*>(widgetForAction(a));
         b->setProperty("tbstyle", QVariant(QString("right")));
         b->setToolButtonStyle(Qt::ToolButtonIconOnly);
@@ -485,13 +485,11 @@ namespace Rv
             {
                 bool isChecked = (contents == "1");
                 m_ghostAction->setChecked(isChecked);
-                ghostTriggered(isChecked);
             }
             else if (name == "update-hold-button")
             {
                 bool isChecked = (contents == "1");
                 m_holdAction->setChecked(isChecked);
-                holdTriggered(isChecked);
             }
         }
 
@@ -510,7 +508,8 @@ namespace Rv
 
     void RvBottomViewToolBar::paintActionTriggered(bool)
     {
-        m_session->userGenericEvent("toggle-draw-panel", "");
+        m_session->userGenericEvent("mode-manager-toggle-mode",
+                                    "annotate_mode");
     }
 
     void RvBottomViewToolBar::infoActionTriggered(bool)
@@ -535,14 +534,44 @@ namespace Rv
 
     void RvBottomViewToolBar::ghostTriggered(bool isChecked)
     {
-        std::string value = isChecked ? "1" : "0";
-        m_session->userGenericEvent("set-annotation-ghost", value);
+        if (m_session->filterLiveReviewEvents())
+        {
+            m_session->userGenericEvent("live-review-blocked-event", "");
+            return;
+        }
+
+        m_ghostAction->setCheckable(true);
+
+        auto* sessionNode = m_session->graph().sessionNode();
+        if (sessionNode != nullptr)
+        {
+            sessionNode->setProperty<IPNode::IntProperty>("paintEffects.ghost",
+                                                          isChecked ? 1 : 0);
+            m_session->userGenericEvent("graph-state-change",
+                                        sessionNode->name()
+                                            + ".paintEffects.ghost");
+        }
     }
 
     void RvBottomViewToolBar::holdTriggered(bool isChecked)
     {
-        std::string value = isChecked ? "1" : "0";
-        m_session->userGenericEvent("set-annotation-hold", value);
+        if (m_session->filterLiveReviewEvents())
+        {
+            m_session->userGenericEvent("live-review-blocked-event", "");
+            return;
+        }
+
+        m_holdAction->setCheckable(true);
+
+        auto* sessionNode = m_session->graph().sessionNode();
+        if (sessionNode != nullptr)
+        {
+            sessionNode->setProperty<IPNode::IntProperty>("paintEffects.hold",
+                                                          isChecked ? 1 : 0);
+            m_session->userGenericEvent("graph-state-change",
+                                        sessionNode->name()
+                                            + ".paintEffects.hold");
+        }
     }
 
     void RvBottomViewToolBar::backStepTriggered()

--- a/src/lib/app/mu_rvui/mode_manager.mu
+++ b/src/lib/app/mu_rvui/mode_manager.mu
@@ -384,15 +384,7 @@ class: ModeManagerMode : MinorMode
         try
         {
             if (!entry.loaded) loadEntry(entry);
-
-            if (entry.name == "annotate_mode")
-            {
-                sendInternalEvent("toggle-draw-panel");
-            }
-            else
-            {
-                activateEntry(entry, !entry.mode._active);   
-            }
+            activateEntry(entry, !entry.mode._active);
         }
         catch (exception exc)
         {

--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/PaintIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/PaintIPNode.h
@@ -27,6 +27,14 @@ namespace IPCore
     //          string text
     //
 
+    struct PaintEffects
+    {
+        int hold = 0;
+        int ghost = 0;
+        int ghostBefore = 5;
+        int ghostAfter = 5;
+    };
+
     class PaintIPNode : public IPNode
     {
     public:
@@ -46,10 +54,6 @@ namespace IPCore
 
             int startFrame{};
             int duration{};
-            int ghost{};
-            int hold{};
-            int ghostAfter{};
-            int ghostBefore{};
             int eye{-1};
 
             bool ghostOn{};
@@ -99,6 +103,7 @@ namespace IPCore
         void compilePenComponent(Component*);
         void compileTextComponent(Component*);
         void compileFrame(Component*);
+        void setPaintEffects();
 
     private:
         PenMap m_penStrokes;
@@ -109,6 +114,7 @@ namespace IPCore
         FrameMap m_frameMap;
         Component* m_tag;
         std::mutex m_commandsMutex;
+        PaintEffects m_paintEffects;
     };
 
 } // namespace IPCore

--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -323,10 +323,6 @@ namespace IPCore
         p.eye = eye;
         p.startFrame = startFrame;
         p.duration = duration;
-        // p.hold = hold;
-        // p.ghost = ghost;
-        // p.ghostBefore = ghostBefore;
-        // p.ghostAfter = ghostAfter;
 
         if (widthP && pointsP && widthP->size() == pointsP->size()
             && widthP->size() > 1)

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -4622,9 +4622,6 @@ namespace IPCore
 
         if (m_filterLiveReviewEvents
             && (eventName == "mode-manager-toggle-mode"
-                || (eventName == "toggle-draw-panel")
-                || (eventName == "set-annotation-hold")
-                || (eventName == "set-annotation-ghost")
                 || (eventName == "remote-eval"
                     && (contents == "commands.stop()"
                         || contents

--- a/src/lib/ip/IPCore/SessionIPNode.cpp
+++ b/src/lib/ip/IPCore/SessionIPNode.cpp
@@ -25,6 +25,10 @@ namespace IPCore
         declareProperty<FloatProperty>("matte.opacity", 0.66f);
         declareProperty<FloatProperty>("matte.heightVisible", -1.0);
         declareProperty<Vec2fProperty>("matte.centerPoint", Vec2f(0.0, 0.0));
+        declareProperty<IntProperty>("paintEffects.hold", 0);
+        declareProperty<IntProperty>("paintEffects.ghost", 0);
+        declareProperty<IntProperty>("paintEffects.ghostBefore", 5);
+        declareProperty<IntProperty>("paintEffects.ghostAfter", 5);
         setMaxInputs(0);
 
         ImageRenderer::queryGLIntoContainer(this);

--- a/src/plugins/rv-packages/annotate/PACKAGE
+++ b/src/plugins/rv-packages/annotate/PACKAGE
@@ -13,7 +13,7 @@ modes:
     menu: Tools/Annotation
     shortcut: 'F10' 
     event: 'key-down--f10'
-    load: immediate
+    load: delay
 
 description: |
 

--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -22,6 +22,15 @@ class: DrawDockWidget : QDockWidget
         QDockWidget.QDockWidget("Draw", parent, Qt.Tool);
         _mode = m;
     }
+
+    method: closeEvent(void; QCloseEvent event)
+    {
+        _mode.toggle();
+
+        // Dont execute this event by OS. We dont want
+        // that Windows closes it.
+        event.ignore();
+    }
 }
 
 class: AnnotateMinorMode : MinorMode
@@ -69,10 +78,6 @@ class: AnnotateMinorMode : MinorMode
         float        minSize;
         int          startFrame;
         int          duration;
-        int          hold;
-        int          ghost;
-        int          ghostBefore;
-        int          ghostAfter;
         PressureMode pressureMode;
         DrawMode     eraserMode;
         DrawMode     penMode;
@@ -297,7 +302,7 @@ class: AnnotateMinorMode : MinorMode
         _autoMark         = b5;
         _linkToolColors   = b6;
 
-        let String name = readSetting("Annotate", "drawmode", String("Select"));
+        let String name = readSetting("Annotate", "drawmode", String("Pen"));
 
         for_each (d; _drawModes)
         {
@@ -399,11 +404,7 @@ class: AnnotateMinorMode : MinorMode
                      "%s.cap" % n,
                      "%s.points" % n,
                      "%s.startFrame" % n,
-                     "%s.duration" % n,
-                     "%s.hold" % n,
-                     "%s.ghost" % n,
-                     "%s.ghostBefore" % n,
-                     "%s.ghostAfter" % n
+                     "%s.duration" % n
                     ];
 
         beginCompoundStateChange();
@@ -433,18 +434,9 @@ class: AnnotateMinorMode : MinorMode
                        int cap,
                        int startFrame,
                        int duration,
-                       int hold,
-                       int ghost,
-                       int ghostBefore,
-                       int ghostAfter,
                        int mode=RenderOverMode,
                        int debug=0)
     {
-        if (_currentDrawMode eq _selectDrawMode)
-        {
-            return;
-        }
-
         let n          = newUniqueName(node, "pen", frame),
             colorName  = "%s.color" % n,
             widthName  = "%s.width" % n,
@@ -456,10 +448,6 @@ class: AnnotateMinorMode : MinorMode
             splatName  = "%s.splat" % n,
             startFrameName = "%s.startFrame" % n,
             durationName = "%s.duration" % n,
-            holdName = "%s.hold" % n,
-            ghostName = "%s.ghost" % n,
-            ghostBeforeName = "%s.ghostBefore" % n,
-            ghostAfterName = "%s.ghostAfter" % n,
             orderName  = frameOrderName(node, frame);
 
         beginCompoundStateChange();
@@ -473,10 +461,6 @@ class: AnnotateMinorMode : MinorMode
         newProperty(splatName, IntType, 1);
         newProperty(startFrameName, IntType, 1);
         newProperty(durationName, IntType, 1);
-        newProperty(holdName, IntType, 1);
-        newProperty(ghostName, IntType, 1);
-        newProperty(ghostBeforeName, IntType, 1);
-        newProperty(ghostAfterName, IntType, 1);
 
         if (mode != RenderOverMode)
         {
@@ -510,10 +494,6 @@ class: AnnotateMinorMode : MinorMode
         setIntProperty(splatName, int[] {if brush == "gauss" then 1 else 0}, true);
         setIntProperty(startFrameName, int[] {startFrame}, true);
         setIntProperty(durationName, int[] {duration}, true);
-        setIntProperty(holdName, int[] {hold}, true);
-        setIntProperty(ghostName, int[] {ghost}, true);
-        setIntProperty(ghostBeforeName, int[] {ghostBefore}, true);
-        setIntProperty(ghostAfterName, int[] {ghostAfter}, true);
 
         try
         {
@@ -571,10 +551,6 @@ class: AnnotateMinorMode : MinorMode
                      float rot,
                      int startFrame,
                      int duration,
-                     int hold,
-                     int ghost,
-                     int ghostBefore,
-                     int ghostAfter,
                      string font = "",
                      string origin = "",
                      int mode=RenderOverMode,
@@ -593,10 +569,6 @@ class: AnnotateMinorMode : MinorMode
             debugName   = "%s.debug" % n,
             startFrameName = "%s.startFrame" % n,
             durationName = "%s.duration" % n,
-            holdName = "%s.hold" % n,
-            ghostName = "%s.ghost" % n,
-            ghostBeforeName = "%s.ghostBefore" % n,
-            ghostAfterName = "%s.ghostAfter" % n,
             orderName   = frameOrderName(node, frame);
 
         beginCompoundStateChange();
@@ -612,10 +584,6 @@ class: AnnotateMinorMode : MinorMode
         newProperty(debugName, IntType, 1);
         newProperty(startFrameName, IntType, 1);
         newProperty(durationName, IntType, 1);
-        newProperty(holdName, IntType, 1);
-        newProperty(ghostName, IntType, 1);
-        newProperty(ghostBeforeName, IntType, 1);
-        newProperty(ghostAfterName, IntType, 1);
 
         if (mode != RenderOverMode)
         {
@@ -636,10 +604,6 @@ class: AnnotateMinorMode : MinorMode
         setIntProperty(debugName, int[] {debug}, true);
         setIntProperty(startFrameName, int[] {startFrame}, true);
         setIntProperty(durationName, int[] {duration}, true);
-        setIntProperty(holdName, int[] {hold}, true);
-        setIntProperty(ghostName, int[] {ghost}, true);
-        setIntProperty(ghostBeforeName, int[] {ghostBefore}, true);
-        setIntProperty(ghostAfterName, int[] {ghostAfter}, true);
 
         try
         {
@@ -815,10 +779,6 @@ class: AnnotateMinorMode : MinorMode
                                          0.0,
                                          _currentNodeInfo.frame,
                                          d.duration,
-                                         d.hold,
-                                         d.ghost,
-                                         d.ghostBefore,
-                                         d.ghostAfter,
                                          "", "", d.renderMode, _debug);
         }
         catch (exception exc)
@@ -913,12 +873,6 @@ class: AnnotateMinorMode : MinorMode
 
     method: push (void; Event event)
     {
-        if (_currentDrawMode eq _selectDrawMode)
-        {
-            togglePlayVerbose(true);
-            return;
-        }
-
         if (filterLiveReviewEvents()) {
             sendInternalEvent("live-review-blocked-event");
             return;
@@ -950,7 +904,7 @@ class: AnnotateMinorMode : MinorMode
             _currentDrawObject = newStroke(_currentNode,
                                            _currentNodeInfo.frame,
                                            incolor, twidth, d.brushName,
-                                           d.join, d.cap, _currentNodeInfo.frame, d.duration, d.hold, d.ghost, d.ghostBefore, d.ghostAfter, d.renderMode, _debug);
+                                           d.join, d.cap, _currentNodeInfo.frame, d.duration, d.renderMode, _debug);
         }
         catch (exception exc)
         {
@@ -964,11 +918,6 @@ class: AnnotateMinorMode : MinorMode
         // Init vars for drag filtering
         _dragLastPointer = ip;
         _dragLastMsec = int(QDateTime.currentMSecsSinceEpoch());
-
-        if (_currentDrawObject eq nil)
-        {
-            return;
-        }
 
         let pei = eventToImageSpace(name, ip, true);
 
@@ -1027,12 +976,6 @@ class: AnnotateMinorMode : MinorMode
             sendInternalEvent("live-review-blocked-event");
             return;
         }
-
-        if (_currentDrawMode eq _selectDrawMode)
-        {
-            return;
-        }
-
         let d = _currentDrawMode;
         _pointerGone = false;
 
@@ -1078,11 +1021,6 @@ class: AnnotateMinorMode : MinorMode
 
     method: release (void; Event event)
     {
-        if (_currentDrawMode eq _selectDrawMode)
-        {
-            return;
-        }
-
         runtime.gc.enable();
         drag(event);
         _currentDrawObject = nil;
@@ -1184,72 +1122,6 @@ class: AnnotateMinorMode : MinorMode
         }
     }
 
-    method: setAnnotationHold (void; Event event)
-    {
-        let isHold = int(event.contents());
-
-        for_each (d; _drawModes)
-        {
-            d.hold = isHold;
-        }
-
-        if (_currentNode eq nil) return;
-
-        for_each(node; nodes())
-        {
-            for_each (prop; properties(node))
-            {
-                if (regex("\\.hold$").match(prop))
-                {
-                    setIntProperty(prop, int[] {isHold}, true);
-                }
-
-                if (regex("\\.duration$").match(prop) && isHold == 0)
-                {
-                    setIntProperty(prop, int[] {1}, true);
-                }
-            }
-        }
-    }
-    
-    method: setAnnotationGhost (void; Event event)
-    {
-        let isGhost = int(event.contents());
-
-        for_each (d; _drawModes)
-        {
-            d.ghost = isGhost;
-        }
-
-        if (_currentNode eq nil) return;
-
-        for_each(node; nodes())
-        {
-            for_each(prop; properties(node))
-            {
-                if (regex("\\.ghost$").match(prop))
-                {
-                    setIntProperty(prop, int[] {isGhost}, true);
-                }
-            }
-        }
-    }
-
-    method: toggleDrawPanel (void; Event event)
-    {
-        if (_drawDock neq nil)
-        {
-            if (_drawDock.visible())
-            {
-                _drawDock.hide();
-            }
-            else
-            {
-                _drawDock.show();
-            }
-        }
-    }
-
     method: auxFilePath (string; string icon)
     {
         io.path.join(supportPath("annotate_mode", "annotate"), icon);
@@ -1323,17 +1195,6 @@ class: AnnotateMinorMode : MinorMode
     method: topLevelChangedSlot (void; bool toplevel)
     {
         _topLevel = toplevel;
-    }
-
-    method: drawDockVisibilityChangedSlot (void; bool isVisible)
-    {
-        if (!isVisible)
-        {
-            _currentDrawMode = _selectDrawMode;
-            commands.setCursor(_currentDrawMode.cursor);
-            updateDrawModeUI();
-            _currentDrawMode.button.setChecked(true);
-        }
     }
 
     method: newSizeSlot (void; int value)
@@ -1539,10 +1400,6 @@ class: AnnotateMinorMode : MinorMode
 
     method: autoMark (int;)
     {
-        if (filterLiveReviewEvents())
-        {
-            return DisabledMenuState;
-        }
         return if _autoMark then CheckedMenuState else UncheckedMenuState;
     }
 
@@ -1783,6 +1640,16 @@ class: AnnotateMinorMode : MinorMode
 
     method: updateDrawModeUI (void;)
     {
+        if (_currentDrawMode eq _selectDrawMode)
+        {
+            _hideDrawPane = _hideDrawPane + 1;
+            if (_active) toggle();
+        }
+        else
+        {
+            if (!_active) toggle();
+            _hideDrawPane = 0;
+        }
 
         if (_activeSampleColor)
         {
@@ -1861,11 +1728,6 @@ class: AnnotateMinorMode : MinorMode
 
     method: shutdown (void; Event event)
     {
-        _currentDrawMode = _selectDrawMode;
-        commands.setCursor(_currentDrawMode.cursor);
-        updateDrawModeUI();
-        _currentDrawMode.button.setChecked(true);
-
         if (_autoSave)
         {
             saveSettings();
@@ -2009,10 +1871,6 @@ class: AnnotateMinorMode : MinorMode
                                      SquareCap,
                                      1,
                                      1,
-                                     0,
-                                     0,
-                                     5,
-                                     5,
                                      0.024, 0.001,
                                      PressureMode.None };
 
@@ -2031,10 +1889,6 @@ class: AnnotateMinorMode : MinorMode
                                      0.024, 0.001,
                                      1,
                                      1,
-                                     0,
-                                     0,
-                                     5,
-                                     5,
                                      PressureMode.None };
 
         _textDrawMode  = DrawMode { "Text",
@@ -2052,10 +1906,6 @@ class: AnnotateMinorMode : MinorMode
                                      0.01, 0.0015,
                                      1,
                                      1,
-                                     0,
-                                     0,
-                                     5,
-                                     5,
                                      PressureMode.None };
 
         _penDrawMode = DrawMode { "Pen",
@@ -2073,10 +1923,6 @@ class: AnnotateMinorMode : MinorMode
                                   0.024, 0.001,
                                   1,
                                   1,
-                                  0,
-                                  0,
-                                  5,
-                                  5,
                                   defaultPMode };
 
 
@@ -2095,10 +1941,6 @@ class: AnnotateMinorMode : MinorMode
                                        0.044, 0.001,
                                        1,
                                        1,
-                                       0,
-                                       0,
-                                       5,
-                                       5,
                                        defaultPMode };
 
 
@@ -2118,10 +1960,6 @@ class: AnnotateMinorMode : MinorMode
                                         0.024, 0.001,
                                         1,
                                         1,
-                                        0,
-                                        0,
-                                        5,
-                                        5,
                                         PressureMode.None };
 
         _softEraseDrawMode = DrawMode { "Air Brush Erase",
@@ -2140,10 +1978,6 @@ class: AnnotateMinorMode : MinorMode
                                         0.044, 0.001,
                                         1,
                                         1,
-                                        0,
-                                        0,
-                                        5,
-                                        5,
                                         PressureMode.None };
 
         _dodgeDrawMode     = DrawMode { "Dodge",
@@ -2161,10 +1995,6 @@ class: AnnotateMinorMode : MinorMode
                                         0.044, 0.001,
                                         1,
                                         1,
-                                        0,
-                                        0,
-                                        5,
-                                        5,
                                         PressureMode.None,
                                         _hardEraseDrawMode,
                                         nil,
@@ -2186,10 +2016,6 @@ class: AnnotateMinorMode : MinorMode
                                         0.044, 0.001,
                                         1,
                                         1,
-                                        0,
-                                        0,
-                                        5,
-                                        5,
                                         PressureMode.None,
                                         _hardEraseDrawMode,
                                         nil,
@@ -2211,10 +2037,6 @@ class: AnnotateMinorMode : MinorMode
                                         0.044, 0.001,
                                         1,
                                         1,
-                                        0,
-                                        0,
-                                        5,
-                                        5,
                                         PressureMode.None };
 
         _smudgeDrawMode   = DrawMode { "Smudge",
@@ -2232,10 +2054,6 @@ class: AnnotateMinorMode : MinorMode
                                         0.044, 0.001,
                                         1,
                                         1,
-                                        0,
-                                        0,
-                                        5,
-                                        5,
                                         PressureMode.None };
 
         _drawModes = DrawMode[] { _selectDrawMode, _penDrawMode, _airBrushDrawMode,
@@ -2265,11 +2083,7 @@ class: AnnotateMinorMode : MinorMode
             _dockArea = Qt.LeftDockWidgetArea;
         }
 
-        if (_currentDrawMode eq nil) 
-        {
-            _currentDrawMode = _selectDrawMode;
-            updateDrawModeUI();
-        }
+        if (_currentDrawMode eq nil) _currentDrawMode = _penDrawMode;
 
         for_each (d; _drawModes)
         {
@@ -2309,7 +2123,6 @@ class: AnnotateMinorMode : MinorMode
         connect(_sizeSlider, QAbstractSlider.valueChanged, newSizeSlot);
         connect(_drawDock, QDockWidget.dockLocationChanged, locationChangedSlot);
         connect(_drawDock, QDockWidget.topLevelChanged, topLevelChangedSlot);
-        connect(_drawDock, QDockWidget.visibilityChanged, drawDockVisibilityChangedSlot);
 
         connect(_colorButton, QPushButton.clicked, chooseColorSlot);
         connect(_colorDialog, QColorDialog.currentColorChanged, newColorSlot(,true,true));
@@ -2344,7 +2157,7 @@ class: AnnotateMinorMode : MinorMode
 
         _drawDock.setFloating(_topLevel);
 
-        _drawDock.hide();
+        _drawDock.show();
 
         //
         //  Force update of UI elements
@@ -2391,10 +2204,6 @@ class: AnnotateMinorMode : MinorMode
               ("key-down--meta-shift--left", prevEvent, "Previous Annotated Frame"),
               ("key-down--alt-shift--right", nextEvent, "Next Annotated Frame"),
               ("key-down--alt-shift--left", prevEvent, "Previous Annotated Frame"),
-              ("set-annotation-ghost", setAnnotationGhost, "Set Annotation Ghost Value"),
-              ("set-annotation-hold", setAnnotationHold, "Set Annotation"),
-              ("toggle-draw-panel", toggleDrawPanel, "Toggle Draw Panel"),
-              ("key-down--f10", toggleDrawPanel, "Toggle Draw Panel"),
               //("key-down--control--z", keyUndoEvent, "Undo"),
               //("key-down--control--Z", keyRedoEvent, "Redo"),
               //("preferences-show", prefsShow, "Configure Preferences"),
@@ -2516,11 +2325,32 @@ class: AnnotateMinorMode : MinorMode
         }
     }
 
+    method: deactivate (void;)
+    {
+        if (_hideDrawPane != 1)
+        {
+            if (_manageDock neq nil) _manageDock.hide();
+            if (_drawDock neq nil) _drawDock.hide();
+            _hideDrawPane = 0;
+        }
+
+        setCursor(CursorDefault);
+        removeTags();
+    }
+
+    method: activate (void;)
+    {
+        updateCurrentNode();
+        if (_manageDock neq nil) _manageDock.show();
+        if (_drawDock neq nil) _drawDock.show();
+        setCursor(_currentDrawMode.cursor);
+        updateDrawModeUI();
+        setTags();
+    }
 
     method: render (void; Event event)
     {
         if (_currentDrawMode eq _dropperDrawMode ||
-            _currentDrawMode eq _selectDrawMode ||
             !_showBrush ||
             _pointerGone)
         {

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -16,6 +16,16 @@ def hook_function(
     in_timeline: otio.schemadef.Annotation.Annotation, argument_map: dict | None = None
 ) -> None:
     """A hook for the annotation schema"""
+
+    metadata = argument_map.get("effect_metadata")
+    is_hold = metadata.get("hold")
+    is_ghost = metadata.get("ghost")
+
+    commands.setIntProperty("#Session.paintEffects.hold", [is_hold])
+    commands.setIntProperty("#Session.paintEffects.ghost", [is_ghost])
+    commands.setIntProperty("#Session.paintEffects.ghostBefore", [5])
+    commands.setIntProperty("#Session.paintEffects.ghostAfter", [5])
+
     for layer in in_timeline.layers:
         if layer.name == "Paint":
             if isinstance(layer.layer_range, otio.opentime.TimeRange):
@@ -38,10 +48,6 @@ def hook_function(
             # Set properties on the paint component of the RVPaint node
             effectHook.set_rv_effect_props(paint_component, {"nextId": stroke_id + 1})
 
-            metadata = argument_map.get("effect_metadata")
-            is_hold = metadata.get("hold")
-            is_ghost = metadata.get("ghost")
-
             start_time = int(time_range.start_time.value)
             end_time = int(start_time + time_range.duration.value)
 
@@ -60,10 +66,6 @@ def hook_function(
                     "mode": 0 if layer.type == "COLOR" else 1,
                     "startFrame": start_time,
                     "duration": duration,
-                    "hold": is_hold,
-                    "ghost": is_ghost,
-                    "ghostBefore": 5,
-                    "ghostAfter": 5,
                 },
             )
 


### PR DESCRIPTION
### [SG-39535](https://jira.autodesk.com/browse/SG-39535): Update UI live review

### Summarize your change.

Enable and disable the Hold and Ghost buttons during a Live Review session. If the user is a participant, the `checked` state will be updated to show the feature is activated while keeping the button disabled. If the user becomes a presenter, the two buttons will be enabled to control if the feature should be activated or deactivated for all the participants. Note that sending the events to update the UI is done in an other PR in Commercial RV. 

### Describe the reason for the change.

An RV participant of a Web to RV Live Review session could render the Hold and Ghost feature but its UI was not updating to show if the feature was activated or not like it is for the presenter.

### Describe what you have tested and on which operating system.

Validating the UI is updated when:
- [X] Joining a Web to RV and RV to RV Live Review session when Hold and Ghost is activated
- [X] Enabling and disabling Hold and Ghost after joining a Web to RV and RV to RV Live Review session
- [X] Changing presenter in a RV to RV Live Review session

### If possible, provide screenshots.