### PR TITLE
Fix issue where the wrong QProcess.finished signal was used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,7 +656,7 @@ jobs:
           $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           $componentsToRemove= @(
             "Microsoft.VisualStudio.Component.VC.${{ matrix.msvc-component }}"
-            "Microsoft.VisualStudio.Component.VC.1${{ matrix.msvc-component }}.Spectre"
+            "Microsoft.VisualStudio.Component.VC.${{ matrix.msvc-component }}.Spectre"
           )
           [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --add " +  $_}
           $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')

--- a/src/lib/app/mu_rvui/external_qprocess.mu
+++ b/src/lib/app/mu_rvui/external_qprocess.mu
@@ -41,7 +41,7 @@ class: ExternalQProcess : ExternalProcess
         }
     }
 
-    method: finish (void; int exitcode = -1, qt.QProcess.ExitStatus exitStatus = -1)
+    method: finish (void; int exitcode, qt.QProcess.ExitStatus exitStatus)
     {
         if (_proc neq nil)
         {

--- a/src/lib/mu/MuQt6/Bridge.cpp
+++ b/src/lib/mu/MuQt6/Bridge.cpp
@@ -1124,6 +1124,33 @@ namespace Mu
 
     //----------------------------------------------------------------------
 
+    bool isKnownDeprecatedSignal(const char* className,
+                                 const std::string& signalName,
+                                 const char* fullSignature)
+    {
+        // Uncomment and modify this function to add known deprecated signals.
+        // See src/lib/mu/MuQt5/Bridge.cpp
+
+        // Example:
+
+        // const std::string classStr = className;
+        // const std::string sigStr = fullSignature;
+
+        // if (classStr == "QMyClass")
+        // {
+        //     if (signalName == "mySignal")
+        //     {
+        //         if (sigStr == "mySignal(int)" || sigStr.find("mySignal(int)")
+        //         == 0)
+        //         {
+        //             return true;
+        //         }
+        //     }
+        // }
+
+        return false;
+    }
+
     void populate(Class* c, const QMetaObject& m, const char** propExclusions)
     {
         bool verbose = false;
@@ -1390,6 +1417,36 @@ namespace Mu
                 || mm.methodSignature()[0] == '_')
             {
                 continue;
+            }
+
+            if (verbose)
+            {
+                std::cout << "Method: " << mm.methodSignature().constData()
+                          << std::endl;
+            }
+
+            // Skip known deprecated signals to avoid errors at runtime.
+            if (mm.methodType() == QMetaMethod::Signal)
+            {
+                std::string currentSignalName =
+                    mm.methodSignature().constData();
+                std::string::size_type parenPos = currentSignalName.find('(');
+                currentSignalName.erase(parenPos,
+                                        currentSignalName.size() - parenPos);
+
+                bool deprecated =
+                    isKnownDeprecatedSignal(m.className(), currentSignalName,
+                                            mm.methodSignature().constData());
+                if (deprecated)
+                {
+                    if (verbose)
+                    {
+                        std::cout << "Skipping known deprecated signal: "
+                                  << mm.methodSignature().constData()
+                                  << std::endl;
+                    }
+                    continue;
+                }
             }
 
             STLVector<ParameterVariable*>::Type params;


### PR DESCRIPTION
### Fix issue where the wrong QProcess.finished signal was used

### Linked issues
n/a

### Summarize your change.
I added some logic to discard known deprecated signals. The logic is present in MuQt5 and MuQt6 in prevision of future deprecated signals.

There is no reliable way to detect if a signal is deprecated. Therefore, we have to rely on known lists.

### Describe the reason for the change.
In Mu code, there is an issue where the wrong QProcess.finished is used because there is a deprecated version of it from Qt 5.13.

### Describe what you have tested and on which operating system.
MacOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.