### PR TITLE
Minor update to boost, the older API has now been retired.

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -2311,7 +2311,8 @@ namespace TwkMovie
         // Get the extension support capability
         //
 
-        string ext = boost::filesystem::extension(m_filename);
+        string ext = boost::filesystem::path(m_filename).extension().string();
+
         if (ext[0] == '.')
             ext.erase(0, 1);
         MovieFFMpegIO::MFFormatMap formats = m_io->getFormats();
@@ -5887,7 +5888,8 @@ namespace TwkMovie
             "verbose: " << request.verbose << " filename: " << filename);
 
         // Check if this is a supported output format
-        string ext = boost::filesystem::extension(m_filename);
+        string ext = boost::filesystem::path(m_filename).extension().string();
+
         if (ext[0] == '.')
             ext.erase(0, 1);
         avformat_alloc_output_context2(&m_avFormatContext, NULL, NULL,


### PR DESCRIPTION

### Boost::filesystem update

This is a pretty trivial change, just updating a boost API change, that C++ on OSX was complaining about.

Seems like the older API is being retired.
