### PR TITLE
Fix issue when importing pyimgui and pyimplot in a Python plugin on Windows

### DIFF
--- a/cmake/dependencies/imgui/CMakeLists_PyImGUI.cmake
+++ b/cmake/dependencies/imgui/CMakeLists_PyImGUI.cmake
@@ -36,6 +36,11 @@ ENDIF()
 
 NANOBIND_ADD_MODULE(pyimgui ${IMGUI_NB_SOURCES})
 
+# Set the correct suffix for Windows Python modules
+IF(RV_TARGET_WINDOWS)
+  SET_TARGET_PROPERTIES(pyimgui PROPERTIES SUFFIX ".pyd")
+ENDIF()
+
 TARGET_LINK_LIBRARIES(
   pyimgui
   PUBLIC ${imgui_LIBRARY}

--- a/cmake/dependencies/imgui/CMakeLists_PyImplot.cmake
+++ b/cmake/dependencies/imgui/CMakeLists_PyImplot.cmake
@@ -32,6 +32,11 @@ ENDIF()
 
 NANOBIND_ADD_MODULE(pyimplot ${IMPLOT_NB_SOURCES})
 
+# Set the correct suffix for Windows Python modules
+IF(RV_TARGET_WINDOWS)
+  SET_TARGET_PROPERTIES(pyimplot PROPERTIES SUFFIX ".pyd")
+ENDIF()
+
 TARGET_LINK_LIBRARIES(
   pyimplot
   PUBLIC ${imgui_LIBRARY}

--- a/cmake/dependencies/pyimgui.cmake
+++ b/cmake/dependencies/pyimgui.cmake
@@ -34,9 +34,12 @@ ENDIF()
 LIST(APPEND _configure_options "-S ${CMAKE_BINARY_DIR}/RV_DEPS_IMGUI/deps/imgui-bundle/external/imgui")
 LIST(APPEND _configure_options "-B ${_build_dir}")
 
-SET(_libname
-    "pyimgui${CMAKE_SHARED_MODULE_SUFFIX}"
-)
+# Set the correct library name - Windows needs .pyd extension for Python modules
+IF(RV_TARGET_WINDOWS)
+  SET(_libname "pyimgui.pyd")
+ELSE()
+  SET(_libname "pyimgui${CMAKE_SHARED_MODULE_SUFFIX}")
+ENDIF()
 
 # The built library will be at the root of the build directory.
 SET(_build_output_path
@@ -75,6 +78,7 @@ EXTERNALPROJECT_ADD(
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options} -DCMAKE_PREFIX_PATH=$ENV{QT_HOME}/lib/cmake -DPython_ROOT=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install
                     -Dimgui_INCLUDE_DIRS=${_imgui_include_dirs} -Dimgui_LIBRARY=${_imgui_library_file} -Dnanobind_ROOT=${RV_DEPS_BASE_DIR}/RV_DEPS_NANOBIND/install/nanobind
+                    -DRV_TARGET_WINDOWS=${RV_TARGET_WINDOWS}
   BUILD_COMMAND ${_cmake_build_command}
   INSTALL_COMMAND ${_cmake_install_command}
   BUILD_BYPRODUCTS ${_build_output_path}
@@ -85,14 +89,14 @@ EXTERNALPROJECT_ADD(
 
 # Not using RV_COPY_LIB_BIN_FOLDERS() because we need to copy the library to a specific location.
 ADD_CUSTOM_COMMAND(
-  COMMENT "Installing ${_target}'s libs into ${_PYTHON_LIB_DIR}"
-  OUTPUT ${RV_STAGE_LIB_DIR}/${_libname}
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${_lib_dir} ${RV_STAGE_LIB_DIR}/${_PYTHON_LIB_DIR}
+  COMMENT "Installing ${_target}'s libs into site-packages"
+  OUTPUT ${RV_STAGE_LIB_DIR}/site-packages/${_libname}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_libpath} ${RV_STAGE_LIB_DIR}/site-packages/${_libname}
   DEPENDS ${_target}
 )
 ADD_CUSTOM_TARGET(
   ${_target}-stage-target ALL
-  DEPENDS ${RV_STAGE_LIB_DIR}/${_libname}
+  DEPENDS ${RV_STAGE_LIB_DIR}/site-packages/${_libname}
 )
 
 ADD_DEPENDENCIES(dependencies ${_target}-stage-target)

--- a/cmake/dependencies/pyimplot.cmake
+++ b/cmake/dependencies/pyimplot.cmake
@@ -34,9 +34,12 @@ ENDIF()
 LIST(APPEND _configure_options "-S ${CMAKE_BINARY_DIR}/RV_DEPS_IMGUI/deps/imgui-bundle-pyimplot/external/implot")
 LIST(APPEND _configure_options "-B ${_build_dir}")
 
-SET(_libname
-    "pyimplot${CMAKE_SHARED_MODULE_SUFFIX}"
-)
+# Set the correct library name - Windows needs .pyd extension for Python modules
+IF(RV_TARGET_WINDOWS)
+  SET(_libname "pyimplot.pyd")
+ELSE()
+  SET(_libname "pyimplot${CMAKE_SHARED_MODULE_SUFFIX}")
+ENDIF()
 
 # The built library will be at the root of the build directory.
 SET(_build_output_path
@@ -71,6 +74,7 @@ EXTERNALPROJECT_ADD(
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options} -DCMAKE_PREFIX_PATH=$ENV{QT_HOME}/lib/cmake -DPython_ROOT=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install
                     -Dimgui_INCLUDE_DIRS=${_imgui_include_dirs} -Dimgui_LIBRARY=${_imgui_library_file} -Dnanobind_ROOT=${RV_DEPS_BASE_DIR}/RV_DEPS_NANOBIND/install/nanobind
+                    -DRV_TARGET_WINDOWS=${RV_TARGET_WINDOWS}
   BUILD_COMMAND ${_cmake_build_command}
   INSTALL_COMMAND ${_cmake_install_command}
   BUILD_BYPRODUCTS ${_build_output_path}
@@ -81,14 +85,14 @@ EXTERNALPROJECT_ADD(
 
 # Not using RV_COPY_LIB_BIN_FOLDERS() because we need to copy the library to a specific location.
 ADD_CUSTOM_COMMAND(
-  COMMENT "Installing ${_target}'s libs into ${_PYTHON_LIB_DIR}"
-  OUTPUT ${RV_STAGE_LIB_DIR}/${_libname}
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${_lib_dir} ${RV_STAGE_LIB_DIR}/${_PYTHON_LIB_DIR}
+  COMMENT "Installing ${_target}'s libs into site-packages"
+  OUTPUT ${RV_STAGE_LIB_DIR}/site-packages/${_libname}
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_libpath} ${RV_STAGE_LIB_DIR}/site-packages/${_libname}
   DEPENDS ${_target}
 )
 ADD_CUSTOM_TARGET(
   ${_target}-stage-target ALL
-  DEPENDS ${RV_STAGE_LIB_DIR}/${_libname}
+  DEPENDS ${RV_STAGE_LIB_DIR}/site-packages/${_libname}
 )
 
 ADD_DEPENDENCIES(dependencies ${_target}-stage-target)


### PR DESCRIPTION
### Fix issue when importing pyimgui and pyimplot in a Python plugin on Windows

### Linked issues
n/a

### Summarize your change.
PyImGUI and PyImPlot could not be imported on Windows.

### Describe the reason for the change.
Make sure that the pyd module is generated and copy it to the right location.

### Describe what you have tested and on which operating system.
Windows

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.