### PR TITLE
Fix duplicated menu options in RV menu (top left) on macos with Qt 6

### DIFF
--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -843,10 +843,7 @@ namespace Rv
         QTimer::singleShot(100, this, SLOT(lazyDeleteGLView()));
     }
 
-    void RvDocument::showDiagnostics() 
-    {
-        m_diagnosticsDock->show(); 
-    }
+    void RvDocument::showDiagnostics() { m_diagnosticsDock->show(); }
 
     void RvDocument::setStereo(bool b)
     {
@@ -1746,6 +1743,29 @@ namespace Rv
             QList<QAction*> actionsMinusFirstOne = mb()->actions().mid(1);
             disconnectActions(actionsMinusFirstOne);
         }
+
+#ifdef PLATFORM_DARWIN
+        // Before clearing the menu bar, ensure shared actions are properly
+        // removed to prevent Qt 6 menu duplication issues on macOS.
+        QList<QAction*> allActions = mb()->actions();
+        for (QAction* action : allActions)
+        {
+            if (QMenu* menu = action->menu())
+            {
+                QList<QAction*> menuActions = menu->actions();
+                for (QAction* menuAction : menuActions)
+                {
+                    if (menuAction == RvApp()->aboutAction()
+                        || menuAction == RvApp()->prefAction()
+                        || menuAction == RvApp()->networkAction()
+                        || menuAction == RvApp()->quitAction())
+                    {
+                        menu->removeAction(menuAction);
+                    }
+                }
+            }
+        }
+#endif
 
         mb()->clear();
 


### PR DESCRIPTION
### Fix duplicated menu on macos with Qt 6

### Linked issues
n/a

### Summarize your change.
Improved the purgeMenus() method in RvDocument.cpp to explicitly remove application-level actions from all menus before clearing the menu bar.

### Describe the reason for the change.
When mb()->clear() is called in purgeMenus(), Qt 6 doesn't automatically remove application-level actions (About, Preferences, Network, Quit) from their current menu locations, causing them to appear duplicated when menus are rebuilt.

### Describe what you have tested and on which operating system.
MacOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.