### PR TITLE
Fix 2x RemoteRvCommands

### DIFF
--- a/src/lib/app/RvApp/CommandsModule.cpp
+++ b/src/lib/app/RvApp/CommandsModule.cpp
@@ -1303,6 +1303,13 @@ namespace Rv
 
         IPGraph::GraphEdit edit(s->graph());
 
+        // silences broadcasting events below this constructor
+        IPMu::RemoteRvCommand remoteRvCommand(s, "addSourceVerbose",
+                                              filesAndOptions, tag);
+
+        // Now that we've broadcast the remote event, complete the work without
+        // broadcasting anything else.
+
         if (Options::sharedOptions().delaySessionLoading)
         {
             s->userGenericEvent("before-progressive-loading", "");
@@ -1387,16 +1394,6 @@ namespace Rv
         names->resize(array->size());
         IPGraph::GraphEdit edit(s->graph());
 
-        if (Options::sharedOptions().delaySessionLoading)
-        {
-            s->userGenericEvent("before-progressive-loading", "");
-
-            // Note: It was decided to trigger the
-            // before-progressive-proxy-loading event even when progressive
-            // source loading is disabled
-            s->userGenericEvent("before-progressive-proxy-loading", "");
-        }
-
         vector<vector<string>> allFilesAndOptions;
 
         for (size_t i = 0; i < array->size(); i++)
@@ -1423,6 +1420,16 @@ namespace Rv
 
         // Now that we've broadcast the remote event, complete the work without
         // broadcasting anything else.
+
+        if (Options::sharedOptions().delaySessionLoading)
+        {
+            s->userGenericEvent("before-progressive-loading", "");
+
+            // Note: It was decided to trigger the
+            // before-progressive-proxy-loading event even when progressive
+            // source loading is disabled
+            s->userGenericEvent("before-progressive-proxy-loading", "");
+        }
 
         for (size_t i = 0; i < allFilesAndOptions.size(); i++)
         {


### PR DESCRIPTION
### Fix 2x RemoteRvCommands

### Linked issues
NA

### Summarize your change.

Note that this commit is only impacting Open RV when using the Open RV Live Review functionality.

This commit adds addSourceVerbose() to the list of the RemoteRvCommands.

It also solves an issue with the addSourcesVerbose() command where the RemoteRvCommands was not executed before it was defined after before-progressive-loading which was preventing the generic-rv-command event from being broadcasted to the participants.


### Describe the reason for the change.
addSourcesVerbose() and addSourceVerbose() were not behaving as expected when used in RV Live Review.

### Describe what you have tested and on which operating system.
Successfully tested on macOS 

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.