### PR TITLE
Fix rvcfg process to allow enabling of ac3 non-free codec (#881)

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -279,6 +279,7 @@ IF(NOT RV_FFMPEG_CONFIG_OPTIONS)
       "aac_at"
       "aac_fixed"
       "aac_latm"
+      "ac3"
       "bink"
       "binkaudio_dct"
       "binkaudio_rdft"


### PR DESCRIPTION
### Fix rvcfg process to allow enabling of ac3 non-free codec

### Summarize your change.
Added ac3 to the list of available non-free codecs in NON_FREE_DECODERS_TO_DISABLE that could
be overridden by rvcfg command

### Describe the reason for the change.
Enabling ac3 via this command did not enable ac3 at build time: rvcfg -DRV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE="ac3"

### Describe what you have tested and on which operating system.
Tested building with ac3 support on Linux RHEL 9.4