### PR TITLE
SequenceNode Stability Improvements

### DIFF
--- a/src/lib/ip/IPBaseNodes/SequenceIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/SequenceIPNode.cpp
@@ -231,8 +231,7 @@ namespace IPCore
                 || index >= m_edlSourceOut->size() - 1
                 || index >= m_edlGlobalIn->size() - 1 || index < 0)
             {
-                TWK_THROW_STREAM(SequenceOutOfBoundsExc,
-                                 "Out-of-bounds EDL data");
+                return -1;
             }
         }
 
@@ -259,6 +258,8 @@ namespace IPCore
         const int globalOffset = m_edlGlobalIn->front();
         int seekFrame = int(samplesToTime(seekSample, sampleRate) * fps + 0.49);
         int index = indexAtFrame(seekFrame + globalOffset);
+        if (index < 0)
+            return -1;
 
         int inputFrame = (*m_edlGlobalIn)[index];
         SampleTime inputStart =
@@ -360,10 +361,12 @@ namespace IPCore
 
         if (source < 0 || source >= ins.size())
         {
-            TWK_THROW_STREAM(SequenceOutOfBoundsExc,
-                             "Bad Sequence EDL source number "
-                                 << source << " is not in range [0,"
-                                 << ins.size() - 1 << "]");
+            stringstream msg;
+            msg << "Bad Sequence EDL source number "
+                << source << " is not in range [0,"
+                << ins.size() - 1 << "]";
+
+            return IPImage::newNoImage(this, msg.str());
         }
 
         IPImage* root =
@@ -997,6 +1000,12 @@ namespace IPCore
             //
 
             int index = indexAtSample(readSample, rate, context.fps);
+            if (index < 0)
+            {
+                cerr << "ERROR: no samples read from input node" << endl;
+                break;
+            }
+
             int sourceIndex = (*m_edlSource)[index];
 
             //


### PR DESCRIPTION
### Summarize your change.

This PR fixes program crashes that can occur if you modify Sequence edl properties. Most of these are due to lack of proper bounds checking on the properties in various locations.

- Add bounds checks before trying to access the edl properties
- Check source indexes are within range of nodes inputs.
- Add NULL check to ImageRenderer

We also modified the node’s behavior so that it no longer throws an exception when it enters a bad state. Instead, it now returns a newNoImage containing the error message. We discovered that when EDL properties are changed dynamically, the node can easily enter a temporary, inconsistent state. This happens because property change events may occur between the setting of individual EDL properties, and the operations that can take place in between are not trivial to manage. Displaying the error console in these situations proved to be both frustrating and confusing for users.

### Describe what you have tested and on which operating system.
Linux, macOS
