### PR TITLE
Fix Y-Inverted Color Picker

### DIFF
--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/FileSourceIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/FileSourceIPNode.h
@@ -215,10 +215,11 @@ namespace IPCore
             const SharedMediaPointer& proxySharedMedia = SharedMediaPointer());
 
         MediaPointer getMediaFromContext(ImageComponent& selection,
-                                         const Context& context);
-        MediaPointer mediaForComponent(ImageComponent&, const Context& context);
-        MediaPointer defaultMedia(int);
-        Movie* movieForThread(const Media*, const Context&);
+                                         const Context& context) const;
+        MediaPointer mediaForComponent(ImageComponent&,
+                                       const Context& context) const;
+        MediaPointer defaultMedia(int) const;
+        Movie* movieForThread(const Media*, const Context&) const;
         void setupRequest(const Movie*, const ImageComponent&, const Context&,
                           Movie::ReadRequest& request);
 


### PR DESCRIPTION
### Summarize your change.

Fixes the color inspector from calculating the wrong coordinate when a RVFileSources has multiple media paths with different orientations

We use multiple media paths to add audio to images sequences from a proxy mov file.

```
rv.commands.addSource(["/path/to/image.####.exr", "/path/to/proxy_with_audio.mov"])
```

The current logic is to use the `ImageStructureInfo` of last movie in the list and not what is currently visible. In some cases the second path might have a different coordinate system then the image sequence. In our cases the Y coordinate is opposite causing the color picker sample location to be upside down.

This change reuses the exisiting `getMediaFromContext` method to get the same media that is displayed. 

### Describe what you have tested and on which operating system.
Linux, macOS
