### PR TITLE
Fix range discrepancy for missing media when in Live Review

### DIFF
--- a/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/FileSourceIPNode.cpp
@@ -2288,7 +2288,21 @@ namespace IPCore
             m_rangeStart = p;
         }
 
-        if (isMediaActive())
+        // Reload media if the media is active or if the range is not the
+        // default
+        // - If the media is active, we need to reload the media to ensure that
+        // the correct frames are loaded
+        // - If the media is NOT active, we normally don't want to reload the
+        // media because doing so would be detrimental to performances in a
+        // multiple media representations scenario where we only load the
+        // active media representation(s).
+        // - If the media is NOT active, we need to reload the media if the
+        // range is not the default range. This special case is typically for
+        // missing media.
+        const Vec2i defaultRange = Vec2i(0, 1);
+        const Vec2i range =
+            propertyValue<Vec2iProperty>("proxy.range", defaultRange);
+        if (isMediaActive() || range != defaultRange)
         {
             HOP_PROF("FileSourceIPNode::readCompleted - reloadMediaFromFiles");
             reloadMediaFromFiles();


### PR DESCRIPTION
### Fix range discrepancy for missing media when in Live Review

### Linked issues
NA

### Describe the reason for the change.
This commit addresses the following issue which has a bigger importance in an RV<->RV Live Review session:

If you load some missing media in RV, you will get a default proxy range of 19 frames.
Here is a python script that can be executed in a python console to reproduce this missing media situation: 
```
from rv import commands as rvc
rvc.addSourceVerbose(["/some/offline/file.mov"])
```

Now if you save the RV session file to disk, clear the RV session, and reload this session, then you will get a range of 1 frame only for the missing media. 

This asymmetery has a significant importance in an RV<->RV Live Review session because it makes a presenter and its participants out of sync if a partitipant joins the session after the missing media is loaded. The reason for this is that when a participant joins an RV<->RV Live Review session, the presenter effectively serializes its session and pass it to the participant. Duplicating the exact same paths as the case above.

The root cause of this issue is that adding a source to an RV session is unfortuntely not equivalent to the one created in an RV session via RvSession::readGTO.

### Summarize your change.

The solution proposed here is to make sure that the RvSession::readGTO tries to reload media even for inactive media if its range is not the default one: which is the case for missing media which has a range of 19 frames.

Now we don't want to reload all the inactive media because it would be detrimental to performances in a multiple media representation scenarios where we only want to load the active media by default. Once the RV session is loaded, the RV user has always the option of loading alternative media representations via the menu.

### Describe what you have tested and on which operating system.

Successfully tested on macO

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

Before: Out of sync when media is missing and participant joins after loading the missing media:
<img width="1453" height="507" alt="before_out_of_sync_when_media_is_missing" src="https://github.com/user-attachments/assets/1522622b-6f79-4b3b-bd4d-7d4bc3bc37fe" />

After: Both in sync when media is missing and participant joins after loading the missing media:
<img width="1429" height="504" alt="after_both_in_sync_even_if_media_is_missing" src="https://github.com/user-attachments/assets/132fe38d-4370-43a0-b9bd-4e8ee4a81228" />
