### PR TITLE
SG-39832: Block Zoom and Pan to participants of Live Review

### DIFF
--- a/src/lib/app/mu_rvui/rvui.mu
+++ b/src/lib/app/mu_rvui/rvui.mu
@@ -2332,6 +2332,11 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
 
 \: dragZoom (void; Event event)
 {
+    if (filterLiveReviewEvents()) {
+        sendInternalEvent("live-review-blocked-event");
+        return;
+    }
+
     State state = data();
 
     let dp = event.pointer() - event.reference(),
@@ -2357,6 +2362,11 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
 
 \: dragMoveLocked (void; bool lockToAxis, Event event)
 {
+    if (filterLiveReviewEvents()) {
+        sendInternalEvent("live-review-blocked-event");
+        return;
+    }
+   
     recordPixelInfo(event);
     State state = data();
     if (state.pixelInfo eq nil || state.pixelInfo.empty()) return;


### PR DESCRIPTION
### [SG-39832](https://jira.autodesk.com/browse/SG-39832): Block Zoom and Pan to participants of Live Review

### Summarize your change.

Block the Zoom and Pan hotkeys if RV is a participant of a Live Review session.

### Describe the reason for the change.

Multiple menus and options are now disabled or blocked when RV is a participant of a Live Review session. However, it was still possible for a user to enable Zoom and Pan through their hotkeys. As a participant, RV should only be a viewer and display exactly what's on the presenter's screen.

### Describe what you have tested and on which operating system.

Zoom and Pan outside and inside a Live Review session was tested on macOS.

### If possible, provide screenshots.

https://github.com/user-attachments/assets/c5004e74-f102-4edd-8c1d-f6adf7469bd0
