### PR TITLE
Fix missing devicePixelRatio() ui stub cmd for rvio

### DIFF
--- a/src/bin/imgtools/rvio/UICommands.cpp
+++ b/src/bin/imgtools/rvio/UICommands.cpp
@@ -229,6 +229,9 @@ namespace RVIO
             new Function(c, "openUrl", openUrl, None, Return, "void",
                          Parameters, new Param(c, "url", "string"), End),
 
+            new Function(c, "devicePixelRatio", devicePixelRatio, None, Return,
+                         "float", End),
+
             EndArguments);
     }
 
@@ -320,5 +323,7 @@ namespace RVIO
     NODE_DECLARATION(javascriptMuExport, void) {}
 
     NODE_IMPLEMENTATION(myNetworkHost, Pointer) { NODE_RETURN(0); }
+
+    NODE_IMPLEMENTATION(devicePixelRatio, float) { NODE_RETURN(1.0f); }
 
 } //  End namespace RVIO

--- a/src/bin/imgtools/rvio/UICommands.h
+++ b/src/bin/imgtools/rvio/UICommands.h
@@ -60,6 +60,7 @@ namespace RVIO
     NODE_DECLARATION(javascriptMuExport, void);
     NODE_DECLARATION(openUrl, void);
     NODE_DECLARATION(myNetworkHost, Mu::Pointer);
+    NODE_DECLARATION(devicePixelRatio, float);
 
 } // namespace RVIO
 


### PR DESCRIPTION
### Fix missing devicePixelRatio() ui stub cmd in rvio

### Linked issues
NA

### Summarize your change.
rvio has its own set of stub UI commands which are effectively noop to make sure it can loads other scripts with UI command. The devicePixelRatio() UI command was recently introduced but I omitted to add an associated stub command to rvio. My bad.

### Describe the reason for the change.

rvio was complaining about the missing devicePixelRatio() command:
RV.app/Contents/PlugIns/Mu/rvtypes.mu, line 530, char 49: Unresolved function call to "devicePixelRatio"
ERROR: while loading source module "/RV.app/Contents/PlugIns/Mu/rvtypes.mu"
ERROR: attempted call to unresolved function
RV.app/Contents/PlugIns/Mu/glyph.mu, line 527, char 43: Unresolved function call to "devicePixelRatio"
ERROR: while loading source module "RV.app/Contents/PlugIns/Mu/[glyph.mu](http://glyph.mu/)"

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.