### PR TITLE
SG-39876: Block Annotation Panel in Live Review

### DIFF
--- a/src/lib/app/mu_rvui/mode_manager.mu
+++ b/src/lib/app/mu_rvui/mode_manager.mu
@@ -426,6 +426,11 @@ class: ModeManagerMode : MinorMode
 
     \: toggleModeEntry (void; Event event, ModeEntry entry, ModeManagerMode mm)
     {
+        if (filterLiveReviewEvents() && (entry.name == "session_manager" || entry.name == "annotate_mode"))
+        {
+            sendInternalEvent("live-review-blocked-event");
+            return;
+        }
         mm.toggleEntry(entry);
     }
 
@@ -676,11 +681,6 @@ class: ModeManagerMode : MinorMode
             {
                 bind(m.event, \: (void; Event ev)
                 {
-                    if (filterLiveReviewEvents() && (m.name == "session_manager" || m.name == "annotate_mode"))
-                    {
-                        sendInternalEvent("live-review-blocked-event");
-                        return;
-                    }
                     toggleModeEntry(ev, m, this);
                 });
             }


### PR DESCRIPTION
### [SG-39876](https://jira.autodesk.com/browse/SG-39876): Block Annotation Panel in Live Review

### Summarize your change.

Block annotate_mode and session_manager when an event triggers toggling their panel.

### Describe the reason for the change.

Blocking the modes inside the `bind` function wasn't blocking the Annotation Panel hotkey when the Live Review Panel was focused on since this path was not used in that case. Moving the validation inside `toggleEntryMode` fixed the issue. Only the Annotation Panel was affected by this issue since it's the only one that is only displayed on the right panel, just like the Live Review panel.

### Describe what you have tested and on which operating system.

Clicking the F10 key while the Live Review Panel is focused on was tested on macOS.