### PR TITLE
Refactor diagnostics view

### DIFF
--- a/src/build/make_pyside6.py
+++ b/src/build/make_pyside6.py
@@ -101,6 +101,8 @@ def prepare() -> None:
             major_minor_version_str = ".".join(version[:2])
             if major_minor_version_str == "14.0":
                 return "14.0.3-based-macos-universal.7z"
+            elif major_minor_version_str == "15.0":
+                return "15.0.0-based-macos-universal.7z"
             elif major_minor_version_str == "17.0":
                 return "17.0.1-based-macos-universal.7z"
             return None

--- a/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
+++ b/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
@@ -43,6 +43,12 @@ namespace Rv
 
     void ImGuiPythonBridge::callCallbacks()
     {
+        // Early exit optimization - avoid Python overhead if no callbacks registered
+        if (s_callbacks.empty())
+        {
+            return;
+        }
+        
         for (auto& cb : s_callbacks)
         {
             PyGILState_STATE gstate = PyGILState_Ensure();

--- a/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
+++ b/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
@@ -5,12 +5,14 @@
 
 namespace Rv
 {
+    static bool s_shuttingDown = false;
+
     void ImGuiPythonBridge::PyObjectDeleter::operator()(PyObject* obj) const
     {
-        // seems to crash on exit if we have a callback registered.
-        // so patching this out for now.
-        // if (obj)
-        //     Py_DECREF(obj);
+        if (obj && !s_shuttingDown && Py_IsInitialized())
+        {
+            Py_DECREF(obj);
+        }
     }
 
     std::vector<ImGuiPythonBridge::PyObjectPtr> ImGuiPythonBridge::s_callbacks;
@@ -30,8 +32,8 @@ namespace Rv
         {
             if (PyObject_RichCompareBool(it->get(), callable, Py_EQ))
             {
-                it = s_callbacks.erase(it);
-                Py_DECREF(callable);
+                // Deleter will handle Py_DECREF automatically.
+                it = s_callbacks.erase(it); 
                 return;
             }
             else
@@ -64,7 +66,20 @@ namespace Rv
 
     void ImGuiPythonBridge::clearCallbacks()
     {
+        s_shuttingDown = true;
+        
+        // During shutdown, we cannot safely call Py_DECREF, so we just release
+        // the smart pointers without calling their deleters and let Python
+        // handle cleanup during interpreter shutdown.
+        for (auto& ptr : s_callbacks)
+        {
+            if (ptr)
+            {
+                // Release without calling Py_DECREF.
+                ptr.release(); 
+            }
+        }
+        
         s_callbacks.clear();
-        // CAll DECREF for each element if we're not using the deleter for this?
     }
 } // namespace Rv

--- a/src/lib/app/RvCommon/DiagnosticsView.cpp
+++ b/src/lib/app/RvCommon/DiagnosticsView.cpp
@@ -16,6 +16,8 @@
 
 #include "DiagnosticsView.Roboto_Regular"
 
+#include <iostream>
+
 namespace Rv
 {
     class DiagnosticsModule
@@ -34,7 +36,6 @@ namespace Rv
 
         if (_initCount == 1)
         {
-            _initCount++;
             ImGui::CreateContext();
             ImPlot::CreateContext();
             ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable;
@@ -51,72 +52,63 @@ namespace Rv
 
             if (_initCount == 0)
             {
+                int callbackCount = Rv::ImGuiPythonBridge::nbCallbacks();
+                Rv::ImGuiPythonBridge::clearCallbacks();
                 ImGui_ImplOpenGL2_Shutdown();
                 ImGui_ImplQt_Shutdown();
                 ImPlot::DestroyContext();
                 ImGui::DestroyContext();
             }
         }
+        else
+        {
+            std::cout << "DiagnosticsModule::shutdown - Warning: shutdown called but init count is already 0" << std::endl;
+        }
     }
 
     int DiagnosticsModule::_initCount = 0;
 
-    std::vector<PyObject*> DiagnosticsView::s_imguiCallbacks;
-
-    void DiagnosticsView::registerImGuiCallback(PyObject* callable)
-    {
-        if (PyCallable_Check(callable))
-        {
-            Py_INCREF(callable);
-            s_imguiCallbacks.push_back(callable);
-        }
-    }
-
-    void DiagnosticsView::callImGuiCallbacks()
-    {
-        for (auto* cb : s_imguiCallbacks)
-        {
-            PyGILState_STATE gstate = PyGILState_Ensure();
-            PyObject* result = PyObject_CallObject(cb, nullptr);
-            if (!result && PyErr_Occurred())
-                PyErr_Print();
-            Py_XDECREF(result);
-            PyGILState_Release(gstate);
-        }
-    }
-
     DiagnosticsView::DiagnosticsView(QWidget* parent, const QSurfaceFormat& fmt)
         : QOpenGLWidget(parent)
         , m_timer(this)
+        , m_initialized(false)
     {
         setFormat(fmt);
-
         setMinimumSize(100, 100);
 
-        DiagnosticsModule::init();
+        // Set the timer interval (40 ms = 25 fps -- more than enough for idle updates)
+        // but don't connect it yet - connection happens when first shown.
+        m_timer.setInterval(40);
+        
+        // NOTE: No ImGui initialization here - it will be done lazily when first shown.
+        // NOTE: Timer connection is also deferred until first show to minimize overhead.
+    }
 
-        applyStyle();
-
-        ImGui_ImplQt_RegisterWidget(this);
-
-        // Send an invalidate request every 33 milliseconds (eg: 30 fps tops)
-        connect(&m_timer, &QTimer::timeout, this,
-                QOverload<>::of(&QWidget::update));
-
-        // every 40 ms = 25 fps -- more than enough for idle updates
-        m_timer.start(40);
+    void DiagnosticsView::initializeImGui()
+    {
+        if (!m_initialized)
+        {
+            DiagnosticsModule::init();
+            applyStyle();
+            ImGui_ImplQt_RegisterWidget(this);
+            m_initialized = true;
+        }
     }
 
     DiagnosticsView::~DiagnosticsView()
     {
         m_timer.stop();
-        DiagnosticsModule::shutdown();
+        if (m_initialized)
+        {
+            DiagnosticsModule::shutdown();
+        }
     }
 
     void DiagnosticsView::initializeGL()
     {
         QOpenGLWidget::initializeGL();
         initializeOpenGLFunctions();
+        // NOTE: ImGui initialization moved to showEvent for lazy loading.
     }
 
     void DiagnosticsView::applyStyle()
@@ -348,6 +340,12 @@ namespace Rv
 
     void DiagnosticsView::paintGL()
     {
+        // Only paint if we're initialized (i.e., if the widget has been shown).
+        if (!m_initialized)
+        {
+            return;
+        }
+
         QOpenGLWidget::paintGL();
 
         // Start ImGui Frame
@@ -360,17 +358,47 @@ namespace Rv
         ImVec2 dockspace_size = ImGui::GetContentRegionAvail();
         ImGui::DockSpaceOverViewport(dockspace_id);
 
+        // Check if we have any Python callbacks registered
+        size_t numCallbacks = Rv::ImGuiPythonBridge::nbCallbacks();
         bool forceShowHelp = false;
-        if ((Rv::ImGuiPythonBridge::nbCallbacks() == 0) || forceShowHelp)
+        
+        if (numCallbacks == 0 || forceShowHelp)
         {
             showHelpWindow();
         }
 
-        Rv::ImGuiPythonBridge::callCallbacks();
+        if (numCallbacks > 0)
+        {
+            Rv::ImGuiPythonBridge::callCallbacks();
+        }
 
         // Render ImGui Frame
         ImGui::Render();
         ImGui_ImplOpenGL2_RenderDrawData(ImGui::GetDrawData());
+    }
+
+    void DiagnosticsView::showEvent(QShowEvent* event)
+    {
+        QOpenGLWidget::showEvent(event);
+        
+        // Perform lazy initialization when first shown
+        if (!m_initialized)
+        {
+            initializeImGui();
+            
+            // Connect the timer now that we actually need it
+            connect(&m_timer, &QTimer::timeout, this, QOverload<>::of(&QWidget::update));
+        }
+        
+        // Start the timer when the widget becomes visible.
+        m_timer.start();
+    }
+
+    void DiagnosticsView::hideEvent(QHideEvent* event)
+    {
+        QOpenGLWidget::hideEvent(event);
+        // Stop the timer when the widget is hidden to save CPU/GPU resources.
+        m_timer.stop();
     }
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/DiagnosticsView.cpp
+++ b/src/lib/app/RvCommon/DiagnosticsView.cpp
@@ -52,7 +52,6 @@ namespace Rv
 
             if (_initCount == 0)
             {
-                int callbackCount = Rv::ImGuiPythonBridge::nbCallbacks();
                 Rv::ImGuiPythonBridge::clearCallbacks();
                 ImGui_ImplOpenGL2_Shutdown();
                 ImGui_ImplQt_Shutdown();

--- a/src/lib/app/RvCommon/RvCommon/DiagnosticsView.h
+++ b/src/lib/app/RvCommon/RvCommon/DiagnosticsView.h
@@ -11,6 +11,8 @@
 #include <QOpenGLExtraFunctions>
 #include <QSurfaceFormat>
 #include <QTimer>
+#include <QShowEvent>
+#include <QHideEvent>
 
 #include <vector>
 
@@ -38,9 +40,16 @@ namespace Rv
         void handleMenuBar();
         void resetDockSpace();
 
+    protected:
+        void showEvent(QShowEvent* event) override;
+        void hideEvent(QHideEvent* event) override;
+
     private:
+        void initializeImGui();
+
         QTimer m_timer;
-        static std::vector<PyObject*> s_imguiCallbacks;
+        bool m_initialized = false;
+        
     };
 } // namespace Rv
 

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -180,7 +180,7 @@ namespace Rv
                 opts.dispAlphaBits, !m_startupResize);
         }
 
