### PR TITLE
SG-40198: Prep work for testing automation of concurrent annotations

### DIFF
--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -1807,7 +1807,8 @@ namespace IPMu
 
     NODE_IMPLEMENTATION(ndc2event, Mu::Vector2f)
     {
-        // Convert from NDC space [-1, 1] to event space coordinates.
+        // Convert from Normalized Device Coordinates (NDC) space [-1, 1] to
+        // event space coordinates.
         // This bypasses image transforms and works purely in viewport space.
         // Height spans 2 NDC units, and assumes the viewport fully contains the
         // height of the image (eg: has vertical bars, no horizontal bars).


### PR DESCRIPTION
### Linked issues

This PR Addresses: SG-40198

### Summarize your change.

This PR addresses 2 issues found in OpenRV to support Multiuser control of annotations.  

First, when running/testing locally, the username is the same and the annotation ID is potentially the same, causing potential prop name conflicts. The prop name has the process id attached, to help differentiate such properties. There used to be a "computer" tag that went unused (a bug) which at the time aimed to do the same thing, but was never implemented properly.

Second, we now support events that draw on the viewport in NDC (normalized display coordinates) space. This allows annotation coords to be specified in a normalized [-1,1] space, which is much easier to use from a plugin (I'll spare the unfortunate details of trying to use absolute "pixel" or "event" coordinates). These functions aren't meant to be used for real live production purposes, they are there mainly for testing automation and scripting simultaneous strokes done in multiple RVs running locally on a single machine, because we don't have 8 hands and 4 mice ;)

Third, again for the purpose of drawing shapes automatically, we allow setting a color, eiher RGB or HSV.  HSV is simpler to use because we can just change the hue and leave the color quite bright and visually distinctive.

### Describe the reason for the change.

Automating the testing and bug fixing of concurrent strokes for live review.

### Describe what you have tested and on which operating system.

Tested multiple clients on macos

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

Not at this stage