### PR TITLE
added bind to event "clear-annotations-current-frame"

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -2406,7 +2406,9 @@ class: AnnotateMinorMode : MinorMode
               ("stylus-color-hsv", setColorHSV, "Select color HSV"),
               ("ndc-pointer-1--drag", dragNDC, "Add to current stroke in NDC space"),
               ("ndc-pointer-1--push", pushNDC, "Start New Stroke in NDC space"),
-              ("ndc-pointer-1--release", releaseNDC, "End Current Stroke in NDC space")
+              ("ndc-pointer-1--release", releaseNDC, "End Current Stroke in NDC space"),
+              ("clear-annotations-current-frame", clearEvent, "Clear annotations on current frame"),
+              ("clear-annotations-all-frames", clearAllEvent, "Clear annotations on all frames")
               // --------------------------------------------------------------
               //("key-down--control--z", keyUndoEvent, "Undo"),
               //("key-down--control--Z", keyRedoEvent, "Redo"),


### PR DESCRIPTION

### Linked issues

### Summarize your change.

Added two events that can be sent internally, to clear the current frame of annotations.  I want to call this internal event from rv_tests.py, when we auto-draw-annotations (circles).

### Describe the reason for the change.

This is necessary for auto-draw-annotations in rv_test.py, where I'd like to clear the frame every 10 annotations (otherwise, in stress tests, annotations keep acumulating, and the render gets slower and slower and slower and slower.

### Describe what you have tested and on which operating system.

rv_tests.py, which is in Commercial RV. 

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.