### PR TITLE
Fix Hold & Ghost rendering issue during playback

### DIFF
--- a/src/lib/ip/IPCore/PaintCommand.cpp
+++ b/src/lib/ip/IPCore/PaintCommand.cpp
@@ -889,8 +889,14 @@ namespace IPCore
                 // so will cause the last cmd to be rendered twice, and in
                 // case of alpha not 0, or 1, it will not be correct
                 //
+                // Note: There is no cache to update when there is only 1
+                // command to render as the context.cachedfbo is already up to
+                // date. In other words when the last command is also the first
+                // command, we don't update the cache.
+                //
 
                 if (context.updateCache && context.cachedfbo
+                    && (context.commands.size() > 1)
                     && (context.commands[i] == context.lastCommand))
                 {
                     if (i > 0)


### PR DESCRIPTION
### Fix Hold & Ghost rendering issue during playback

### Linked issues
NA

### Summarize your change.

The Hold & Ghost rendering issue during playback was caused by a faulty logic in IPCore::Paint::renderPaintCommands().  I believe this was a legacy issue from a long time ago. 

**Problem:**
During playback, the hold & ghost would not render correctly during playback: frozen frames would be observed which would be updated whenever there was a new annotation to render.

**Cause:** 
IPCore::ImageRenderer::renderPaint() can leverage a cached fbo which is stored in paintContext.cachedfbo. When rendering multiple paint commands, IPCore::Paint::renderPaintCommands() is using this cachedfbo and it updates it when reaching the last command. All good. 

There was an edge case that was not covered by this logic: when this last paint command is also the first and only command: in this case we do not want to update the cache because the case is already up to date and no paint command has been rendered yet. This is exactly what was causing these playback artifacts.

**Solution:**
Added a check to prevent updating the cache when the last paint command is also the first and only command.

### Describe the reason for the change.

In somte situations, the hold & ghost would not render correctly during playback: frozen frames would be observed which would be updated whenever there was a new annotation to render.

### Describe what you have tested and on which operating system.

Successfully tested on mac OS.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.