### PR TITLE
SG-40023: Fix Clone Sync

### DIFF
--- a/src/plugins/rv-packages/sync/sync.mu
+++ b/src/plugins/rv-packages/sync/sync.mu
@@ -37,7 +37,7 @@ global float POINTER_TIME_TO_LIVE = 10.0;
         require qt;
 
         let d = qt.QDateTime.currentDateTime();
-        print(\"sync(%s,%s): %s\\n\" % (myNetworkPort(), d.toString(\"mm:ss:zzz\", qt.QCalendar()), s));
+        print("sync(%s,%s): %s\n" % (myNetworkPort(), d.toString("mm:ss:zzz", qt.QCalendar()), s));
     }
 }
 


### PR DESCRIPTION
### [SG-40023](https://jira.autodesk.com/browse/SG-40023): Fix Clone Sync

### Summarize your change.

Fix formatting issue in the print statement for debugging in sync.mu

### Describe the reason for the change.

This line was changed a few times in the last months with the addition of Qt6 in RV. The resulting line is a mix of two previous fixes and a warning of a missing '"' was now present on this line. This format issue was causing syntax errors preventing Clone Sync from being enabled correctly. \" are not necessary and this is actually how the line was before the previous changes.

### Describe what you have tested and on which operating system.

Launching Clone Sync on macOS