### PR TITLE
Fix drop region for High-DPI displays (#889)

### DIFF
--- a/src/lib/app/mu_rvui/glyph.mu
+++ b/src/lib/app/mu_rvui/glyph.mu
@@ -528,6 +528,15 @@ operator: & (Glyph; Glyph a, Glyph b)
         bsize = (h - m[2] - m[3]) / descriptors.size(),
         inregion = -1;
 
+    // Take device pixel ratio into account
+    // Note that w and h come from the domain.x and domain.y respectively which
+    // is the resolution in pixels of the viewable area that is already adjusted
+    // for devicePixelRatio, whereas x and y are mouse pointers which are not 
+    // adjusted for devicePixelRatio.
+    x *= devicePixelRatio;
+    y *= devicePixelRatio;
+    margin *= devicePixelRatio;
+
     for_index (i; descriptors)
     {
         gltext.size(20*devicePixelRatio);


### PR DESCRIPTION
### 889: Fix drop region for High-DPI displays

### Linked issues
Fixes #889

### Describe the reason for the change.
Could not add new content sources via drag and drop when a source is already loaded on High-DPI displays

### Summarize your change.
Now taking devicePixelRatio (High-DPI display) into account in drawDropRegions() mu method.

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.