### PR TITLE
Alt+Shift key up doesn't clear Alt modifier (#879)

### DIFF
--- a/src/lib/app/RvCommon/QTTranslator.cpp
+++ b/src/lib/app/RvCommon/QTTranslator.cpp
@@ -133,7 +133,11 @@ namespace Rv
                 //  is that in many cases this code causes the control modifier
                 //  to be lost.
                 //
+                // Alt modifier included in handling, as a mismatch can
+                // occur when pressing Alt + Shift. Qt can incorrectly
+                // substitute Meta button for Alt on key up.
                 if (m_modifiers & Qt::ControlModifier
+                    || m_modifiers & Qt::AltModifier
                     || m_modifiers & Qt::MetaModifier)
                 {
                     m_modifiers = inputEvent->modifiers() & 0xffff0000;


### PR DESCRIPTION
This update includes Alt in handling that already exists for clearing modifiers after a modifier mismatch occurs.

`Alt` + `Shift` modifier key-down was incorrectly identifying as `Meta` + `Shift` on key-up. As a result, `Alt` state continued after key up, which caused operators to think RV was hung -- spacebar wouldn't play/pause, dragging cursor on screen wouldn't scrub timeline, etc.

Reproduced Alt+Shift issue on Linux RHEL 9.4 and RHEL 7.2, using:
* Latest OpenRV main branch
* RV 2023.0.3
* RV 7.2.6 Confirmed it did not happen on MacOS Sequoia.

<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.