### PR TITLE
SG-40579: Add GIF support

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -6495,6 +6495,7 @@ namespace TwkMovie
         // Video
         formats["avi"] = make_pair("Audio Video Interleave", vidcap);
         formats["flv"] = make_pair("Flash Video", vidcap);
+        formats["gif"] = make_pair("Graphics Interchange Format", vidcap);
         formats["m3u8"] = make_pair("M3U8 Stream Metadata", vidcap);
         formats["m4v"] = make_pair("iTunes Video Format (from MPEG-4)", vidcap);
         formats["mkv"] = make_pair("Matroska Video", vidcap);


### PR DESCRIPTION
### Linked issues

### Summarize your change.

Added GIF to the list of supported video formats.

### Describe the reason for the change.

FFmpeg can decode animated gifs, so adding gifs to MovieFFMpegIO::getFormats() was all it took to get OpenRV to play animated gifs like they were movies.

### Describe what you have tested and on which operating system.

Successfully tested on Rocky Linux 9.5

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.