### PR TITLE
SG-40116: Fix removal of EnvVar prefix to filenames by broadcasting unmodified paths

### DIFF
--- a/src/lib/app/RvApp/CommandsModule.cpp
+++ b/src/lib/app/RvApp/CommandsModule.cpp
@@ -1377,15 +1377,17 @@ namespace Rv
         string tag = (muTag) ? muTag->c_str() : "";
 
         vector<string> sargs;
+        vector<string> sargsRemote;
 
         for (size_t i = 0; i < array->size(); i++)
         {
             string arg = array->element<StringType::String*>(i)->c_str();
+            sargsRemote.push_back(arg);
             sargs.push_back(IPCore::Application::mapFromVar(arg));
         }
 
         // silences broadcasting events below this constructor
-        IPMu::RemoteRvCommand remoteRvCommand(s, "addSources", sargs, tag,
+        IPMu::RemoteRvCommand remoteRvCommand(s, "addSources", sargsRemote, tag,
                                               processOpts, merge);
 
         //
@@ -1413,28 +1415,32 @@ namespace Rv
         IPGraph::GraphEdit edit(s->graph());
 
         vector<vector<string>> allFilesAndOptions;
+        vector<vector<string>> allFilesAndOptionsRemote;
 
         for (size_t i = 0; i < array->size(); i++)
         {
             DynamicArray* currentSource = array->element<DynamicArray*>(i);
 
             vector<string> filesAndOptions;
+            vector<string> filesAndOptionsRemote;
             filesAndOptions.reserve(currentSource->size());
             for (size_t j = 0; j < currentSource->size(); j++)
             {
                 string arg =
                     currentSource->element<StringType::String*>(j)->c_str();
 
+                filesAndOptionsRemote.emplace_back(arg);
                 filesAndOptions.emplace_back(
                     IPCore::Application::mapFromVar(arg));
             }
 
             allFilesAndOptions.push_back(filesAndOptions);
+            allFilesAndOptionsRemote.push_back(filesAndOptionsRemote);
         }
 
         // silences broadcasting events below this constructor
         IPMu::RemoteRvCommand remoteRvCommand(s, "addSourcesVerbose",
-                                              allFilesAndOptions, tag);
+                                              allFilesAndOptionsRemote, tag);
 
         // Now that we've broadcast the remote event, complete the work without
         // broadcasting anything else.


### PR DESCRIPTION
### Fix removal of environment variable prefix by broadcasting unmodified paths.

This is a tentative fix for SG-40116

Labeled as "**DO NOT MERGED - BLOCKED**" until customer validates this PR.

### Describe the reason for the change.

Customer reported that they prefix their filenames by an environment variable, but that when broadcasting the filenames the env var had been replaced by the expanded version. Remote computers receiving the filenames thus can't resolve the files locally.

### Summarize your change.

In addSources and addSourcesVerbose, send the raw, unmodified filename to the broadcast remote command. 

Let's hope this fixes it!

### Describe what you have tested and on which operating system.

Not tested; just built. Needs customer validation.

### Add a list of changes, and note any that might need special attention during the review.

N/A

### If possible, provide screenshots.