### PR TITLE
fix path swap variable

### DIFF
--- a/src/lib/app/RvApp/CommandsModule.cpp
+++ b/src/lib/app/RvApp/CommandsModule.cpp
@@ -1296,16 +1296,23 @@ namespace Rv
         const StringType* stype = c->stringType();
 
         vector<string> filesAndOptions;
+        vector<string> filesAndOptionsRemote;
         filesAndOptions.reserve(array->size());
-        for (size_t i = 0; i < array->size(); i++)
-            filesAndOptions.emplace_back(
-                array->element<StringType::String*>(i)->c_str());
+        filesAndOptionsRemote.reserve(array->size());
 
-        IPGraph::GraphEdit edit(s->graph());
+        for (size_t i = 0; i < array->size(); i++)
+        {
+
+            string arg = IPCore::Application::mapFromVar(
+                array->element<StringType::String*>(i)->c_str());
+            filesAndOptions.emplace_back(arg);
+            filesAndOptionsRemote.emplace_back(
+                IPCore::Application::mapToVar(arg));
+        }
 
         // silences broadcasting events below this constructor
         IPMu::RemoteRvCommand remoteRvCommand(s, "addSourceVerbose",
-                                              filesAndOptions, tag);
+                                              filesAndOptionsRemote, tag);
 
         // Now that we've broadcast the remote event, complete the work without
         // broadcasting anything else.
@@ -1377,15 +1384,18 @@ namespace Rv
         string tag = (muTag) ? muTag->c_str() : "";
 
         vector<string> sargs;
+        vector<string> sargsRemote;
 
         for (size_t i = 0; i < array->size(); i++)
         {
-            string arg = array->element<StringType::String*>(i)->c_str();
-            sargs.push_back(IPCore::Application::mapFromVar(arg));
+            string arg = IPCore::Application::mapFromVar(
+                array->element<StringType::String*>(i)->c_str());
+            sargs.push_back(arg);
+            sargsRemote.push_back(IPCore::Application::mapToVar(arg));
         }
 
         // silences broadcasting events below this constructor
-        IPMu::RemoteRvCommand remoteRvCommand(s, "addSources", sargs, tag,
+        IPMu::RemoteRvCommand remoteRvCommand(s, "addSources", sargsRemote, tag,
                                               processOpts, merge);
 
         //
@@ -1413,28 +1423,31 @@ namespace Rv
         IPGraph::GraphEdit edit(s->graph());
 
         vector<vector<string>> allFilesAndOptions;
+        vector<vector<string>> allFilesAndOptionsRemote;
 
         for (size_t i = 0; i < array->size(); i++)
         {
             DynamicArray* currentSource = array->element<DynamicArray*>(i);
 
             vector<string> filesAndOptions;
+            vector<string> filesAndOptionsRemote;
             filesAndOptions.reserve(currentSource->size());
             for (size_t j = 0; j < currentSource->size(); j++)
             {
-                string arg =
-                    currentSource->element<StringType::String*>(j)->c_str();
-
-                filesAndOptions.emplace_back(
-                    IPCore::Application::mapFromVar(arg));
+                string arg = IPCore::Application::mapFromVar(
+                    currentSource->element<StringType::String*>(j)->c_str());
+                filesAndOptions.emplace_back(arg);
+                filesAndOptionsRemote.emplace_back(
+                    IPCore::Application::mapToVar(arg));
             }
 
             allFilesAndOptions.push_back(filesAndOptions);
+            allFilesAndOptionsRemote.push_back(filesAndOptionsRemote);
         }
 
         // silences broadcasting events below this constructor
         IPMu::RemoteRvCommand remoteRvCommand(s, "addSourcesVerbose",
-                                              allFilesAndOptions, tag);
+                                              allFilesAndOptionsRemote, tag);
 
         // Now that we've broadcast the remote event, complete the work without
         // broadcasting anything else.


### PR DESCRIPTION

### Summarize your change.

Fixed path swap environment variable not working anymore.

When using RemoteRvCommands, the path swap variable was stripped out and replaced before broadcasting the path values. This fix prevents this from happening.

### Describe the reason for the change.
bug reported by customer

### Describe what you have tested and on which operating system.
trivial fixes

### Add a list of changes, and note any that might need special attention during the review.
trivial fixes

### If possible, provide screenshots.