### PR TITLE
Update macOS build instructions to warn about Xcode 26

### DIFF
--- a/docs/build_system/config_macos.md
+++ b/docs/build_system/config_macos.md
@@ -29,7 +29,11 @@ From macOS System Settings > Privacy & Security > App Management, allow Terminal
 (install_xcode)=
 ## Install Xcode
 
-From the App Store, download Xcode. Make sure that it is the source of the active developer directory.
+**Heads Up:**
+Xcode 26 isn't supported yet because it needs the fix for [QTBUG-137687](https://bugreports.qt.io/browse/QTBUG-137687). This fix is available in Qt 6.5.10, but there isn't a PySide6 version that matches this Qt version as of now.
+In the meantime, you can use Xcode 16.4 on the latest macOS Tahoe 26 to build Open RV.
+
+From the App Store, download Xcode 16.4. Make sure that it is the source of the active developer directory.
 
 `xcode-select -p` should return `/Applications/Xcode.app/Contents/Developer`. If that is not the case, run `sudo xcode-select -s /Applications/Xcode.app`
 


### PR DESCRIPTION
### Update macOS build instructions to warn about Xcode 26

### Linked issues
NA

### Summarize your change.
Specified which version of Xcode can be used to successfully build Open RV on macOS (Xcode 16.4) and which cannot (Xcode 26).

### Describe the reason for the change.
As of now, Open RV cannot be built with latest Xcode 26.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.