### PR TITLE
Changing version to OpenRV 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.27)
 # These variables are parsed by sphinx for the documentation. One-line formatting facilitates parsing and readability.
 # cmake-format: off
 SET(RV_MAJOR_VERSION "3" CACHE STRING "RV's version major")
-SET(RV_MINOR_VERSION "0" CACHE STRING "RV's version minor")
+SET(RV_MINOR_VERSION "1" CACHE STRING "RV's version minor")
 SET(RV_REVISION_NUMBER "0" CACHE STRING "RV's revision number")
 SET(RV_VERSION_YEAR "2025" CACHE STRING "RV's year of release.")
 # cmake-format: on


### PR DESCRIPTION
### Changing version to OpenRV 3.1.0

### Linked issues
n/a

### Summarize your change.
Changing version to OpenRV 3.1.0

### Describe the reason for the change.
OpenRV 3.0.0 has been released.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.