### PR TITLE
SG-39966: Fix annotation color selection

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -2159,7 +2159,7 @@ class: AnnotateMinorMode : MinorMode
         connect(_drawDock, QDockWidget.topLevelChanged, topLevelChangedSlot);
 
         connect(_colorButton, QPushButton.clicked, chooseColorSlot);
-        connect(_colorDialog, QColorDialog.currentColorChanged, newColorSlot(,true,true));
+        connect(_colorDialog, QColorDialog.colorSelected, newColorSlot(,true,true));
 
         _undoAct = QAction(auxIcon("undo_64x64.png"), "Undo", m);
         _redoAct = QAction(auxIcon("redo_64x64.png"), "Redo", m);


### PR DESCRIPTION
### [SG-39966](https://jira.autodesk.com/browse/SG-39966): Fix annotation color selection

### Summarize your change.

Replace QColorDialog `currentColorChanged` signal with `colorSelected`.

### Describe the reason for the change.

`currentColorChanged` is a signal emitted whenever the color is changed in the dialog. This means that "Ok" and "Cancel" had no effect since the color was already changed as soon as it was selected. `colorSelected` is emitted just after "Ok" is clicked to set the color to use. That way, the color is only set after the user has clicked on "Ok", quitting the dialog or clicking on "Cancel" will not save the selected color.

### Describe what you have tested and on which operating system.

Selecting colors through the QColorDialog was tested on macOS.