### PR TITLE
Do not build libpng as a framework on MacOS

### DIFF
--- a/cmake/dependencies/png.cmake
+++ b/cmake/dependencies/png.cmake
@@ -37,6 +37,7 @@ ENDIF()
 LIST(APPEND _configure_options "-DZLIB_ROOT=${RV_DEPS_ZLIB_ROOT_DIR}")
 LIST(APPEND _configure_options "-DPNG_EXECUTABLES=OFF")
 LIST(APPEND _configure_options "-DPNG_TESTS=OFF")
+LIST(APPEND _configure_options "-DPNG_FRAMEWORK=OFF")
 
 EXTERNALPROJECT_ADD(
   ${_target}


### PR DESCRIPTION
### Do not build libpng as a framework on MacOS

### Linked issues
n/a

### Summarize your change.
Prevent libpng from building as a framework on MacOS.

### Describe the reason for the change.
Since the update to libpng 1.6.48, libpng builds as a framework on MacOS. `PNG_FRAMEWORK` will be passed to keep the same behavior as before the version update.

### Describe what you have tested and on which operating system.
MacOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.