### PR TITLE
Fix fit window to image crash - w keyboard shortcut

### DIFF
--- a/cmake/dependencies/ocio.cmake
+++ b/cmake/dependencies/ocio.cmake
@@ -124,7 +124,7 @@ LIST(APPEND _byproducts "${_pyocio_lib}")
 # Assemble CMake configure options
 #
 # The '_configure_options' list gets reset and initialized in 'RV_CREATE_STANDARD_DEPS_VARIABLES'
-LIST(APPEND _configure_options "-DOCIO_BUILD_TESTS=ON")
+LIST(APPEND _configure_options "-DOCIO_BUILD_TESTS=OFF")
 LIST(APPEND _configure_options "-DOCIO_BUILD_GPU_TESTS=OFF")
 LIST(APPEND _configure_options "-DOCIO_BUILD_PYTHON=ON") # This build PyOpenColorIO
 

--- a/src/lib/app/mu_rvui/CMakeLists.txt
+++ b/src/lib/app/mu_rvui/CMakeLists.txt
@@ -10,15 +10,15 @@ SET(_target
 
 IF(RV_VFX_PLATFORM STREQUAL CY2024)
   SET(MU_QT_QAPPLICATION_AVAILABLE_GEOMETRY
-    "
+      "
        // Get available screen geometry for the screen containing the window\n \
        let screen = qt.QGuiApplication.screenAt(globalPos);\n \
        if (screen eq nil) screen = qt.QGuiApplication.primaryScreen();\n \
-       let usedRect = screen.availableGeometry();\n \
+       let usedRect = if (screen eq nil) then mainRect else screen.availableGeometry();\n \
     "
   )
   SET(MU_DPI_SCALING_ADJUSTMENT
-    "
+      "
        // Check for DPI/scaling on the current screen\n \
        let globalPos = mainWin.mapToGlobal(qt.QPoint(0, 0));\n \
        let dpiScreen = qt.QGuiApplication.screenAt(globalPos);\n \
@@ -42,7 +42,9 @@ ELSEIF(RV_VFX_PLATFORM STREQUAL CY2023)
   SET(MU_QT_QAPPLICATION_AVAILABLE_GEOMETRY
       "let usedRect = qt.QApplication.desktop().availableGeometry(mainWin);\n"
   )
-  SET(MU_DPI_SCALING_ADJUSTMENT "")
+  SET(MU_DPI_SCALING_ADJUSTMENT
+      ""
+  )
 ENDIF()
 SET(MU_QT_QAPPLICATION_AVAILABLE_GEOMETRY
     "${MU_QT_QAPPLICATION_AVAILABLE_GEOMETRY}"

--- a/src/lib/mu/MuQt6/QGuiApplicationType.cpp
+++ b/src/lib/mu/MuQt6/QGuiApplicationType.cpp
@@ -304,8 +304,18 @@ namespace Mu
     Pointer qt_QGuiApplication_primaryScreen_QScreen(Mu::Thread& NODE_THREAD)
     {
         MuLangContext* c = static_cast<MuLangContext*>(NODE_THREAD.context());
-        return makeinstance<QScreenType>(c, QGuiApplication::primaryScreen(),
-                                         "qt.QScreen");
+
+        // Retrieve the primary screen
+        QScreen* screen = QGuiApplication::primaryScreen();
+
+        // If no screen is found, return nullptr
+        if (!screen)
+        {
+            return nullptr;
+        }
+
+        // Create a new instance of QScreenType and return it
+        return makeinstance<QScreenType>(c, screen, "qt.QScreen");
     }
 
     int qt_QGuiApplication_queryKeyboardModifiers_int(Mu::Thread& NODE_THREAD)
@@ -323,10 +333,24 @@ namespace Mu
     Pointer qt_QGuiApplication_screenAt_QScreen_QPoint(Mu::Thread& NODE_THREAD,
                                                        Pointer param_point)
     {
-        MuLangContext* c = static_cast<MuLangContext*>(NODE_THREAD.context());
-        const QPoint arg0 = getqtype<QPointType>(param_point);
-        return makeinstance<QScreenType>(c, QGuiApplication::screenAt(arg0),
-                                         "qt.QScreen");
+        // Retrieve the current MuLangContext from the NODE_THREAD context
+        MuLangContext* context =
+            static_cast<MuLangContext*>(NODE_THREAD.context());
+
+        // Convert the passed parameter to a QPoint object
+        const QPoint point = getqtype<QPointType>(param_point);
+
+        // Retrieve the screen at the specified point
+        QScreen* screen = QGuiApplication::screenAt(point);
+
+        // If no screen is found, return nullptr
+        if (!screen)
+        {
+            return nullptr;
+        }
+
+        // Create a new instance of QScreenType and return it
+        return makeinstance<QScreenType>(context, screen, "qt.QScreen");
     }
 
     void qt_QGuiApplication_setDesktopSettingsAware_void_bool(

--- a/src/lib/mu/MuQt6/QScreenType.cpp
+++ b/src/lib/mu/MuQt6/QScreenType.cpp
@@ -275,8 +275,19 @@ namespace Mu
         MuLangContext* c = static_cast<MuLangContext*>(NODE_THREAD.context());
         QScreen* arg0 = object<QScreen>(param_this);
         QPoint arg1 = getqtype<QPointType>(param_point);
-        return makeinstance<QScreenType>(c, arg0->virtualSiblingAt(arg1),
-                                         "qt.QScreen");
+
+        // Retrieve the screen at point within the set of
+        // QScreen::virtualSiblings()
+        QScreen* screen = arg0->virtualSiblingAt(arg1);
+
+        // If no screen is found, return nullptr
+        if (!screen)
+        {
+            return nullptr;
+        }
+
+        // Create a new instance of QScreenType and return it
+        return makeinstance<QScreenType>(c, screen, "qt.QScreen");
     }
 
     Pointer qt_QScreen_virtualSize_QSize_QScreen(Mu::Thread& NODE_THREAD,

--- a/src/lib/mu/MuQt6/QWidgetType.cpp
+++ b/src/lib/mu/MuQt6/QWidgetType.cpp
@@ -1567,7 +1567,18 @@ namespace Mu
     {
         MuLangContext* c = static_cast<MuLangContext*>(NODE_THREAD.context());
         QWidget* arg0 = object<QWidget>(param_this);
-        return makeinstance<QScreenType>(c, arg0->screen(), "qt.QScreen");
+
+        // Retrieve the screen the widget is on
+        QScreen* screen = arg0->screen();
+
+        // If no screen is found, return nullptr
+        if (!screen)
+        {
+            return nullptr;
+        }
+
+        // Create a new instance of QScreenType and return it
+        return makeinstance<QScreenType>(c, screen, "qt.QScreen");
     }
 
     void qt_QWidget_scroll_void_QWidget_int_int(Mu::Thread& NODE_THREAD,


### PR DESCRIPTION
### Fix fit window to image crash - w keyboard shortcut

### Linked issues
Fixes #885

### Describe the reason for the change.
**Problem:**
RV was sometimes crashing when fitting the window to image - w keyboard shortcut

### Summarize your change.

**Cause:**
The source of this isssue is that the FitWindowToImage functionality uses a new Qt6 functionality: QGuiApplication::screenAt() wrapped in the Mu command qt.QGuiApplication.screenAt().
Now this new Qt6 method can possibly returns nullptr if the position nis outside any visible screen.
The new associated Mu binding was always wrapping the returned pointer as a Mu object no matter what: makeinstance<QScreenType>.
Which is why the crash occurred: when the position was outside the screen then the Mu code would reference the nullptr.

**Solution:**
Now returning a nullptr for all Mu bindings wrapping a QScreen as a Mu object: makeinstance<QScreenType>
I did that for all the places where we were wrapping a QScreen in Mu as all the instances could actually be null as per the Qt6 documentation.

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.