-        // Create DiagnosticsView as a dockable widget.
+        // Create DiagnosticsView as a dockable widget (lazy initialization).
         m_diagnosticsView = new DiagnosticsView(nullptr, m_glView->format());
 
         // Dockable to QMainWindow, not centralwidget.
@@ -843,7 +843,10 @@ namespace Rv
         QTimer::singleShot(100, this, SLOT(lazyDeleteGLView()));
     }
 
-    void RvDocument::showDiagnostics() { m_diagnosticsDock->show(); }
+    void RvDocument::showDiagnostics() 
+    {
+        m_diagnosticsDock->show(); 
+    }
 
     void RvDocument::setStereo(bool b)
     {


### PR DESCRIPTION
### Refactor diagnostics view

### Linked issues
n/a

### Summarize your change.

The primary issue was an always-on 25fps timer that consumed CPU/GPU resources even when the diagnostics window was never opened, along with eager initialization of ImGui/ImPlot contexts and Python bridge overhead. 

The solution was to implemented a lazy initialization where all expensive operations (ImGui context creation, timer connections, Python bridge setup) are deferred until the diagnostics window is first shown.

Additionally, I improved the shutdown sequence to prevent the application from hanging and crashing during exit.

Finally, I removed duplicated code in DiagnosticsView that was not used.

### Describe the reason for the change.

- Segmentation fault when leaving the application because the code was trying to delete Python references that did not exist anymore
- Slowness and High CPU usage seen during integration tests with Live review plugin. There were a lot of different initialization that was done before showing the diagnostics windows and it was slowing the normal operation of the application.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.