### PR TITLE
SG-39510: Close annotation panel when joining Live Review

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -1804,6 +1804,14 @@ class: AnnotateMinorMode : MinorMode
     method: nextSlot (void; bool b) { nextAnnotatedFrame(); }
     method: prevSlot (void; bool b) { prevAnnotatedFrame(); }
 
+    method: onPresenterChanged(void; Event event)
+    {
+        if (_active && filterLiveReviewEvents())
+        {
+            toggle();
+        }
+        event.reject();
+    }
 
     method: AnnotateMinorMode (AnnotateMinorMode; string name)
     {
@@ -2239,6 +2247,7 @@ class: AnnotateMinorMode : MinorMode
               ("key-down--meta-shift--left", prevEvent, "Previous Annotated Frame"),
               ("key-down--alt-shift--right", nextEvent, "Next Annotated Frame"),
               ("key-down--alt-shift--left", prevEvent, "Previous Annotated Frame"),
+              ("internal-sync-presenter-changed", onPresenterChanged, "Live Review Presenter Changed")
               //("key-down--control--z", keyUndoEvent, "Undo"),
               //("key-down--control--Z", keyRedoEvent, "Redo"),
               //("preferences-show", prefsShow, "Configure Preferences"),


### PR DESCRIPTION
### [SG-39510](https://jira.autodesk.com/browse/SG-39510): Close annotation panel when joining Live Review

### Summarize your change.

When joining a Live Review session, the Annotation panel should be closed if it was still open. Since a participant shouldn't be allowed to annotate the media in a standard Live Review session, there is no reason for the panel to be available.

### Describe the reason for the change.

In a previous PR, options and menus related to annotations were blocked for participants of a Live Review session. However, if the Annotation panel was opened when joining a session, it would stay that way. This can be confusing to the participant since all other options are disabled. 

### Describe what you have tested and on which operating system.

Testing joining a Live Review session with the Annotation panel opened and closed was perform on macOS