### PR TITLE
Fix audio buffering crash

### DIFF
--- a/src/lib/app/mu_rvui/rvui.mu
+++ b/src/lib/app/mu_rvui/rvui.mu
@@ -5575,8 +5575,11 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
 \: audioCacheProgressGlyph (void; bool outline)
 {
     let (_, u, _) = cacheUsage(),
-        total     = (frameEnd() - frameStart()) / fps(),
-        pcent     = u / total;
+        total     = (frameEnd() - frameStart()) / fps();
+
+    if (total <= 0.0) return;
+
+    let pcent = u / total;
     
     glColor(Color(.25, .25, .25, 1));
     drawCircleFan(0, 0, 0.5, pcent, 1, .3, outline);


### PR DESCRIPTION
### Linked issues

[#610](https://github.com/AcademySoftwareFoundation/OpenRV/issues/610)

### Summarize your change.

This update adds a check to audioCacheProgressGlyph() to confirm that the total frames is not less than or equal to 0.

### Describe the reason for the change.

If audio buffering ends prematurely (ex: the EDL data is changed while a source's audio is being actively cached), this can cause audioCacheProgressGlyph to calculate the total frames as less than or equal to 0, which would cause the code to either divide by zero or draw a negative percentage glyph, which causes OpenRV to freeze.  I added a check that the total frames are greater than 0.

### Describe what you have tested and on which operating system.

Successfully tested on Rocky Linux 9.5.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.