### PR TITLE
Fix Export > Snapshot feature

### DIFF
--- a/src/lib/app/RvApp/CommandsModule.cpp
+++ b/src/lib/app/RvApp/CommandsModule.cpp
@@ -550,11 +550,16 @@ namespace Rv
             d->width() - m.left - m.right, d->height() - m.bottom - m.top, 4,
             TwkFB::FrameBuffer::UCHAR);
 
-        const ImageRenderer::GLFBO* fbo =
-            renderer->newOutputOnlyImageFBO(GL_RGBA8)->fbo();
+        // Get current framebuffer id.
+        GLuint qtDefaultFBO;
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, (GLint*)&qtDefaultFBO);
+
         renderer->render(s->currentFrame(), s->displayImage());
 
         glFinish();
+
+        // Ensure we're reading from Qt's default framebuffer.
+        glBindFramebufferEXT(GL_READ_FRAMEBUFFER_EXT, d->fboID());
 
         glReadPixels(m.left, m.bottom, d->width() - m.left - m.right,
                      d->height() - m.bottom - m.top, GL_RGBA, GL_UNSIGNED_BYTE,
@@ -562,8 +567,8 @@ namespace Rv
 
         glFinish();
 
-        fbo->unbind();
-        renderer->releaseImageFBO(fbo);
+        // Restore original framebuffer.
+        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, qtDefaultFBO);
 
         TwkFB::FrameBufferIO::WriteRequest request;
         TwkFB::FrameBufferIO::ConstFrameBufferVector fbs(1);


### PR DESCRIPTION
### Fix Export > Snapshot feature

### Linked issues
#894 

### Summarize your change.

Fixed OpenGL framebuffer state management in `exportCurrentFrame` by removing unused FBO creation and adding explicit framebuffer binding. The function now properly saves and restores Qt's framebuffer state, and explicitly binds the device's default framebuffer for glReadPixels() to ensure consistent behavior.

### Describe the reason for the change.

The Export > Snapshot menu option was broken with Qt 6.

The original implementation was causing `GL_ERROR: invalid framebuffer operation errors` in GLView.cpp due to improper OpenGL framebuffer state management. The code was creating a custom FBO via renderer->newOutputOnlyImageFBO() but never actually using it for pixel reading. Instead, it read pixels from whatever framebuffer happened to be bound at the time, then called fbo->unbind() on the unused custom FBO.

This was cause issue because the context was bind to the framebuffer id 0, and we cannot use that with QOpenGL* widgets. We have to use the default framebuffer object (which is not 0 with QOpenGL* widgets).

### Describe what you have tested and on which operating system.
MacOS