### PR TITLE
SG-39830: Add refreshOutputVideoDevice to CommandsModule

### DIFF
--- a/src/lib/app/mu_rvui/commands.mud
+++ b/src/lib/app/mu_rvui/commands.mud
@@ -1766,6 +1766,10 @@ For a device in a module return the ID string for one of the ModuleNameID, Devic
 or VideoAndDataFormatID. This is currently used to locate settings for display profiles.
 """
 
+refreshOutputVideoDevice"""
+Refresh the output video device based on the value of outputVideoDevice().
+"""
+
 devicePixelRatio """
 Return the device pixel ratio for high DPI displays.
 For reference: https://doc.qt.io/qt-6/highdpi.html

--- a/src/lib/app/py_rvui/rv_commands_setup.py
+++ b/src/lib/app/py_rvui/rv_commands_setup.py
@@ -278,6 +278,7 @@ all_mu_commands = [
     "writeAllNodeDefinitions",
     "writeNodeDefinition",
     "videoDeviceIDString",
+    "setOutputVideoDevice",
     "readProfile",
     "writeProfile",
     "editProfiles",

--- a/src/lib/app/py_rvui/rv_commands_setup.py
+++ b/src/lib/app/py_rvui/rv_commands_setup.py
@@ -278,7 +278,7 @@ all_mu_commands = [
     "writeAllNodeDefinitions",
     "writeNodeDefinition",
     "videoDeviceIDString",
-    "setOutputVideoDevice",
+    "refreshOutputVideoDevice",
     "readProfile",
     "writeProfile",
     "editProfiles",

--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -5128,6 +5128,14 @@ namespace IPMu
         NODE_RETURN(stype->allocate(idstr));
     }
 
+    NODE_IMPLEMENTATION(setOutputVideoDevice, void)
+    {
+        Session* s = Session::currentSession();
+        auto outputDevice = s->outputVideoDevice();
+
+        s->setOutputVideoDevice(outputDevice);
+    }
+
     NODE_IMPLEMENTATION(audioTextureID, int)
     {
         Session* s = Session::currentSession();
@@ -6449,6 +6457,9 @@ namespace IPMu
                          new Param(c, "moduleName", "string"),
                          new Param(c, "deviceName", "string"),
                          new Param(c, "idtype", "int"), End),
+
+            new Function(c, "setOutputVideoDevice", setOutputVideoDevice, None,
+                         Return, "void", End),
 
             new Function(c, "licensingState", licensingState, None, Return,
                          "int", End),

--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -5128,7 +5128,7 @@ namespace IPMu
         NODE_RETURN(stype->allocate(idstr));
     }
 
-    NODE_IMPLEMENTATION(setOutputVideoDevice, void)
+    NODE_IMPLEMENTATION(refreshOutputVideoDevice, void)
     {
         Session* s = Session::currentSession();
         auto outputDevice = s->outputVideoDevice();
@@ -6458,8 +6458,8 @@ namespace IPMu
                          new Param(c, "deviceName", "string"),
                          new Param(c, "idtype", "int"), End),
 
-            new Function(c, "setOutputVideoDevice", setOutputVideoDevice, None,
-                         Return, "void", End),
+            new Function(c, "refreshOutputVideoDevice",
+                         refreshOutputVideoDevice, None, Return, "void", End),
 
             new Function(c, "licensingState", licensingState, None, Return,
                          "int", End),


### PR DESCRIPTION
### [SG-39830](https://jira.autodesk.com/browse/SG-39830): Add refreshOutputVideoDevice to CommandsModule

### Summarize your change.

Add refreshOutputVideoDevice in CommandsModule.cpp and rv_commands_setup.py to access the function in Python.

### Describe the reason for the change.

When loading a media file, RV calls systematically `setOutputVideoDevice` in `readGTO` of RVSession.cpp. However, when joining an OTIO-based Live Review session, this path is never used and the output video device will not be set properly after quitting and joining back a session. To replicate the normal behaviour the output video device should be set when joining an OTIO-based Live Review session. To do so, that C++ function needs to be available in Python through the commands module. Note that this behaviour was not affecting RV to RV Live Review session since in that case, `readGTO` was being called.

### Describe what you have tested and on which operating system.

Quitting and joining back an OTIO-based Live Review session with the presentation mode enabled through NDI in RV.