### PR TITLE
Fix before/after-progressive-loading events imbalance

### DIFF
--- a/src/lib/app/RvApp/CommandsModule.cpp
+++ b/src/lib/app/RvApp/CommandsModule.cpp
@@ -1312,7 +1312,25 @@ namespace Rv
 
         if (Options::sharedOptions().delaySessionLoading)
         {
-            s->userGenericEvent("before-progressive-loading", "");
+            // Note: It was decided to trigger the before-progressive-loading
+            // event even when progressive source loading is disabled as per the
+            // documentation. When progressive source loading is enabled, we
+            // have to check that some media is not already loading before
+            // triggering the event because the after-progressive-loading event
+            // is triggered when all the media are loaded, and we don't want to
+            // trigger it if some media is still loading, otherwise we would end
+            // up with an imbalance between the before-progressive-loading and
+            // after-progressive-loading events. This is the reason why we check
+            // if the graph isMediaLoading() before triggering the
+            // before-progressive-loading event.
+            // If progressive source loading is disabled, we don't have to check
+            // if the graph isMediaLoading() because this mechanism is not used
+            // in that case.
+            if (!Options::sharedOptions().progressiveSourceLoading
+                || !s->graph().isMediaLoading())
+            {
+                s->userGenericEvent("before-progressive-loading", "");
+            }
 
             // Note: It was decided to trigger the
             // before-progressive-proxy-loading event even when progressive
@@ -1423,7 +1441,25 @@ namespace Rv
 
         if (Options::sharedOptions().delaySessionLoading)
         {
-            s->userGenericEvent("before-progressive-loading", "");
+            // Note: It was decided to trigger the before-progressive-loading
+            // event even when progressive source loading is disabled as per the
+            // documentation. When progressive source loading is enabled, we
+            // have to check that some media is not already loading before
+            // triggering the event because the after-progressive-loading event
+            // is triggered when all the media are loaded, and we don't want to
+            // trigger it if some media is still loading, otherwise we would end
+            // up with an imbalance between the before-progressive-loading and
+            // after-progressive-loading events. This is the reason why we check
+            // if the graph isMediaLoading() before triggering the
+            // before-progressive-loading event.
+            // If progressive source loading is disabled, we don't have to check
+            // if the graph isMediaLoading() because this mechanism is not used
+            // in that case.
+            if (!Options::sharedOptions().progressiveSourceLoading
+                || !s->graph().isMediaLoading())
+            {
+                s->userGenericEvent("before-progressive-loading", "");
+            }
 
             // Note: It was decided to trigger the
             // before-progressive-proxy-loading event even when progressive

--- a/src/lib/ip/IPBaseNodes/IPBaseNodes/FileSourceIPNode.h
+++ b/src/lib/ip/IPBaseNodes/IPBaseNodes/FileSourceIPNode.h
@@ -276,7 +276,7 @@ namespace IPCore
         std::atomic<IPGraph::WorkItemID> m_workItemID;
         Mutex m_dispatchIDListMutex;
         std::list<Application::DispatchID> m_dispatchIDList;
-        std::atomic<IPGraph::WorkItemID> m_loadingID;
+        std::atomic<IPGraph::WorkItemID> m_loadingID{0};
         Mutex m_dispatchIDCancelRequestedMutex;
         std::set<Application::DispatchID> m_dispatchIDCancelRequestedSet;
         bool m_progressiveSourceLoading;


### PR DESCRIPTION
### Fix before/after-progressive-loading events imbalance

### Linked issues
NA

### Summarize your change.

This commit fixes a potential imbalance between before-progressive-loading and after-progressive-loading events when progressive source loading is active.
This commit only affects Open RV when the progressive source loading is enabled 
Which can be done via by setting the following env var:
export RV_PROGRESSIVE_SOURCE_LOADING=1

Also in this commit :  properly initialized a progressive source loading variable m_loadingID which was uninitialized.

### Describe the reason for the change.

This event imbalance proved to be detrimental to a recent mechanism that was introduced in RV Live Review where some commands such as addSourceVerbose() or clearSession() for examples, are executed on the participant RVs as native commands instead of broadcasting the numerous RV graph changes which are a side effect of such meta command.

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.