### PR TITLE
SG-39680: Fixed crash on exit with registered imgui callback (temp patch)

### DIFF
--- a/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
+++ b/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
@@ -7,8 +7,10 @@ namespace Rv
 {
     void ImGuiPythonBridge::PyObjectDeleter::operator()(PyObject* obj) const
     {
-        if (obj)
-            Py_DECREF(obj);
+        // seems to crash on exit if we have a callback registered.
+        // so patching this out for now.
+        // if (obj)
+        //     Py_DECREF(obj);
     }
 
     std::vector<ImGuiPythonBridge::PyObjectPtr> ImGuiPythonBridge::s_callbacks;
@@ -53,5 +55,11 @@ namespace Rv
     }
 
     int ImGuiPythonBridge::nbCallbacks() { return (int)s_callbacks.size(); }
+
+    void ImGuiPythonBridge::clearCallbacks()
+    {
+        s_callbacks.clear();
+        // CAll DECREF for each element if we're not using the deleter for this?
+    }
 
 } // namespace Rv

--- a/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.h
+++ b/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.h
@@ -18,6 +18,7 @@ namespace Rv
         static void unregisterCallback(PyObject* callable);
         static void callCallbacks();
         static int nbCallbacks();
+        static void clearCallbacks();
 
         struct PyObjectDeleter
         {


### PR DESCRIPTION

### Linked issues

Fixes SG-39680

### Summarize your change.

I silenced the reference decrement in the python object deleter; I'll have to wait for Cedrik to create a proper fix for this. 
Ideally we want to call clearCallbacks() before exiting the app, there seems to be a weird race condition that prevents us from doing so. 

Furthermore, decrementing the refcount in the deleter appears to run counter to the fact that we're already decrementing the refcount when we unregister the callback.  I'm not sure if we're meant to keep the refcount derement in the deleter, or even if the deleter is needed at all at this point. 

### Describe the reason for the change.

Segfault on exit, need to send beta build.

### Describe what you have tested and on which operating system.

macOS

### Add a list of changes, and note any that might need special attention during the review.

Make sure we don't sefault on exit

### If possible, provide screenshots.

n/a