### PR TITLE
Disable High-DPI by Default on Windows

### DIFF
--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -250,9 +250,21 @@ int utf8Main(int argc, char* argv[])
     XInitThreads();
 #endif
 
-    // Now supporting high DPI displays by default
-    // Setting the following environment variable, disable the high DPI support
+#ifdef PLATFORM_WINDOWS
+    // High DPI support is disabled by default on Windows.
+    // This is a temporary measure due to reported crashes with
+    // QtWebEngineWidgets in Qt 6.5.3 on high DPI displays. To enable High DPI
+    // support, set the environment variable "RV_QT_HDPI_SUPPORT". Note: The
+    // "RV_QT_HDPI_SUPPORT" environment variable was also used in previous
+    // versions of RV.
+    const bool noHighDPISupport = getenv("RV_QT_HDPI_SUPPORT") == nullptr;
+#else
+    // High DPI support is enabled by default on non-Windows platforms.
+    // To disable High DPI support, set the environment variable
+    // "RV_NO_QT_HDPI_SUPPORT".
     const bool noHighDPISupport = getenv("RV_NO_QT_HDPI_SUPPORT") != nullptr;
+#endif
+
     if (noHighDPISupport)
     {
         qunsetenv("QT_SCALE_FACTOR");


### PR DESCRIPTION
### Disable High-DPI by Default on Windows

### Linked issues
NA

### Summarize your change.

- Disable High DPI support by default on Windows.
- On Windows, restore the "RV_QT_HDPI_SUPPORT" environment variable to be able to re-enable it (it was also used in previous versions of RV.)

### Describe the reason for the change.

This is a temporary measure due to reported crashes with QtWebEngineWidgets in Qt 6.5.3 on high DPI displays on Windows.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.