### PR TITLE
SG-39984: Fix duration and startFrame paint properties

### DIFF
--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -488,22 +488,27 @@ namespace IPCore
                 sessionNode->property<IntProperty>("paintEffects",
                                                    "ghostAfter");
 
-            m_paintEffects.hold =
-                (holdProperty != nullptr && holdProperty->size() != 0)
-                    ? holdProperty->front()
-                    : 0;
-            m_paintEffects.ghost =
-                (ghostProperty != nullptr && ghostProperty->size() != 0)
-                    ? ghostProperty->front()
-                    : 0;
-            m_paintEffects.ghostBefore = (ghostBeforeProperty != nullptr
-                                          && ghostBeforeProperty->size() != 0)
-                                             ? ghostBeforeProperty->front()
-                                             : 5;
-            m_paintEffects.ghostAfter = (ghostAfterProperty != nullptr
-                                         && ghostAfterProperty->size() != 0)
-                                            ? ghostAfterProperty->front()
-                                            : 5;
+            if (holdProperty != nullptr && holdProperty->size() != 0)
+            {
+                m_paintEffects.hold = holdProperty->front();
+            }
+
+            if (ghostProperty != nullptr && ghostProperty->size() != 0)
+            {
+                m_paintEffects.ghost = ghostProperty->front();
+            }
+
+            if (ghostBeforeProperty != nullptr
+                && ghostBeforeProperty->size() != 0)
+            {
+                m_paintEffects.ghostBefore = ghostBeforeProperty->front();
+            }
+
+            if (ghostAfterProperty != nullptr
+                && ghostAfterProperty->size() != 0)
+            {
+                m_paintEffects.ghostAfter = ghostAfterProperty->front();
+            }
         }
     }
 

--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -9,16 +9,46 @@
 #include <IPCore/Exception.h>
 #include <IPCore/IPGraph.h>
 #include <TwkGLText/TwkGLText.h>
+#include <exception>
 #include <mutex>
 #include <stl_ext/string_algo.h>
 #include <cstdlib>
 #include <IPCore/ShaderCommon.h>
+#include <string>
 #include <tuple>
 
 namespace
 {
     using namespace IPCore;
     using PerFramePaintCommands = std::map<int, PaintIPNode::LocalCommands>;
+
+    int getStartFrame(const TwkContainer::Component& component)
+    {
+        std::stringstream stringStream;
+        stringStream << component.name();
+
+        std::string property;
+        std::vector<std::string> properties{};
+
+        while (std::getline(stringStream, property, ':'))
+        {
+            properties.push_back(property);
+        }
+
+        if (properties.size() > 2)
+        {
+            try
+            {
+                return std::stoi(properties[2]);
+            }
+            catch (const std::exception& e)
+            {
+                std::cout
+                    << "ERROR: Unable to get the frame from the pen component: "
+                    << e.what() << "'\n";
+            }
+        }
+    }
 
     // Calculates the opacity based on the distance from the annotated frame to
     // make the ghosted annotation more visible closer to the frame and less
@@ -305,10 +335,10 @@ namespace IPCore
         const int startFrame =
             (startFrameP != nullptr && startFrameP->size() != 0)
                 ? startFrameP->front()
-                : 0;
+                : getStartFrame(*c);
         const int duration = (durationP != nullptr && durationP->size() != 0)
                                  ? durationP->front()
-                                 : 0;
+                                 : 1;
 
         p.width = width;
         p.color = color;
@@ -467,11 +497,11 @@ namespace IPCore
             m_paintEffects.ghostBefore = (ghostBeforeProperty != nullptr
                                           && ghostBeforeProperty->size() != 0)
                                              ? ghostBeforeProperty->front()
-                                             : 0;
+                                             : 5;
             m_paintEffects.ghostAfter = (ghostAfterProperty != nullptr
                                          && ghostAfterProperty->size() != 0)
                                             ? ghostAfterProperty->front()
-                                            : 0;
+                                            : 5;
         }
     }
 

--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -48,6 +48,8 @@ namespace
                     << e.what() << "'\n";
             }
         }
+
+        return 0;
     }
 
     // Calculates the opacity based on the distance from the annotated frame to


### PR DESCRIPTION
### [SG-39984](https://jira.autodesk.com/browse/SG-39984): Fix duration and startFrame paint properties

### Summarize your change.

Change fallback values of duration and startFrame when the properties are not defined on the paint node. For duration, that value should have been 1 instead of 0. For startFrame, the frame value is access through the pen component that is format as follows: `"pen:strokeId:frameNumber:user"`. Even if it wasn't causing an issue, I changed the `ghostBefore` and `ghostAfter` values to 5 instead of 0 to match what the SessionIPNode is setting since 0 doesn't make sense here.

### Describe the reason for the change.

The `duration` and `startFrame` properties were added to know when and for how long to display held and ghosted annotations as well as calculate the opacity level for ghosted annotations. However, these two properties doesn't exist in previous version of RV. This is causing an issue, because annotations saved in an older RV session won't have these new properties and the hold and ghost feature will not be displayed properly.The fallback values are now taking care of that case.

### Describe what you have tested and on which operating system.

Enabling hold and ghost on an RV session from RV 2024.2.1 in RV 2025.0.0 was tested on macOS.