### PR TITLE
Lint and format Python code with Ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,16 @@ jobs:
       - name: Build OpenRV main executable
         run: |
           cmake --build _build --config ${{ matrix.build-type }} --target main_executable --parallel=$(python -c 'import os; print(os.cpu_count())') -v
+
+      - name: Lint Python code with ruff
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: check
+          
+      - name: Format Python code with ruff
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: format --check
       
       - name: Tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,12 @@ repos:
     hooks:
       - id: cmake-format
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.2
+    hooks:
+      - id: ruff-check
+      - id: ruff-format
+
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v19.1.4'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,6 @@ repos:
     hooks:
       - id: cmake-format
 
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
-
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v19.1.4'
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,19 +3,19 @@
 # -- Project information
 import re
 
-project = 'Open RV'
-author = 'Open RV contributors'
+project = "Open RV"
+author = "Open RV contributors"
 
-version = '0.0'
-release = '0.0.0'
+version = "0.0"
+release = "0.0.0"
 
 # https://regex101.com/r/Sr8aQX/2
-# This pattern assumes that the SET command follows the typical syntax of a CMake SET command, 
-# with a variable name, a string value enclosed in quotes, and the CACHE STRING clause. 
+# This pattern assumes that the SET command follows the typical syntax of a CMake SET command,
+# with a variable name, a string value enclosed in quotes, and the CACHE STRING clause.
 # It captures the numeric part of the value assigned to these variables.
 pattern = r'SET\(\s*(?:RV_MAJOR_VERSION|RV_MINOR_VERSION|RV_REVISION_NUMBER|RV_VERSION_YEAR)\s*"(\d+)"\s*CACHE\s*STRING\s*"[^"]+"\s*\)'
 # Open the file and read its contents
-with open('../CMakeLists.txt', 'r') as file:
+with open("../CMakeLists.txt", "r") as file:
     text = file.read()
 
 # Find all matches of the pattern in the text
@@ -25,11 +25,11 @@ matches = re.findall(pattern, text)
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 #
 # version
-# The major project version, used as the replacement for |version|. 
+# The major project version, used as the replacement for |version|.
 # For example, for the Python documentation, this may be something like 2.6.
 #
 # release
-# The full project version, used as the replacement for |release| and e.g. in the HTML templates. 
+# The full project version, used as the replacement for |release| and e.g. in the HTML templates.
 # For example, for the Python documentation, this may be something like 2.6.0rc1.
 #
 # If you don’t need the separation provided between version and release, just set them both to the same value.
@@ -41,29 +41,29 @@ copyright = matches[3]
 # -- General configuration
 
 extensions = [
-    'myst_parser',
-    'sphinx_carousel.carousel',
-    'sphinx_copybutton',
-    'sphinx.ext.duration',
-    'sphinx.ext.doctest',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
-    'sphinx_tabs.tabs',
-    'sphinx_rtd_theme'
+    "myst_parser",
+    "sphinx_carousel.carousel",
+    "sphinx_copybutton",
+    "sphinx.ext.duration",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx_tabs.tabs",
+    "sphinx_rtd_theme",
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
-intersphinx_disabled_domains = ['std']
+intersphinx_disabled_domains = ["std"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # -- Options for HTML output
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # -- Options for EPUB output
-epub_show_urls = 'footnote'
+epub_show_urls = "footnote"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+line-length = 120
+target-version = 'py311'
+exclude = [
+    "src/pub/*",
+    "src/plugins/rv-packages/webview2/webview2.py",
+    "src/plugins/rv-packages/source_setup/source_setup.py",
+    "src/plugins/rv-packages/rvnuke/rvNuke.py",
+    "src/plugins/rv-packages/rvnuke/menu.py",
+    "src/plugins/rv-packages/pyside_example/pyside_example.py",
+    "src/plugins/rv-packages/pymystuff/pymystuff.py",
+    "src/plugins/rv-packages/lat_long_viewer/lat_long_viewer.py",
+    "src/plugins/rv-packages/data_display_indicators/data_display_indicator_mode.py",
+    "src/plugins/rv-packages/custom_lut_menu_mode/custom_lut_menu_mode.py",
+    "src/plugins/python/gtoContainer/gtoContainer.py",
+    "src/lib/mu/MuQt6",
+    "src/lib/mu/MuQt5",
+    "src/lib/app/py_rvui/rv_commands_setup.py",
+    "src/lib/app/py_rvui/rv/qtutils.py"
+]

--- a/src/bin/mu/mu-interp/test/ack.py
+++ b/src/bin/mu/mu-interp/test/ack.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-# 
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
-# 
+#
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 import sys
 
 sys.setrecursionlimit(10000)

--- a/src/bin/mu/mu-interp/test/mandelbrot.py
+++ b/src/bin/mu/mu-interp/test/mandelbrot.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python
-# 
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+#
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 # by Daniel Rosengren
 
-import sys, time
+import sys
+import time
 
 stdout = sys.stdout
 

--- a/src/bin/mu/mu-interp/test/rng.py
+++ b/src/bin/mu/mu-interp/test/rng.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-# 
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
 #
-import sys
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 IM = 139968
 IA = 3877
@@ -20,7 +19,6 @@ def gen_random(max):
 
 
 def main(N):
-
     if N < 1:
         N = 1
     gr = gen_random

--- a/src/bin/mu/mu-interp/test/tak.py
+++ b/src/bin/mu/mu-interp/test/tak.py
@@ -1,8 +1,8 @@
 #! /depot/python/arch/bin/python
-# 
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+#
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 # takeuchi benchmark in Python
 # see <url:http://www.lib.uchicago.edu/keith/crisis/benchmarks/tak/>

--- a/src/bin/python/py-interp/tests/__init__.py
+++ b/src/bin/python/py-interp/tests/__init__.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import os
 import unittest
@@ -10,7 +10,5 @@ import unittest
 class TestBaseSetup(unittest.TestCase):
     def test_qt_env_var(self):
         qt_platform = os.environ.get("QT_QPA_PLATFORM")
-        self.assertIsNotNone(
-            qt_platform, "Was expecting the QT_QPA_PLATFORM environment variable"
-        )
+        self.assertIsNotNone(qt_platform, "Was expecting the QT_QPA_PLATFORM environment variable")
         self.assertEqual("minimal", qt_platform)

--- a/src/bin/python/py-interp/tests/test_SSL.py
+++ b/src/bin/python/py-interp/tests/test_SSL.py
@@ -8,6 +8,8 @@
 #
 # *****************************************************************************
 
+import unittest
+
 
 def _fetch(name, func, url):
     try:
@@ -102,14 +104,9 @@ def fetch_all(url, is_valid_url):
         raise AssertionError(f"FAILED: One of the libraries failed to fetch {url}")
 
     elif is_valid_url is False and any(results) is True:
-        raise AssertionError(
-            f"FAILED: One of the libraries failed to raise an error for {url}"
-        )
+        raise AssertionError(f"FAILED: One of the libraries failed to raise an error for {url}")
 
     print(f" - All libraries behaved well on {url}\n")
-
-
-import unittest
 
 
 class TestSSL(unittest.TestCase):

--- a/src/bin/python/py-interp/tests/test_misc_failures.py
+++ b/src/bin/python/py-interp/tests/test_misc_failures.py
@@ -1,19 +1,20 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 """
 Simple tests asserting that our testing setup
 does report failures.
 """
+
 import unittest
 
 
 class TestMiscFailures(unittest.TestCase):
     def test_importing_invalid_package(self):
         with self.assertRaises(ImportError):
-            import non_existing_package
+            import non_existing_package  # noqa: F401
 
     # def test_invalid_syntax(self):
     #    with self.assertRaises(SyntaxError):
@@ -22,7 +23,7 @@ class TestMiscFailures(unittest.TestCase):
 
     def test_calling_non_existing_method(self):
         with self.assertRaises(NameError):
-            pirnt("Hello from Python!")
+            pirnt("Hello from Python!")  # noqa: F821
 
 
 if __name__ == "__main__":

--- a/src/bin/python/py-interp/tests/test_rv_package.py
+++ b/src/bin/python/py-interp/tests/test_rv_package.py
@@ -1,18 +1,19 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 """
-Simple test just asserting that our application 
+Simple test just asserting that our application
 setup is allowing the import of RV's main package.
 """
+
 import unittest
 
 
 class TestRvPackage(unittest.TestCase):
     def test_importing_rv_package(self):
-        import rv
+        import rv  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/src/build/install_all_rvpkg.py
+++ b/src/build/install_all_rvpkg.py
@@ -12,10 +12,7 @@ def get_packages_from_dir(packages_source_folder: pathlib.Path) -> [pathlib.Path
 
 
 def install_rvpkg_packages(
-    *,
-    rvpkg_path: pathlib.Path,
-    packages_source_folder: pathlib.Path,
-    packages_destination_folder: pathlib.Path
+    *, rvpkg_path: pathlib.Path, packages_source_folder: pathlib.Path, packages_destination_folder: pathlib.Path
 ) -> None:
     command = [
         rvpkg_path,
@@ -33,9 +30,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--rvpkg", dest="rvpkg_path", type=pathlib.Path, required=True)
-    parser.add_argument(
-        "--source", dest="packages_source_folder", type=pathlib.Path, required=True
-    )
+    parser.add_argument("--source", dest="packages_source_folder", type=pathlib.Path, required=True)
     parser.add_argument(
         "--destination",
         dest="packages_destination_folder",

--- a/src/build/make_openssl.py
+++ b/src/build/make_openssl.py
@@ -34,9 +34,7 @@ def get_openssl_args(root) -> List[str]:
 
     :return: Path to the openssl binary
     """
-    openssl_bins = glob.glob(
-        os.path.join(root, "**", "bin", "openssl*"), recursive=True
-    )
+    openssl_bins = glob.glob(os.path.join(root, "**", "bin", "openssl*"), recursive=True)
 
     print(openssl_bins)
 
@@ -136,9 +134,7 @@ def test_openssl_distribution() -> None:
         openssl_bin = get_openssl_args(tmp_openssl_dir)
 
         subprocess_env = os.environ.copy()
-        subprocess_env.update(
-            {"LD_LIBRARY_PATH": os.path.join(tmp_openssl_dir, LIB_DIR)}
-        )
+        subprocess_env.update({"LD_LIBRARY_PATH": os.path.join(tmp_openssl_dir, LIB_DIR)})
 
         print(f"Executing {openssl_bin}")
         subprocess.run(
@@ -242,9 +238,7 @@ if __name__ == "__main__":
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
     parser.add_argument("--arch", dest="arch", type=str, required=False, default="")
-    parser.add_argument(
-        "--perlroot", dest="perlroot", type=str, required=False, default=""
-    )
+    parser.add_argument("--perlroot", dest="perlroot", type=str, required=False, default="")
 
     parser.add_argument("--vfx_platform", dest="vfx_platform", type=int, required=True)
 

--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -23,7 +23,6 @@ from utils import (
     download_file,
     extract_7z_archive,
     verify_7z_archive,
-    source_widows_msvc_env,
     update_env_path,
 )
 from make_python import get_python_interpreter_args
@@ -142,12 +141,8 @@ def prepare() -> None:
     print(f"Installing numpy with {install_numpy_args}")
     subprocess.run(install_numpy_args).check_returncode()
 
-    cmakelist_path = os.path.join(
-        SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt"
-    )
-    old_cmakelist_path = os.path.join(
-        SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt.old"
-    )
+    cmakelist_path = os.path.join(SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt")
+    old_cmakelist_path = os.path.join(SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt.old")
     if os.path.exists(old_cmakelist_path):
         os.remove(old_cmakelist_path)
 
@@ -222,15 +217,13 @@ def build() -> None:
     # We force Visual Studio 2017 here to make it build without errors.
     if platform.system() == "Windows":
         # Add Qt jom to the path to build in parallel
-        jom_path = os.path.abspath(
-            os.path.join(QT_OUTPUT_DIR, "..", "..", "Tools", "QtCreator", "bin", "jom")
-        )
+        jom_path = os.path.abspath(os.path.join(QT_OUTPUT_DIR, "..", "..", "Tools", "QtCreator", "bin", "jom"))
         if os.path.exists(os.path.join(jom_path, "jom.exe")):
             print(f"jom.exe was successfully located at: {jom_path}")
             update_env_path([jom_path])
         else:
             print(f"Could not find jom.exe at the expected location: {jom_path}")
-            print(f"Build performance might be impacted")
+            print("Build performance might be impacted")
 
         # Add the debug switch to match build type but only on Windows
         # (on other platforms, PySide2 is built in release)
@@ -270,9 +263,7 @@ def build() -> None:
     subprocess.run(generator_cleanup_args).check_returncode()
 
     if OPENSSL_OUTPUT_DIR and platform.system() == "Windows":
-        pyside_folder = glob.glob(
-            os.path.join(python_home, "**", "site-packages", "PySide2"), recursive=True
-        )[0]
+        pyside_folder = glob.glob(os.path.join(python_home, "**", "site-packages", "PySide2"), recursive=True)[0]
         openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "bin", "lib*"))
 
         for lib in openssl_libs:
@@ -292,14 +283,11 @@ if __name__ == "__main__":
     parser.add_argument("--source-dir", dest="source", type=pathlib.Path, required=True)
     parser.add_argument("--python-dir", dest="python", type=pathlib.Path, required=True)
     parser.add_argument("--qt-dir", dest="qt", type=pathlib.Path, required=True)
-    parser.add_argument(
-        "--openssl-dir", dest="openssl", type=pathlib.Path, required=False
-    )
+    parser.add_argument("--openssl-dir", dest="openssl", type=pathlib.Path, required=False)
     parser.add_argument("--temp-dir", dest="temp", type=pathlib.Path, required=True)
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
     parser.add_argument("--variant", dest="variant", type=str, required=True)
-
 
     # Major and minor version with dots.
     parser.add_argument("--python-version", dest="python_version", type=str, required=True, default="")
@@ -316,7 +304,7 @@ if __name__ == "__main__":
     QT_OUTPUT_DIR = args.qt
     VARIANT = args.variant
     PYTHON_VERSION = args.python_version
-    
+
     print(args)
 
     if args.prepare:

--- a/src/build/make_pyside6.py
+++ b/src/build/make_pyside6.py
@@ -23,8 +23,6 @@ from utils import (
     download_file,
     extract_7z_archive,
     verify_7z_archive,
-    source_widows_msvc_env,
-    update_env_path,
 )
 from make_python import get_python_interpreter_args
 
@@ -90,7 +88,7 @@ def prepare() -> None:
             version_search = re.search(r"version (\d+)\.(\d+)\.(\d+)", version_output)
             if version_search:
                 return version_search.groups()
-            print(f"ERROR: Could not extract clang --version")
+            print("ERROR: Could not extract clang --version")
             return None
 
         def get_clang_filename_suffix(version):
@@ -110,9 +108,7 @@ def prepare() -> None:
         clang_version = get_clang_version()
         if clang_version:
             clang_filename_suffix = get_clang_filename_suffix(clang_version)
-            fallback_clang_filename_suffix = get_fallback_clang_filename_suffix(
-                clang_version
-            )
+            fallback_clang_filename_suffix = get_fallback_clang_filename_suffix(clang_version)
 
     elif system == "Linux":
         clang_filename_suffix = "19.1.0-based-linux-Rhel8.8-gcc10.3-x86_64.7z"
@@ -132,17 +128,11 @@ def prepare() -> None:
         download_ok = download_file(download_url, libclang_zip)
         if not download_ok and fallback_clang_filename_suffix:
             fallback_download_url = LIBCLANG_URL_BASE + fallback_clang_filename_suffix
-            print(
-                f"WARNING: Could not download or version does not exist: {download_url}"
-            )
-            print(
-                f"WARNING: Attempting to fallback on known version: {fallback_download_url}..."
-            )
+            print(f"WARNING: Could not download or version does not exist: {download_url}")
+            print(f"WARNING: Attempting to fallback on known version: {fallback_download_url}...")
             download_ok = download_file(fallback_download_url, libclang_zip)
         if not download_ok:
-            print(
-                f"ERROR: Could not download or version does not exist: {download_url}"
-            )
+            print(f"ERROR: Could not download or version does not exist: {download_url}")
 
     # clean up previous failed extraction
     libclang_tmp = os.path.join(TEMP_DIR, "libclang-tmp")
@@ -179,12 +169,8 @@ def prepare() -> None:
     print(f"Installing numpy with {install_numpy_args}")
     subprocess.run(install_numpy_args).check_returncode()
 
-    cmakelist_path = os.path.join(
-        SOURCE_DIR, "sources", "shiboken6", "ApiExtractor", "CMakeLists.txt"
-    )
-    old_cmakelist_path = os.path.join(
-        SOURCE_DIR, "sources", "shiboken6", "ApiExtractor", "CMakeLists.txt.old"
-    )
+    cmakelist_path = os.path.join(SOURCE_DIR, "sources", "shiboken6", "ApiExtractor", "CMakeLists.txt")
+    old_cmakelist_path = os.path.join(SOURCE_DIR, "sources", "shiboken6", "ApiExtractor", "CMakeLists.txt.old")
     if os.path.exists(old_cmakelist_path):
         os.remove(old_cmakelist_path)
 
@@ -295,9 +281,7 @@ def build() -> None:
     subprocess.run(generator_cleanup_args).check_returncode()
 
     if OPENSSL_OUTPUT_DIR and platform.system() == "Windows":
-        pyside_folder = glob.glob(
-            os.path.join(python_home, "**", "site-packages", "PySide6"), recursive=True
-        )[0]
+        pyside_folder = glob.glob(os.path.join(python_home, "**", "site-packages", "PySide6"), recursive=True)[0]
         openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "bin", "lib*"))
 
         for lib in openssl_libs:
@@ -317,18 +301,14 @@ if __name__ == "__main__":
     parser.add_argument("--source-dir", dest="source", type=pathlib.Path, required=True)
     parser.add_argument("--python-dir", dest="python", type=pathlib.Path, required=True)
     parser.add_argument("--qt-dir", dest="qt", type=pathlib.Path, required=True)
-    parser.add_argument(
-        "--openssl-dir", dest="openssl", type=pathlib.Path, required=False
-    )
+    parser.add_argument("--openssl-dir", dest="openssl", type=pathlib.Path, required=False)
     parser.add_argument("--temp-dir", dest="temp", type=pathlib.Path, required=True)
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
     parser.add_argument("--variant", dest="variant", type=str, required=True)
 
     # Major and minor version with dots.
-    parser.add_argument(
-        "--python-version", dest="python_version", type=str, required=True, default=""
-    )
+    parser.add_argument("--python-version", dest="python_version", type=str, required=True, default="")
 
     parser.set_defaults(prepare=False, build=False)
 

--- a/src/build/make_python.py
+++ b/src/build/make_python.py
@@ -112,7 +112,7 @@ except Exception as e:
 '''
 
 
-def get_python_interpreter_args(python_home: str, variant : str) -> List[str]:
+def get_python_interpreter_args(python_home: str, variant: str) -> List[str]:
     """
     Return the path to the python interpreter given a Python home
 
@@ -123,25 +123,19 @@ def get_python_interpreter_args(python_home: str, variant : str) -> List[str]:
     build_opentimelineio = platform.system() == "Windows" and variant == "Debug"
     python_name_pattern = "python*" if not build_opentimelineio else "python_d*"
 
-    python_interpreters = glob.glob(
-        os.path.join(python_home, python_name_pattern), recursive=True
-    )
-    python_interpreters += glob.glob(
-        os.path.join(python_home, "bin", python_name_pattern)
-    )
+    python_interpreters = glob.glob(os.path.join(python_home, python_name_pattern), recursive=True)
+    python_interpreters += glob.glob(os.path.join(python_home, "bin", python_name_pattern))
 
     # sort put python# before python#-config, prioritize debug on Windows debug builds
     python_interpreters = sorted(
-        [
-            p
-            for p in python_interpreters
-            if os.path.islink(p) is False and os.access(p, os.X_OK)
-        ],
+        [p for p in python_interpreters if os.path.islink(p) is False and os.access(p, os.X_OK)],
         key=lambda p: (
             "-config" in os.path.basename(p),  # config variants last
-            not ("_d" in os.path.basename(p) and platform.system() == "Windows" and variant.lower() == "debug"),  # prioritize _d on Windows debug
-            os.path.basename(p)  # alphabetical
-        )
+            not (
+                "_d" in os.path.basename(p) and platform.system() == "Windows" and variant.lower() == "debug"
+            ),  # prioritize _d on Windows debug
+            os.path.basename(p),  # alphabetical
+        ),
     )
 
     if not python_interpreters or os.path.exists(python_interpreters[0]) is False:
@@ -162,9 +156,7 @@ def patch_python_distribution(python_home: str) -> None:
     :param python_home: Home of the Python to patch.
     """
 
-    for failed_lib in glob.glob(
-        os.path.join(python_home, "lib", "**", "*_failed.so"), recursive=True
-    ):
+    for failed_lib in glob.glob(os.path.join(python_home, "lib", "**", "*_failed.so"), recursive=True):
         # The Python build mark some so as _failed if it cannot load OpenSSL. In our case it's expected because
         # out OpenSSL package works with RPATH and the RPATH is not set on the python build tests. If the lib failed
         # for other reasons, it will fail later in our build script.
@@ -173,10 +165,8 @@ def patch_python_distribution(python_home: str) -> None:
             shutil.move(failed_lib, failed_lib.replace("_failed.so", ".so"))
     if OPENSSL_OUTPUT_DIR:
         if platform.system() == "Darwin":
-            openssl_libs = glob.glob(
-                os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.dylib*")
-            )
-            openssl_libs = [l for l in openssl_libs if os.path.islink(l) is False]
+            openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.dylib*"))
+            openssl_libs = [lib for lib in openssl_libs if os.path.islink(lib) is False]
 
             python_openssl_libs = []
 
@@ -186,9 +176,7 @@ def patch_python_distribution(python_home: str) -> None:
                 shutil.copyfile(lib_path, dest)
                 python_openssl_libs.append(dest)
 
-            libs_to_patch = glob.glob(
-                os.path.join(python_home, "lib", "**", "*.so"), recursive=True
-            )
+            libs_to_patch = glob.glob(os.path.join(python_home, "lib", "**", "*.so"), recursive=True)
 
             for lib_path in python_openssl_libs:
                 lib_name = os.path.basename(lib_path)
@@ -207,9 +195,7 @@ def patch_python_distribution(python_home: str) -> None:
                     subprocess.run(install_name_tool_change_args).check_returncode()
 
         elif platform.system() == "Linux":
-            openssl_libs = glob.glob(
-                os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR, "lib*.so*")
-            )
+            openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR, "lib*.so*"))
 
             for lib_path in openssl_libs:
                 print(f"Copying {lib_path} to the python home")
@@ -256,9 +242,7 @@ def patch_python_distribution(python_home: str) -> None:
     print(f"Installing wheel with {wheel_install_args}")
     subprocess.run(wheel_install_args).check_returncode()
 
-    site_packages = glob.glob(
-        os.path.join(python_home, "**", "site-packages"), recursive=True
-    )[0]
+    site_packages = glob.glob(os.path.join(python_home, "**", "site-packages"), recursive=True)[0]
 
     if os.path.exists(site_packages) is False:
         raise FileNotFoundError()
@@ -272,9 +256,7 @@ def patch_python_distribution(python_home: str) -> None:
     print(f"Installing the sitecustomize.py payload at {site_customize_path}")
     site_customize_path = os.path.join(site_packages, "sitecustomize.py")
     if os.path.exists(site_customize_path):
-        print(
-            "Found a sitecustomize.py in the site-packages, the content of the file will be overwritten"
-        )
+        print("Found a sitecustomize.py in the site-packages, the content of the file will be overwritten")
         os.remove(site_customize_path)
 
     with open(site_customize_path, "w") as sitecustomize_file:
@@ -302,7 +284,7 @@ def test_python_distribution(python_home: str) -> None:
         #       python while RV uses the debug version.
         build_opentimelineio = platform.system() == "Windows" and VARIANT == "Debug"
         if build_opentimelineio:
-            print(f"Building opentimelineio")
+            print("Building opentimelineio")
 
             # Request an opentimelineio debug build
             my_env = os.environ.copy()
@@ -310,12 +292,8 @@ def test_python_distribution(python_home: str) -> None:
 
             # Specify the location of the debug python import lib (eg. python39_d.lib)
             python_include_dirs = os.path.join(tmp_python_home, "include")
-            python_lib = os.path.join(
-                tmp_python_home, "libs", f"python{PYTHON_VERSION}_d.lib"
-            )
-            my_env["CMAKE_ARGS"] = (
-                f"-DPython_LIBRARY={python_lib} -DCMAKE_INCLUDE_PATH={python_include_dirs}"
-            )
+            python_lib = os.path.join(tmp_python_home, "libs", f"python{PYTHON_VERSION}_d.lib")
+            my_env["CMAKE_ARGS"] = f"-DPython_LIBRARY={python_lib} -DCMAKE_INCLUDE_PATH={python_include_dirs}"
 
             opentimelineio_install_arg = python_interpreter_args + [
                 "-m",
@@ -324,7 +302,7 @@ def test_python_distribution(python_home: str) -> None:
                 ".",
             ]
 
-            result = subprocess.run(
+            subprocess.run(
                 opentimelineio_install_arg,
                 env=my_env,
                 cwd=OPENTIMELINEIO_SOURCE_DIR,
@@ -334,16 +312,12 @@ def test_python_distribution(python_home: str) -> None:
             # Example: _opentimed_d.cp39-win_amd64.pyd instead of _opentime_d.pyd
             # and _otiod_d.cp39-win_amd64.pyd instead of _otio_d.pyd
             # We fix those names here
-            otio_module_dir = os.path.join(
-                tmp_python_home, "lib", "site-packages", "opentimelineio"
-            )
+            otio_module_dir = os.path.join(tmp_python_home, "lib", "site-packages", "opentimelineio")
             for _file in os.listdir(otio_module_dir):
                 if _file.endswith("pyd"):
                     otio_lib_name_split = os.path.basename(_file).split(".")
                     if len(otio_lib_name_split) > 2:
-                        new_otio_lib_name = (
-                            otio_lib_name_split[0].replace("d_d", "_d") + ".pyd"
-                        )
+                        new_otio_lib_name = otio_lib_name_split[0].replace("d_d", "_d") + ".pyd"
                         src_file = os.path.join(otio_module_dir, _file)
                         dst_file = os.path.join(otio_module_dir, new_otio_lib_name)
                         shutil.copyfile(src_file, dst_file)
@@ -400,9 +374,7 @@ def test_python_distribution(python_home: str) -> None:
             ),
         ]
         print(f"Validating the python package with {python_validation2_args}")
-        subprocess.run(
-            python_validation2_args, env={**os.environ, "SSL_CERT_FILE": dummy_ssl_file}
-        ).check_returncode()
+        subprocess.run(python_validation2_args, env={**os.environ, "SSL_CERT_FILE": dummy_ssl_file}).check_returncode()
 
         python_validation3_args = python_interpreter_args + [
             "-c",
@@ -471,9 +443,7 @@ def configure() -> None:
 
             if platform.system() == "Linux":
                 # This option prevent Python to build the _ssl module correctly on Darwin.
-                configure_args.append(
-                    f"--with-openssl-rpath={OPENSSL_OUTPUT_DIR}/{LIB_DIR}"
-                )
+                configure_args.append(f"--with-openssl-rpath={OPENSSL_OUTPUT_DIR}/{LIB_DIR}")
 
         if VARIANT == "Release":
             configure_args.append("--enable-optimizations")
@@ -483,62 +453,32 @@ def configure() -> None:
         PKG_CONFIG_PATH = []
 
         if platform.system() == "Darwin":
-            readline_prefix_proc = subprocess.run(
-                ["brew", "--prefix", "readline"], capture_output=True
-            )
+            readline_prefix_proc = subprocess.run(["brew", "--prefix", "readline"], capture_output=True)
             readline_prefix_proc.check_returncode()
 
-            tcl_prefix_proc = subprocess.run(
-                ["brew", "--prefix", "tcl-tk@8"], capture_output=True
-            )
+            tcl_prefix_proc = subprocess.run(["brew", "--prefix", "tcl-tk@8"], capture_output=True)
             tcl_prefix_proc.check_returncode()
 
-            python_tk_prefix_proc = subprocess.run(
-                ["brew", "--prefix", "python-tk"], capture_output=True
-            )
+            python_tk_prefix_proc = subprocess.run(["brew", "--prefix", "python-tk"], capture_output=True)
             python_tk_prefix_proc.check_returncode()
 
-            xz_prefix_proc = subprocess.run(
-                ["brew", "--prefix", "xz"], capture_output=True
-            )
+            xz_prefix_proc = subprocess.run(["brew", "--prefix", "xz"], capture_output=True)
             xz_prefix_proc.check_returncode()
 
-            sdk_prefix_proc = subprocess.run(
-                ["xcrun", "--show-sdk-path"], capture_output=True
-            )
+            sdk_prefix_proc = subprocess.run(["xcrun", "--show-sdk-path"], capture_output=True)
             sdk_prefix_proc.check_returncode()
 
-            readline_prefix = (
-                pathlib.Path(readline_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
-            tcl_prefix = (
-                pathlib.Path(tcl_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
-            xz_prefix = (
-                pathlib.Path(xz_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
-            sdk_prefix = (
-                pathlib.Path(sdk_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
-            python_tk_prefix = (
-                pathlib.Path(python_tk_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
+            readline_prefix = pathlib.Path(readline_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
+            tcl_prefix = pathlib.Path(tcl_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
+            xz_prefix = pathlib.Path(xz_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
+            sdk_prefix = pathlib.Path(sdk_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
+            python_tk_prefix = pathlib.Path(python_tk_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
 
-            CPPFLAGS.append(f'-I{os.path.join(readline_prefix, "include")}')
-            CPPFLAGS.append(f'-I{os.path.join(tcl_prefix, "include")}')
-            CPPFLAGS.append(f'-I{os.path.join(xz_prefix, "include")}')
-            CPPFLAGS.append(f'-I{os.path.join(sdk_prefix, "usr", "include")}')
-            CPPFLAGS.append(f'-I{os.path.join(python_tk_prefix, "include")}')
+            CPPFLAGS.append(f"-I{os.path.join(readline_prefix, 'include')}")
+            CPPFLAGS.append(f"-I{os.path.join(tcl_prefix, 'include')}")
+            CPPFLAGS.append(f"-I{os.path.join(xz_prefix, 'include')}")
+            CPPFLAGS.append(f"-I{os.path.join(sdk_prefix, 'usr', 'include')}")
+            CPPFLAGS.append(f"-I{os.path.join(python_tk_prefix, 'include')}")
 
             LD_LIBRARY_PATH.append(os.path.join(readline_prefix, "lib"))
             LD_LIBRARY_PATH.append(os.path.join(tcl_prefix, "lib"))
@@ -552,14 +492,10 @@ def configure() -> None:
 
         if OPENSSL_OUTPUT_DIR:
             if platform.system() == "Darwin":
-                configure_args.append(
-                    f"LC_RPATH={os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR)}"
-                )
-                configure_args.append(f'LDFLAGS={" ".join(LDFLAGS)}')
-                configure_args.append(f'CPPFLAGS={" ".join(CPPFLAGS)}')
-                configure_args.append(
-                    f"DYLD_LIBRARY_PATH={os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR)}"
-                )
+                configure_args.append(f"LC_RPATH={os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR)}")
+                configure_args.append(f"LDFLAGS={' '.join(LDFLAGS)}")
+                configure_args.append(f"CPPFLAGS={' '.join(CPPFLAGS)}")
+                configure_args.append(f"DYLD_LIBRARY_PATH={os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR)}")
             else:
                 # Linux (NOT Windows was checked before)
                 configure_args.append(f"LDFLAGS=-L{OPENSSL_OUTPUT_DIR}/{LIB_DIR}")
@@ -571,9 +507,7 @@ def configure() -> None:
 
         print(f"Executing {configure_args} from {SOURCE_DIR}")
 
-        subprocess.run(
-            configure_args, cwd=SOURCE_DIR, env=subprocess_env
-        ).check_returncode()
+        subprocess.run(configure_args, cwd=SOURCE_DIR, env=subprocess_env).check_returncode()
 
         makefile_path = os.path.join(SOURCE_DIR, "Makefile")
         old_makefile_path = os.path.join(SOURCE_DIR, "Makefile.old")
@@ -590,9 +524,7 @@ def configure() -> None:
                     if new_line.startswith("LINKFORSHARED="):
                         if platform.system() == "Linux":
                             makefile.write(
-                                new_line.strip()
-                                + " -Wl,-rpath,'$$ORIGIN/../lib',-rpath,'$$ORIGIN/../Qt'"
-                                + "\n"
+                                new_line.strip() + " -Wl,-rpath,'$$ORIGIN/../lib',-rpath,'$$ORIGIN/../Qt'" + "\n"
                             )
                         elif platform.system() == "Darwin":
                             makefile.write(
@@ -610,7 +542,6 @@ def build() -> None:
     """
 
     if platform.system() == "Windows":
-
         build_args = [
             os.path.join(SOURCE_DIR, "PCBuild", "build.bat"),
             "-p",
@@ -682,9 +613,7 @@ def install_python_vfx2023() -> None:
         # libs - required by pyside2
         dst_dir = os.path.join(OUTPUT_DIR, "libs")
         os.mkdir(dst_dir)
-        python_libs = glob.glob(
-            os.path.join(SOURCE_DIR, "PCBuild", "amd64", "python*.lib")
-        )
+        python_libs = glob.glob(os.path.join(SOURCE_DIR, "PCBuild", "amd64", "python*.lib"))
         if python_libs:
             for python_lib in python_libs:
                 shutil.copy(python_lib, dst_dir)
@@ -723,6 +652,7 @@ def install_python_vfx2023() -> None:
 
     patch_python_distribution(OUTPUT_DIR)
     test_python_distribution(OUTPUT_DIR)
+
 
 def install_python_vfx2024() -> None:
     """
@@ -769,10 +699,7 @@ def install_python_vfx2024() -> None:
 
         print(f"Executing {install_args}")
 
-        subprocess.run(
-            install_args,
-            cwd=SOURCE_DIR
-        ).check_returncode()
+        subprocess.run(install_args, cwd=SOURCE_DIR).check_returncode()
 
         # bin
         libs_dir = os.path.join(OUTPUT_DIR, "libs")
@@ -793,7 +720,7 @@ def install_python_vfx2024() -> None:
 
         # Move files under root directory into the bin folder.
         for filename in os.listdir(os.path.join(OUTPUT_DIR)):
-            file_path = os.path.join(OUTPUT_DIR, filename)  
+            file_path = os.path.join(OUTPUT_DIR, filename)
             if os.path.isfile(file_path):
                 shutil.move(file_path, os.path.join(dst_dir, filename))
 
@@ -840,6 +767,7 @@ def install_python_vfx2024() -> None:
     patch_python_distribution(OUTPUT_DIR)
     test_python_distribution(OUTPUT_DIR)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
@@ -849,9 +777,7 @@ if __name__ == "__main__":
     parser.add_argument("--install", dest="install", action="store_true")
 
     parser.add_argument("--source-dir", dest="source", type=pathlib.Path, required=True)
-    parser.add_argument(
-        "--openssl-dir", dest="openssl", type=pathlib.Path, required=False
-    )
+    parser.add_argument("--openssl-dir", dest="openssl", type=pathlib.Path, required=False)
     parser.add_argument("--temp-dir", dest="temp", type=pathlib.Path, required=True)
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
@@ -914,7 +840,7 @@ if __name__ == "__main__":
         build()
 
     if args.install:
-        # The install functions has a lot of similiarity but I think it is better to have two differents 
+        # The install functions has a lot of similiarity but I think it is better to have two differents
         # functions because it will be easier to drop the support for a VFX platform.
         if VFX_PLATFORM == 2023:
             install_python_vfx2023()

--- a/src/build/patch_OCIO/ocio_pyopencolorio_patch.py
+++ b/src/build/patch_OCIO/ocio_pyopencolorio_patch.py
@@ -1,4 +1,7 @@
-import argparse, shutil, pathlib, re, sys
+import argparse
+import shutil
+import pathlib
+import re
 
 
 def patch_execute(filename):

--- a/src/build/patch_PySide2/windows_desktop.py
+++ b/src/build/patch_PySide2/windows_desktop.py
@@ -20,9 +20,7 @@ def prepare_packages_win32(self, vars):
     # For now, debug symbols will not be shipped into the package.
     copy_pdbs = False
     pdbs = []
-    if (
-        self.debug or OPTION["DEBUG"] or self.build_type == "RelWithDebInfo"
-    ) and copy_pdbs:
+    if (self.debug or OPTION["DEBUG"] or self.build_type == "RelWithDebInfo") and copy_pdbs:
         pdbs = ["*.pdb"]
 
     # <install>/lib/site-packages/{st_package_name}/* ->
@@ -115,10 +113,7 @@ def prepare_packages_win32(self, vars):
             vars=vars,
         )
 
-    if (
-        config.is_internal_shiboken_generator_build()
-        or config.is_internal_pyside_build()
-    ):
+    if config.is_internal_shiboken_generator_build() or config.is_internal_pyside_build():
         # <install>/include/* -> <setup>/{st_package_name}/include
         copydir(
             "{install_dir}/include/{cmake_package_name}",
@@ -224,14 +219,10 @@ def prepare_packages_win32(self, vars):
             # Re-generate examples Qt resource files for Python 3
             # compatibility
             if sys.version_info[0] == 3:
-                examples_path = "{st_build_dir}/{st_package_name}/examples".format(
-                    **vars
-                )
+                examples_path = "{st_build_dir}/{st_package_name}/examples".format(**vars)
                 pyside_rcc_path = "{install_dir}/bin/rcc.exe".format(**vars)
                 pyside_rcc_options = ["-g", "python"]
-                regenerate_qt_resources(
-                    examples_path, pyside_rcc_path, pyside_rcc_options
-                )
+                regenerate_qt_resources(examples_path, pyside_rcc_path, pyside_rcc_options)
 
         if vars["ssl_libs_dir"]:
             # <ssl_libs>/* -> <setup>/{st_package_name}/openssl
@@ -248,10 +239,7 @@ def prepare_packages_win32(self, vars):
         # shiboken module, because libshiboken uses C++ code.
         copy_msvc_redist_files(vars, "{build_dir}/msvc_redist".format(**vars))
 
-    if (
-        config.is_internal_pyside_build()
-        or config.is_internal_shiboken_generator_build()
-    ):
+    if config.is_internal_pyside_build() or config.is_internal_shiboken_generator_build():
         copy_qt_artifacts(self, copy_pdbs, vars)
         copy_msvc_redist_files(vars, "{build_dir}/msvc_redist".format(**vars))
 
@@ -418,9 +406,7 @@ def copy_qt_artifacts(self, copy_pdbs, vars):
                 return os.path.exists(path)
 
         # e.g. "/home/work/qt/qtbase/bin/Qt5Coredd.dll"
-        other_config_path = os.path.join(
-            file_path_dir_name, maybe_debug_name + file_ext
-        )
+        other_config_path = os.path.join(file_path_dir_name, maybe_debug_name + file_ext)
 
         if filter_match(file_name, filter) and predicate(other_config_path):
             return True
@@ -441,9 +427,7 @@ def copy_qt_artifacts(self, copy_pdbs, vars):
         pdb_pattern = "*{}.pdb"
         if copy_pdbs:
             plugin_dll_patterns += [pdb_pattern]
-        plugin_dll_filter = functools.partial(
-            qt_build_config_filter, plugin_dll_patterns
-        )
+        plugin_dll_filter = functools.partial(qt_build_config_filter, plugin_dll_patterns)
         copydir(
             "{qt_plugins_dir}",
             "{st_build_dir}/{st_package_name}/plugins",
@@ -500,9 +484,7 @@ def copy_qt_artifacts(self, copy_pdbs, vars):
             vars=vars,
         )
 
-        filter = "QtWebEngineProcess{}.exe".format(
-            "d" if (self.debug or OPTION["DEBUG"]) else ""
-        )
+        filter = "QtWebEngineProcess{}.exe".format("d" if (self.debug or OPTION["DEBUG"]) else "")
         copydir(
             "{qt_bin_dir}",
             "{st_build_dir}/{st_package_name}",

--- a/src/build/quoteFile.py
+++ b/src/build/quoteFile.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2001, Tweak Films
 # Copyright (c) 2008, Tweak Software
 #
-# SPDX-License-Identifier: Apache-2.0 
+# SPDX-License-Identifier: Apache-2.0
 #
 # Quote a text file in C++ form for inclusion into a C++ source file
 #
 import sys
-import string
 
 index = 1
 varlist = []
@@ -36,10 +35,10 @@ outfile.write("//\n")
 outfile.write("const char* " + cppname + " = ")
 
 for line in lines:
-    l = line.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    line = line.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
     for subst in varlist:
-        l = l.replace(subst[0], subst[1])
-    outfile.write('"' + l + '"\n')
+        line = line.replace(subst[0], subst[1])
+    outfile.write('"' + line + '"\n')
 
 outfile.write(";\n")
 outfile.close()

--- a/src/build/utils.py
+++ b/src/build/utils.py
@@ -261,11 +261,7 @@ def get_cygpath_windows(cygpath: str) -> str:
     Returns the windows path corresponding to the cygpath passed as parameter.
     :param string cygpath: cygpath to be translated. Example: C:/git/OpenRV/_build
     """
-    return (
-        subprocess.check_output(["cygpath", "--windows", "--absolute", f"{cygpath}"])
-        .rstrip()
-        .decode("utf-8")
-    )
+    return subprocess.check_output(["cygpath", "--windows", "--absolute", f"{cygpath}"]).rstrip().decode("utf-8")
 
 
 def update_env_path(newpaths: str) -> None:
@@ -274,7 +270,7 @@ def update_env_path(newpaths: str) -> None:
     """
     paths = os.environ["PATH"].lower().split(os.pathsep)
     for path in newpaths:
-        if not path.lower() in paths:
+        if path.lower() not in paths:
             paths.insert(0, path)
             os.environ["PATH"] = "{}{}{}".format(path, os.pathsep, os.environ["PATH"])
 
@@ -303,7 +299,7 @@ def source_widows_msvc_env(msvc_year: str) -> None:
                 if not (len(ob) == 2):
                     print("Unexpected result: {}".format(ob))
                     raise ValueError
-            except:
+            except Exception:
                 return False
             return True
 
@@ -330,10 +326,10 @@ def source_widows_msvc_env(msvc_year: str) -> None:
             # make sure the lines are strings
             lines = map(lambda s: s.decode(), lines)
         # consume whatever output occurs until the tag is reached
-        consume(itertools.takewhile(lambda l: tag not in l, lines))
+        consume(itertools.takewhile(lambda line: tag not in line, lines))
         # define a way to handle each KEY=VALUE line
         # parse key/values into pairs
-        pairs = map(lambda l: l.rstrip().split("=", 1), lines)
+        pairs = map(lambda line: line.rstrip().split("=", 1), lines)
         # make sure the pairs are valid
         valid_pairs = filter(validate_pair, pairs)
         # construct a dictionary of the pairs
@@ -378,24 +374,16 @@ def source_widows_msvc_env(msvc_year: str) -> None:
             )
 
     if not os.path.exists(vcvars_path):
-        print(
-            "ERROR: Failed to find the MSVC compiler environment init script (vcvars64.bat) on your system."
-        )
+        print("ERROR: Failed to find the MSVC compiler environment init script (vcvars64.bat) on your system.")
         return
     else:
-        print(
-            f"Found MSVC compiler environment init script (vcvars64.bat):\n{vcvars_path}"
-        )
+        print(f"Found MSVC compiler environment init script (vcvars64.bat):\n{vcvars_path}")
 
     # Get MSVC env
     vcvars_cmd = [vcvars_path]
     msvc_env = get_environment_from_batch_command(vcvars_cmd)
-    msvc_env_paths = os.pathsep.join(
-        [msvc_env[k] for k in msvc_env if k.upper() == "PATH"]
-    ).split(os.pathsep)
-    msvc_env_without_paths = dict(
-        [(k, msvc_env[k]) for k in msvc_env if k.upper() != "PATH"]
-    )
+    msvc_env_paths = os.pathsep.join([msvc_env[k] for k in msvc_env if k.upper() == "PATH"]).split(os.pathsep)
+    msvc_env_without_paths = dict([(k, msvc_env[k]) for k in msvc_env if k.upper() != "PATH"])
 
     # Extend os.environ with MSVC env
     update_env_path(msvc_env_paths)
@@ -414,16 +402,13 @@ def get_mingw64_path_on_windows(winpath: str) -> str:
         return winpath
 
     return (
-        subprocess.check_output(
-            ["c:\\msys64\\usr\\bin\\cygpath.exe", "--mixed", "--absolute", f"{winpath}"]
-        )
+        subprocess.check_output(["c:\\msys64\\usr\\bin\\cygpath.exe", "--mixed", "--absolute", f"{winpath}"])
         .rstrip()
         .decode("utf-8")
     )
 
 
 def get_mingw64_args(cmd_args: List[str]) -> List[str]:
-
     updated_cmd_args = cmd_args
     updated_cmd_args.append(";sleep 10")
 

--- a/src/lib/app/RvCommon/generate_theme.py
+++ b/src/lib/app/RvCommon/generate_theme.py
@@ -26,10 +26,10 @@ Features:
 Usage Examples:
     # Use config file (auto-detects platform template)
     python generate_theme.py --config rv_theme_variables.conf --output rv_dark.qss
-    
+
     # Override variables from command line (will prompt for missing ones)
     python generate_theme.py --config rv_theme_variables.conf --output rv_blue.qss --set ACCENT_PRIMARY=rgb(0,100,200) --set ACCENT_SECONDARY=rgb(50,150,255)
-    
+
     # No config file (will prompt for all required variables)
     python generate_theme.py --output rv_custom.qss --set PRIMARY_BACKGROUND=rgb(40,40,40)
 """
@@ -61,11 +61,7 @@ def get_platform_template() -> str:
     """Get the appropriate template file for the current platform"""
     system = platform.system().lower()
     # Windows and Linux both use the Linux template, only macOS uses the macOS template
-    template_name = (
-        "rv_mac_dark.qss.template"
-        if system == "darwin"
-        else "rv_linux_dark.qss.template"
-    )
+    template_name = "rv_mac_dark.qss.template" if system == "darwin" else "rv_linux_dark.qss.template"
 
     # Check if we're being run from OpenRV root directory
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -96,9 +92,7 @@ def adjust_output_path(output_file: str) -> str:
         if os.path.exists(rvcommon_path):
             # Only adjust if output path is just a filename (no directory)
             if not os.path.dirname(output_file):
-                adjusted_path = os.path.join(
-                    "src", "lib", "app", "RvCommon", output_file
-                )
+                adjusted_path = os.path.join("src", "lib", "app", "RvCommon", output_file)
                 logger.info(f"Placing output in RvCommon directory: {adjusted_path}")
                 return adjusted_path
 
@@ -121,14 +115,10 @@ def adjust_config_path(config_file: Optional[str]) -> Optional[str]:
         if os.path.exists(rvcommon_path):
             # Only adjust if config path is just a filename (no directory)
             if not os.path.dirname(config_file):
-                adjusted_path = os.path.join(
-                    "src", "lib", "app", "RvCommon", config_file
-                )
+                adjusted_path = os.path.join("src", "lib", "app", "RvCommon", config_file)
                 # Check if the adjusted path exists, if not, try the original
                 if os.path.exists(adjusted_path):
-                    logger.info(
-                        f"Using config from RvCommon directory: {adjusted_path}"
-                    )
+                    logger.info(f"Using config from RvCommon directory: {adjusted_path}")
                     return adjusted_path
 
     return config_file
@@ -162,9 +152,7 @@ def load_variables_from_config(config_file: Optional[str]) -> Dict[str, str]:
                             continue
 
                         if not value:
-                            logger.warning(
-                                f"Empty value in {config_file} line {line_num}: {key} = (empty)"
-                            )
+                            logger.warning(f"Empty value in {config_file} line {line_num}: {key} = (empty)")
                             invalid_count += 1
                             continue
 
@@ -178,21 +166,15 @@ def load_variables_from_config(config_file: Optional[str]) -> Dict[str, str]:
                         if validate_css_value(key, value):
                             variables[key] = value
                         else:
-                            logger.warning(
-                                f"Skipping invalid value in {config_file} line {line_num}: {key} = {value}"
-                            )
+                            logger.warning(f"Skipping invalid value in {config_file} line {line_num}: {key} = {value}")
                             example = get_example_value(key)
                             logger.info(f"Example: {key} = {example}")
-                            logger.info(
-                                f"Variable will remain as {{{{{key}}}}} placeholder"
-                            )
+                            logger.info(f"Variable will remain as {{{{{key}}}}} placeholder")
                             invalid_count += 1
                             # Skip invalid values - don't include them
                     else:
-                        logger.warning(
-                            f"Malformed line in {config_file} line {line_num}: {original_line.strip()}"
-                        )
-                        logger.info(f"Expected format: VARIABLE = value")
+                        logger.warning(f"Malformed line in {config_file} line {line_num}: {original_line.strip()}")
+                        logger.info("Expected format: VARIABLE = value")
                         invalid_count += 1
     except UnicodeDecodeError as e:
         logger.error(f"Config file {config_file} has encoding issues: {e}")
@@ -203,9 +185,7 @@ def load_variables_from_config(config_file: Optional[str]) -> Dict[str, str]:
         return {}
 
     if invalid_count > 0:
-        logger.warning(
-            f"Found {invalid_count} invalid value(s) in config file. Please fix them to ensure proper CSS."
-        )
+        logger.warning(f"Found {invalid_count} invalid value(s) in config file. Please fix them to ensure proper CSS.")
 
     return variables
 
@@ -246,9 +226,7 @@ def validate_css_value(var_name: str, value: str) -> bool:
         # Check for valid CSS color formats
 
         # RGB format: rgb(r, g, b) with proper range validation
-        rgb_match = re.match(
-            r"^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$", value
-        )
+        rgb_match = re.match(r"^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$", value)
         if rgb_match:
             r, g, b = map(int, rgb_match.groups())
             return 0 <= r <= 255 and 0 <= g <= 255 and 0 <= b <= 255
@@ -278,10 +256,7 @@ def validate_css_value(var_name: str, value: str) -> bool:
         }
 
         # Check Hex format or named colors (case insensitive)
-        return (
-            re.match(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$", value) is not None
-            or value.lower() in named_colors
-        )
+        return re.match(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$", value) is not None or value.lower() in named_colors
 
     # Non-color variables: for now all variables are colors
     return len(value.strip()) > 0
@@ -302,9 +277,7 @@ def get_example_value(var_name: str) -> str:
 def collect_missing_variables(missing_vars: Set[str]) -> Dict[str, str]:
     """Interactive collection of missing variables with validation"""
     print("\nMissing variables detected. Please provide values:")
-    print(
-        "('quit' to abort, 'default' to use default value, 'help' for examples, Ctrl+C to cancel)"
-    )
+    print("('quit' to abort, 'default' to use default value, 'help' for examples, Ctrl+C to cancel)")
 
     # Read the config file and get the default value for the variable
     config_file = adjust_config_path("rv_theme_variables.conf")
@@ -336,9 +309,7 @@ def collect_missing_variables(missing_vars: Set[str]) -> Dict[str, str]:
                             print(f"Set: {var_name} = {variables[var_name]}")
                             break
                         else:
-                            print(
-                                f"No default value found for {var_name}. Please provide a valid CSS value."
-                            )
+                            print(f"No default value found for {var_name}. Please provide a valid CSS value.")
                             continue
                     else:
                         # Validate the value
@@ -374,9 +345,7 @@ def process_template(template_file: str, variables: Dict[str, str]) -> str:
         with open(template_file, "r", encoding="utf-8") as f:
             content = f.read()
     except UnicodeDecodeError as e:
-        raise ValueError(
-            f"Template file {template_file} has encoding issues: {e}. Please save as UTF-8."
-        )
+        raise ValueError(f"Template file {template_file} has encoding issues: {e}. Please save as UTF-8.")
     except Exception as e:
         raise ValueError(f"Failed to read template file {template_file}: {e}")
 
@@ -389,9 +358,7 @@ def process_template(template_file: str, variables: Dict[str, str]) -> str:
     # Check for variables in config that don't exist in template
     extra_vars = set(variables.keys()) - template_vars
     if extra_vars:
-        logger.warning(
-            f"Found {len(extra_vars)} variables in config that don't exist in template:"
-        )
+        logger.warning(f"Found {len(extra_vars)} variables in config that don't exist in template:")
         for var in sorted(extra_vars):
             logger.info(f"  {var} = {variables[var]}")
         logger.info("These variables will be ignored.")
@@ -399,9 +366,7 @@ def process_template(template_file: str, variables: Dict[str, str]) -> str:
     # Check for missing variables
     missing_vars = template_vars - set(variables.keys())
     if missing_vars:
-        logger.info(
-            f"Found {len(missing_vars)} missing variables: {', '.join(sorted(missing_vars))}"
-        )
+        logger.info(f"Found {len(missing_vars)} missing variables: {', '.join(sorted(missing_vars))}")
 
         # Collect missing variables interactively
         new_vars = collect_missing_variables(missing_vars)
@@ -500,9 +465,7 @@ def main():
         help="Set variable (format: KEY=VALUE). Can be used multiple times",
     )
 
-    parser.add_argument(
-        "--list-variables", help="List all variables found in a config file"
-    )
+    parser.add_argument("--list-variables", help="List all variables found in a config file")
 
     args = parser.parse_args()
 

--- a/src/lib/app/py_rvui/rv/extra_commands.py
+++ b/src/lib/app/py_rvui/rv/extra_commands.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 def __dummy__():
     pass

--- a/src/lib/app/py_rvui/rv/runtime.py
+++ b/src/lib/app/py_rvui/rv/runtime.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import os
 
@@ -12,18 +12,16 @@ def __dummy__():
 
 def setup_webview_default_profile():
     default_profile = QWebEngineProfile.defaultProfile()
-    user_agent = (
-        default_profile.httpUserAgent() + " RV/" + os.environ["TWK_APP_VERSION"]
-    )
+    user_agent = default_profile.httpUserAgent() + " RV/" + os.environ["TWK_APP_VERSION"]
     default_profile.setHttpUserAgent(user_agent)
 
 
 try:
     from PySide2.QtWebEngineWidgets import QWebEngineProfile
 except ImportError:
-  try:
-    from PySide6.QtWebEngineCore import QWebEngineProfile
-  except ImportError:
-    pass
+    try:
+        from PySide6.QtWebEngineCore import QWebEngineProfile
+    except ImportError:
+        pass
 
 setup_webview_default_profile()

--- a/src/lib/app/py_rvui/rv/rvtypes.py
+++ b/src/lib/app/py_rvui/rv/rvtypes.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import rv.commands
 import os
@@ -75,9 +75,7 @@ class Mode(object):
             rv.commands.deactivateMode(self._modeName)
 
         rv.commands.redraw()
-        rv.commands.sendInternalEvent(
-            "mode-toggled", "%s|%s" % (self._modeName, self._active), "Mode"
-        )
+        rv.commands.sendInternalEvent("mode-toggled", "%s|%s" % (self._modeName, self._active), "Mode")
 
     def layout(self, event):
         "Layout any margins or precompute anything necessary for rendering"
@@ -88,7 +86,7 @@ class Mode(object):
         pass
 
     def supportPath(self, module, packageName=None):
-        if packageName == None:
+        if packageName is None:
             packageName = module.__name__
         return os.path.join(
             os.path.dirname(os.path.dirname(module.__file__)),
@@ -97,18 +95,14 @@ class Mode(object):
         )
 
     def qmlPath(self, module, packageName=None):
-        if packageName == None:
+        if packageName is None:
             packageName = module.__name__
-        return os.path.join(
-            os.path.dirname(os.path.dirname(module.__file__)), "QML", packageName
-        )
+        return os.path.join(os.path.dirname(os.path.dirname(module.__file__)), "QML", packageName)
 
     def configPath(self, packageName):
         """Returns a path to a writable directory where temporary, and
         configuration files specific to a package are/should be located. The
         directory will be created if it does not yet exist."""
-
-        import platform
 
         envvar = os.getenv("TWK_APP_SUPPORT_PATH")
         userDir = envvar.split(concat_seperator())[0]
@@ -117,7 +111,7 @@ class Mode(object):
         try:
             if not os.path.exists(directory):
                 sys.mkdir(directory, 0x1FF)
-        except:
+        except Exception:
             print("ERROR: mode config path failed to create directory %s" % directory)
 
         return directory
@@ -158,13 +152,13 @@ class MinorMode(Mode):
         self.setMenu(menu)
 
     def setMenu(self, menu):
-        if menu == None:
+        if menu is None:
             menu = []
         self._menu = menu
         rv.commands.defineModeMenu(self._modeName, self._menu, False)
 
     def setMenuStrict(self, menu):
-        if menu == None:
+        if menu is None:
             menu = []
         self._menu = menu
         rv.commands.defineModeMenu(self._modeName, self._menu, True)
@@ -217,9 +211,7 @@ class Widget(MinorMode):
         self._inCloseArea = False
         self._containsPointer = False
         self._whichMargin = -1
-        MinorMode.init(
-            self, name, globalBindings, overrideBindings, menu, sortKey, ordering
-        )
+        MinorMode.init(self, name, globalBindings, overrideBindings, menu, sortKey, ordering)
 
     def toggle(self):
         self._active = not self._active
@@ -233,9 +225,7 @@ class Widget(MinorMode):
 
         rv.commands.redraw()
 
-        rv.commands.sendInternalEvent(
-            "mode-toggled", "%s|%s" % (self._modeName, self._active), "Mode"
-        )
+        rv.commands.sendInternalEvent("mode-toggled", "%s|%s" % (self._modeName, self._active), "Mode")
 
     def updateMargins(self, activated):
         #
@@ -278,12 +268,7 @@ class Widget(MinorMode):
             self.updateMargins(True)
 
     def contains(self, p):
-        if (
-            p[0] >= self._x
-            and p[0] <= self._x + self._w
-            and p[1] >= self._y
-            and p[1] <= self._y + self._h
-        ):
+        if p[0] >= self._x and p[0] <= self._x + self._w and p[1] >= self._y and p[1] <= self._y + self._h:
             return True
 
         return False

--- a/src/lib/app/py_rvui/rv/rvui.py
+++ b/src/lib/app/py_rvui/rv/rvui.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import rv.commands
 import rv.rvtypes
@@ -43,9 +43,9 @@ def remotePyEval(event):
     "python eval() event contents"
     try:
         val = eval(event.contents())
-        if val != None:
+        if val is not None:
             event.setReturnContent(str(val))
-    except:
+    except Exception:
         import sys
 
         e = sys.exc_info()

--- a/src/plugins/python/network/network/__init__.py
+++ b/src/plugins/python/network/network/__init__.py
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-from .rvNetwork import RvCommunicator
+from .rvNetwork import RvCommunicator as RvCommunicator

--- a/src/plugins/python/network/network/muConsole.py
+++ b/src/plugins/python/network/network/muConsole.py
@@ -27,12 +27,12 @@ class MuConsole:
         while 1:
             time.sleep(0.1)
 
-            l = sys.stdin.readline()
-            if l[0] == "\n":
+            line = sys.stdin.readline()
+            if line[0] == "\n":
                 print("RETURN:", self.rvc.remoteEvalAndReturn(buf))
                 buf = ""
             else:
-                buf += l
+                buf += line
 
             self.rvc.processEvents()
 

--- a/src/plugins/python/network/network/playControl.py
+++ b/src/plugins/python/network/network/playControl.py
@@ -27,7 +27,6 @@ class PlayControl:
         self.frameChanged = True
 
     def run(self):
-
         sys.stdout.write("Type: p=play, s=stop, r=reverse play, q=quit\r\n")
 
         while 1:

--- a/src/plugins/python/network/network/rvNetwork.py
+++ b/src/plugins/python/network/network/rvNetwork.py
@@ -6,7 +6,6 @@
 #
 from __future__ import print_function
 
-import os
 import socket
 import sys
 import time
@@ -92,7 +91,7 @@ class RvCommunicator:
                 self._sendMessage("DISCONNECT")
             self.sock.shutdown(socket.SHUT_RDWR)
             self.sock.close()
-        except:
+        except Exception:
             pass
         self.connected = False
 
@@ -166,8 +165,7 @@ class RvCommunicator:
                 sanitized_msg = (msg.errno, msg.strerror)
             if (
                 sanitized_msg[1] != "Resource temporarily unavailable"
-                and sanitized_msg[1]
-                != "A non-blocking socket operation could not be completed immediately"
+                and sanitized_msg[1] != "A non-blocking socket operation could not be completed immediately"
                 and sanitized_msg[0] != 10035
             ):
                 print("ERROR: peek for messages failed: %s\n" % msg, file=sys.stderr)
@@ -185,7 +183,6 @@ class RvCommunicator:
         return field
 
     def _receiveSingleMessage(self):
-
         messType = 0
         messContents = 0
 
@@ -271,7 +268,6 @@ class RvCommunicator:
         self._processEvents()
 
     def _processEvents(self, processReturnOnly=False):
-
         while 1:
             noMessage = True
             while noMessage:
@@ -300,10 +296,7 @@ class RvCommunicator:
                             file=sys.stderr,
                         )
                         return six.ensure_binary("")
-                elif (
-                    len(self.eventQueue) == 0
-                    or (event, contents) != self.eventQueue[-1:]
-                ):
+                elif len(self.eventQueue) == 0 or (event, contents) != self.eventQueue[-1:]:
                     self.eventQueue.append((event, contents))
 
             elif messType == six.ensure_binary("PING"):

--- a/src/plugins/python/rvSession/rvSession.py
+++ b/src/plugins/python/rvSession/rvSession.py
@@ -37,7 +37,7 @@ CAVEATS:
 
 * This is write-only, no session file reading yet.
 
-* Only version 4 session files (RV v4.0.7 and above) are supported 
+* Only version 4 session files (RV v4.0.7 and above) are supported
 
 RELEASE NOTES:
 
@@ -106,15 +106,11 @@ class _Node:
         """
         nodeType = six.ensure_binary(nodeType)
         try:
-            pipeProp = self.getProperty(
-                pipelineType, pipelineSuffix, "pipeline", "nodes"
-            )
+            pipeProp = self.getProperty(pipelineType, pipelineSuffix, "pipeline", "nodes")
             pipenodes = pipeProp[1] + [nodeType]
         except KeyError:
             pipenodes = [nodeType]
-        self.setProperty(
-            pipelineType, pipelineSuffix, "pipeline", "nodes", gto.STRING, pipenodes
-        )
+        self.setProperty(pipelineType, pipelineSuffix, "pipeline", "nodes", gto.STRING, pipenodes)
 
         return "%s_%d" % (pipelineSuffix, len(pipenodes) - 1)
 
@@ -124,9 +120,7 @@ class _Node:
         return None if it cannot be located.
         """
         try:
-            pipeProp = self.getProperty(
-                pipelineType, pipelineSuffix, "pipeline", "nodes"
-            )
+            pipeProp = self.getProperty(pipelineType, pipelineSuffix, "pipeline", "nodes")
         except KeyError:
             return None
 
@@ -174,10 +168,7 @@ class _Node:
         others may only allow a certain number of inputs.
         """
         if self.maxInputs != -1 and len(self.inputs) + 1 > self.maxInputs:
-            raise Exception(
-                "ERROR: node '%s' (%s) only allowed %d inputs"
-                % (self.name, self.typeName, self.maxInputs)
-            )
+            raise Exception("ERROR: node '%s' (%s) only allowed %d inputs" % (self.name, self.typeName, self.maxInputs))
         else:
             self.inputs.append(node.name)
 
@@ -230,9 +221,7 @@ class Source(_GroupNode):
         """
         Offset must be in _seconds_.
         """
-        self.setProperty(
-            "RVFileSource", "source", "group", "audioOffset", gto.FLOAT, offset
-        )
+        self.setProperty("RVFileSource", "source", "group", "audioOffset", gto.FLOAT, offset)
 
     def setRangeOffset(self, offset):
         """
@@ -240,9 +229,7 @@ class Source(_GroupNode):
         to have the first frame of foo.mov set to 101, set range
         offset to 100.
         """
-        self.setProperty(
-            "RVFileSource", "source", "group", "rangeOffset", gto.INT, offset
-        )
+        self.setProperty("RVFileSource", "source", "group", "rangeOffset", gto.INT, offset)
 
     def setCutIn(self, frame):
         """
@@ -271,10 +258,7 @@ class Source(_GroupNode):
         As a helper, a dictionary can be supplied that will print metadata sorted by the keys
         """
         if isinstance(metadata, dict):
-            metadata = [
-                "{0}={1}".format(k, v)
-                for k, v in sorted(metadata.items(), reverse=True)
-            ]
+            metadata = ["{0}={1}".format(k, v) for k, v in sorted(metadata.items(), reverse=True)]
 
         self.setProperty(
             "RVFileSource",
@@ -292,7 +276,7 @@ class Source(_GroupNode):
         """
         args = ["RVLinearize", "RVLinearizePipelineGroup", "tolinPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
         self.setProperty(
             "RVLinearize",
@@ -311,11 +295,9 @@ class Source(_GroupNode):
         """
         args = ["RVLensWarp", "RVLinearizePipelineGroup", "tolinPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
-        self.setProperty(
-            "RVLensWarp", pipeNode, "warp", "pixelAspectRatio", gto.FLOAT, pa
-        )
+        self.setProperty("RVLensWarp", pipeNode, "warp", "pixelAspectRatio", gto.FLOAT, pa)
         self.setProperty("RVLensWarp", pipeNode, "node", "active", gto.INT, 1)
 
     ## Color
@@ -328,13 +310,11 @@ class Source(_GroupNode):
         """
         args = ["RVColor", "RVColorPipelineGroup", "colorPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
         self.setProperty("RVColor", pipeNode, "color", "exposure", gto.FLOAT, exp)
         self.setProperty("RVColor", pipeNode, "color", "active", gto.INT, 1)
-        self.setProperty(
-            "RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1
-        )
+        self.setProperty("RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1)
         self.setProperty("RVFormat", "format", "color", "maxBitDepth", gto.INT, 0)
 
     def setColorScale(self, scale):
@@ -345,13 +325,11 @@ class Source(_GroupNode):
         """
         args = ["RVColor", "RVColorPipelineGroup", "colorPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
         self.setProperty("RVColor", pipeNode, "color", "scale", gto.FLOAT, scale)
         self.setProperty("RVColor", pipeNode, "color", "active", gto.INT, 1)
-        self.setProperty(
-            "RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1
-        )
+        self.setProperty("RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1)
         self.setProperty("RVFormat", "format", "color", "maxBitDepth", gto.INT, 0)
 
     ## Channels and Layers
@@ -363,19 +341,13 @@ class Source(_GroupNode):
         """
         args = ["RVColor", "RVColorPipelineGroup", "colorPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
-        self.setProperty(
-            "RVColor", pipeNode, "color", "channelOrder", gto.STRING, channelOrder
-        )
+        self.setProperty("RVColor", pipeNode, "color", "channelOrder", gto.STRING, channelOrder)
         self.setProperty("RVColor", pipeNode, "color", "active", gto.INT, 1)
-        self.setProperty(
-            "RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1
-        )
+        self.setProperty("RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1)
         self.setProperty("RVFormat", "format", "color", "maxBitDepth", gto.INT, 0)
-        self.setProperty(
-            "RVFileSource", "source", "request", "readAllChannels", gto.INT, 1
-        )
+        self.setProperty("RVFileSource", "source", "request", "readAllChannels", gto.INT, 1)
 
     def setImageLayerSelection(self, layer):
         """
@@ -395,16 +367,10 @@ class Source(_GroupNode):
         channelMap can be a single channel which represents RGB, or a tuple ("Z","A"). Mapping
         happens in software
         """
-        self.setProperty(
-            "RVChannelMap", "channelMap", "format", "channels", gto.STRING, channelMap
-        )
-        self.setProperty(
-            "RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1
-        )
+        self.setProperty("RVChannelMap", "channelMap", "format", "channels", gto.STRING, channelMap)
+        self.setProperty("RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1)
         self.setProperty("RVFormat", "format", "color", "maxBitDepth", gto.INT, 0)
-        self.setProperty(
-            "RVFileSource", "source", "request", "readAllChannels", gto.INT, 1
-        )
+        self.setProperty("RVFileSource", "source", "request", "readAllChannels", gto.INT, 1)
 
     ## Text
     def setTextPosition(self, x, y):
@@ -415,17 +381,13 @@ class Source(_GroupNode):
         lower right == 1,1
         upper right == 1,0
         """
-        self.setProperty(
-            "RVPaint", "paint", self.txt.name, "position", gto.FLOAT, (x, y)
-        )
+        self.setProperty("RVPaint", "paint", self.txt.name, "position", gto.FLOAT, (x, y))
 
     def setTextColor(self, r=1, g=1, b=1, a=1):
         """
         modify color to text # note: this should probably use a tuple like other "set" functions
         """
-        self.setProperty(
-            "RVPaint", "paint", self.txt.name, "color", gto.FLOAT, (r, g, b, a)
-        )
+        self.setProperty("RVPaint", "paint", self.txt.name, "color", gto.FLOAT, (r, g, b, a))
 
     def setTextSize(self, size):
         """
@@ -445,9 +407,7 @@ class Source(_GroupNode):
             if k not in ["order", "sourceCount", "name"]:
                 if isinstance(v, str):
                     valueType = gto.STRING
-                self.setProperty(
-                    "RVPaint", "paint", self.txt.name, "{0}".format(k), valueType, v
-                )
+                self.setProperty("RVPaint", "paint", self.txt.name, "{0}".format(k), valueType, v)
         # For layout, but not source
         # self.txt.order.append(self.txt.name)
         return self.txt.name
@@ -620,17 +580,13 @@ class Layout(_GroupNode):
         """
         modify position of text. Positions are x, y values from lower left == 0, upper right == 1
         """
-        self.setProperty(
-            "RVPaint", "paint", self.txt.name, "position", gto.FLOAT, (x, y)
-        )
+        self.setProperty("RVPaint", "paint", self.txt.name, "position", gto.FLOAT, (x, y))
 
     def setTextColor(self, r=1, g=1, b=1, a=1):
         """
         modify color to text
         """
-        self.setProperty(
-            "RVPaint", "paint", self.txt.name, "color", gto.FLOAT, (r, g, b, a)
-        )
+        self.setProperty("RVPaint", "paint", self.txt.name, "color", gto.FLOAT, (r, g, b, a))
 
     def setTextSize(self, size):
         """
@@ -650,9 +606,7 @@ class Layout(_GroupNode):
             if k not in ["order", "sourceCount", "name"]:
                 if isinstance(v, str):
                     valueType = gto.STRING
-                self.setProperty(
-                    "RVPaint", "paint", self.txt.name, "{0}".format(k), valueType, v
-                )
+                self.setProperty("RVPaint", "paint", self.txt.name, "{0}".format(k), valueType, v)
         self.txt.order.append(self.txt.name)
 
     def setFrameNumberForText(self, frame):
@@ -691,7 +645,6 @@ class Layout(_GroupNode):
         scale = 1.0 / nside
 
         pos = []
-        total = 0
         for row in reversed(range(0, nside)):
             y = scale * row - (0.5 * scale)
             for column in range(0, nside):
@@ -770,7 +723,6 @@ class Session:
 
     @staticmethod
     def lookupNodeType(key):
-
         if key in Session.nodeTypes.keys():
             return Session.nodeTypes[key]
 
@@ -808,9 +760,7 @@ class Session:
         LUTs, or stereo modes.
         """
 
-        self.outputGroup.setProperty(
-            objType, objName, contName, propName, valueType, value
-        )
+        self.outputGroup.setProperty(objType, objName, contName, propName, valueType, value)
 
     def newNode(self, nodeType, uiName=None):
         """
@@ -828,10 +778,8 @@ class Session:
         try:
             (objType, cons) = Session.lookupNodeType(nodeType)
             node = cons()
-        except:
-            raise Exception(
-                "Can't construct node of type '%s':" % nodeType, sys.exc_info()[0]
-            )
+        except Exception:
+            raise Exception("Can't construct node of type '%s':" % nodeType, sys.exc_info()[0])
 
         if nodeType == "Source":
             node.name = "sourceGroup%06d" % self.sourceCount
@@ -875,13 +823,12 @@ class Session:
         """
 
         subObjects = {}
-        if obj != None:
+        if obj is not None:
             subObjects[""] = (obj, {})
 
         containers = {}
 
-        for (path, info) in sorted(properties.items()):
-
+        for path, info in sorted(properties.items()):
             (subObjType, subObject, container, prop) = path
             (typeName, value) = info
 
@@ -910,28 +857,22 @@ class Session:
 
             w = 1
             element = value
-            if type(element) == type([]):
+            if type(element) is type([]):
                 element = element[0]
             else:
                 value = [value]
 
-            if type(element) == type((0,)):
+            if type(element) is type((0,)):
                 w = len(element)
 
-            gtoContainer.append(
-                gc.Property(prop, typeName, size=len(value), width=w, data=value)
-            )
+            gtoContainer.append(gc.Property(prop, typeName, size=len(value), width=w, data=value))
 
     def _writeSessionObject(self, top):
-
         top.rv = self._getVersionedObj("rv", "RVSession")
         self._writeProperties(top, top.rv, "rv", self.properties)
 
     def _writeDefaultOutput(self, top):
-
-        top.defaultOutputGroup = self._getVersionedObj(
-            "defaultOutputGroup", "RVOutputGroup"
-        )
+        top.defaultOutputGroup = self._getVersionedObj("defaultOutputGroup", "RVOutputGroup")
         self._writeProperties(
             top,
             top.defaultOutputGroup,
@@ -940,7 +881,6 @@ class Session:
         )
 
     def _writeConnections(self, top):
-
         #
         #   Input order is significant for stack/sequence/layout
         #   nodes, so preserve it here.
@@ -957,9 +897,7 @@ class Session:
         top.connections = self._getVersionedObj("connections", "connection")
 
         top.connections.evaluation = gc.Component("evaluation", "compinterp")
-        top.connections.evaluation.append(
-            gc.Property("connections", gto.STRING, size=len(cons), width=2, data=cons)
-        )
+        top.connections.evaluation.append(gc.Property("connections", gto.STRING, size=len(cons), width=2, data=cons))
 
     def _writeNodes(self, top):
         """
@@ -1014,9 +952,7 @@ class Session:
         "pair"     Left eye on left, Right eye on right
         "mirror"   Like "pair" but with right eye mirrored
         """
-        self.setOutputProperty(
-            "RVOutputDisplayStereo", "stereo", "stereo", "type", gto.STRING, mode
-        )
+        self.setOutputProperty("RVOutputDisplayStereo", "stereo", "stereo", "type", gto.STRING, mode)
 
     def setOutputGamma(self, gamma):
         """
@@ -1024,14 +960,10 @@ class Session:
         """
         args = ["RVDisplayColor", "RVDisplayPipelineGroup", "colorPipeline"]
         pipeNode = self.outputGroup.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.outputGroup.addPipelineNode(*args)
-        self.setOutputProperty(
-            "RVDisplayColor", pipeNode, "color", "gamma", gto.FLOAT, gamma
-        )
-        self.setOutputProperty(
-            "RVDisplayColor", pipeNode, "color", "active", gto.INT, 1
-        )
+        self.setOutputProperty("RVDisplayColor", pipeNode, "color", "gamma", gto.FLOAT, gamma)
+        self.setOutputProperty("RVDisplayColor", pipeNode, "color", "active", gto.INT, 1)
 
         return pipeNode
 
@@ -1041,11 +973,9 @@ class Session:
         """
         args = ["RVDisplayColor", "RVDisplayPipelineGroup", "colorPipeline"]
         pipeNode = self.outputGroup.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.outputGroup.addPipelineNode(*args)
-        self.setOutputProperty(
-            "RVDisplayColor", pipeNode, "lut", "file", gto.STRING, name
-        )
+        self.setOutputProperty("RVDisplayColor", pipeNode, "lut", "file", gto.STRING, name)
         self.setOutputProperty("RVDIsplayColor", pipeNode, "lut", "active", gto.INT, 1)
 
         return pipeNode

--- a/src/plugins/rv-packages/annot_tools/annot_tools.py
+++ b/src/plugins/rv-packages/annot_tools/annot_tools.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # *****************************************************************************
-import os
 
 import rv.commands as rvc
 import rv.extra_commands as rvec
@@ -58,9 +57,7 @@ class RVAnnotTools(rv.rvtypes.MinorMode):
 
         for frame in range(source_data["startFrame"], source_data["endFrame"] + 1):
             paint_prop = "{}.paint".format(paint_node)
-            text_name = "text:{}:{}:annotation".format(
-                rvc.getIntProperty("{}.nextId".format(paint_prop))[0], frame
-            )
+            text_name = "text:{}:{}:annotation".format(rvc.getIntProperty("{}.nextId".format(paint_prop))[0], frame)
             text_prop = "{}.{}".format(paint_node, text_name)
 
             rvc.setIntProperty("{}.{}".format(paint_prop, "show"), [1])
@@ -68,25 +65,17 @@ class RVAnnotTools(rv.rvtypes.MinorMode):
             rvc.newProperty("{}.{}".format(text_prop, "position"), rvc.FloatType, 2)
             rvc.newProperty("{}.{}".format(text_prop, "color"), rvc.FloatType, 4)
             rvc.newProperty("{}.{}".format(text_prop, "size"), rvc.FloatType, 1)
-            rvc.newProperty(
-                "{}.frame:{}.order".format(paint_node, frame), rvc.StringType, 1
-            )
+            rvc.newProperty("{}.frame:{}.order".format(paint_node, frame), rvc.StringType, 1)
 
             rvc.setStringProperty(
                 "{}.{}".format(text_prop, "text"),
                 ["This is frame {}".format(frame)],
                 True,
             )
-            rvc.setFloatProperty(
-                "{}.{}".format(text_prop, "position"), [-0.6, 0.24], True
-            )
-            rvc.setFloatProperty(
-                "{}.{}".format(text_prop, "color"), [1.0, 1.0, 1.0, 1.0], True
-            )
+            rvc.setFloatProperty("{}.{}".format(text_prop, "position"), [-0.6, 0.24], True)
+            rvc.setFloatProperty("{}.{}".format(text_prop, "color"), [1.0, 1.0, 1.0, 1.0], True)
             rvc.setFloatProperty("{}.{}".format(text_prop, "size"), [0.01], True)
-            rvc.setStringProperty(
-                "{}.frame:{}.order".format(paint_node, frame), [text_name], True
-            )
+            rvc.setStringProperty("{}.frame:{}.order".format(paint_node, frame), [text_name], True)
 
 
 g_the_mode = None

--- a/src/plugins/rv-packages/channel_select/channel_select.py
+++ b/src/plugins/rv-packages/channel_select/channel_select.py
@@ -1,29 +1,23 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands as rvc
 from rv import extra_commands as rve
 from rv import rvtypes as rvt
 
-import os
-import sys
-import re
-
 
 def getColorSelectNodes():
-
     try:
         return rvc.nodesOfType("ChannelSelect")
-    except:
+    except Exception:
         pass
 
     return None
 
 
 def channelIs(node, num):
-
     active = rvc.getIntProperty(node + ".node.active")[0]
     chan = rvc.getIntProperty(node + ".parameters.channel")[0]
 
@@ -32,19 +26,12 @@ def channelIs(node, num):
 
 class ColorSelectMode(rvt.MinorMode):
     def readPrefs(self):
-
-        self._postDisplaySelect = bool(
-            rvc.readSettings("channel_select", "postDisplaySelect", False)
-        )
+        self._postDisplaySelect = bool(rvc.readSettings("channel_select", "postDisplaySelect", False))
 
     def writePrefs(self):
-
-        rvc.writeSettings(
-            "channel_select", "postDisplaySelect", self._postDisplaySelect
-        )
+        rvc.writeSettings("channel_select", "postDisplaySelect", self._postDisplaySelect)
 
     def addChannelSelect(self):
-
         if self._postDisplaySelect:
             groups = []
             for dg in rvc.nodesOfType("RVDisplayGroup"):
@@ -57,7 +44,7 @@ class ColorSelectMode(rvt.MinorMode):
         for g in groups:
             nodes = rvc.getStringProperty(g + ".pipeline.nodes")
 
-            if not ("ChannelSelect" in nodes):
+            if "ChannelSelect" not in nodes:
                 nodes += ["ChannelSelect"]
                 rvc.setStringProperty(g + ".pipeline.nodes", nodes, True)
 
@@ -70,7 +57,6 @@ class ColorSelectMode(rvt.MinorMode):
 
     def toggleChannel(self, num):
         def foo(event):
-
             self.addChannelSelect()
 
             nodes = getColorSelectNodes()
@@ -93,18 +79,15 @@ class ColorSelectMode(rvt.MinorMode):
         return foo
 
     def togglePostDisplaySelect(self, event):
-
         self._postDisplaySelect = not self._postDisplaySelect
         self.writePrefs()
 
     def postDisplaySelectState(self):
-
         if self._postDisplaySelect:
             return rvc.CheckedMenuState
         return rvc.UncheckedMenuState
 
     def __init__(self):
-
         rvt.MinorMode.__init__(self)
 
         self.readPrefs()
@@ -137,5 +120,4 @@ class ColorSelectMode(rvt.MinorMode):
 
 
 def createMode():
-
     return ColorSelectMode()

--- a/src/plugins/rv-packages/collapse_missing_frames/collapse_missing_frames.py
+++ b/src/plugins/rv-packages/collapse_missing_frames/collapse_missing_frames.py
@@ -1,9 +1,9 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
-from rv import rvtypes, commands, extra_commands
+# SPDX-License-Identifier: Apache-2.0
+#
+from rv import rvtypes, commands
 
 
 def groupMemberOfType(node, memberType):
@@ -38,9 +38,7 @@ class CollapseMissingFrames(rvtypes.MinorMode):
             self.collapse(source, True)
 
     def collapse(self, source, force=False):
-        linPG = groupMemberOfType(
-            commands.nodeGroup(source), "RVLinearizePipelineGroup"
-        )
+        linPG = groupMemberOfType(commands.nodeGroup(source), "RVLinearizePipelineGroup")
         retime = groupMemberOfType(linPG, "RVRetime")
         if not force and retime is not None and isCollapsed(retime):
             commands.setIntProperty(retime + ".explicit.active", [0])
@@ -63,17 +61,13 @@ class CollapseMissingFrames(rvtypes.MinorMode):
                         [int(rangeInfo["start"])],
                         True,
                     )
-                    commands.setIntProperty(
-                        retime + ".explicit.inputFrames", partial, True
-                    )
+                    commands.setIntProperty(retime + ".explicit.inputFrames", partial, True)
                     commands.setIntProperty(retime + ".explicit.active", [1])
 
     def collapsed(self):
         sources = commands.sourcesAtFrame(commands.frame())
         for source in sources:
-            linPG = groupMemberOfType(
-                commands.nodeGroup(source), "RVLinearizePipelineGroup"
-            )
+            linPG = groupMemberOfType(commands.nodeGroup(source), "RVLinearizePipelineGroup")
             retime = groupMemberOfType(linPG, "RVRetime")
             if retime is None or not isCollapsed(retime):
                 return commands.UncheckedMenuState
@@ -90,7 +84,6 @@ class CollapseMissingFrames(rvtypes.MinorMode):
         return self._collapseAll
 
     def __init__(self):
-
         rvtypes.MinorMode.__init__(self)
 
         self.init(
@@ -119,9 +112,7 @@ class CollapseMissingFrames(rvtypes.MinorMode):
             ],
         )
 
-        self._collapseAll = commands.readSettings(
-            "COLLAPSE_MISSING", "collapseAll", False
-        )
+        self._collapseAll = commands.readSettings("COLLAPSE_MISSING", "collapseAll", False)
 
 
 def createMode():

--- a/src/plugins/rv-packages/custom_mattes/custom_mattes.py
+++ b/src/plugins/rv-packages/custom_mattes/custom_mattes.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, rvtypes, extra_commands
 import os
@@ -22,9 +22,7 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         try:
             definition = os.environ["RV_CUSTOM_MATTE_DEFINITIONS"]
         except KeyError:
-            definition = str(
-                commands.readSettings("CUSTOM_MATTES", "customMattesDefinition", "")
-            )
+            definition = str(commands.readSettings("CUSTOM_MATTES", "customMattesDefinition", ""))
         try:
             if os.path.exists(definition):
                 self.updateMattesFromFile(definition)
@@ -46,7 +44,6 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         return matteState
 
     def selectMatte(self, matte):
-
         # Create a method that is specific to each matte for setting the
         # relavent session node properties to display the matte
         def select(event):
@@ -56,12 +53,8 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
                 extra_commands.displayFeedback("Disabling mattes", 2.0)
             else:
                 m = self._mattes[matte]
-                commands.setFloatProperty(
-                    "#Session.matte.aspect", [float(m["ratio"])], True
-                )
-                commands.setFloatProperty(
-                    "#Session.matte.heightVisible", [float(m["heightVisible"])], True
-                )
+                commands.setFloatProperty("#Session.matte.aspect", [float(m["ratio"])], True)
+                commands.setFloatProperty("#Session.matte.heightVisible", [float(m["heightVisible"])], True)
                 commands.setFloatProperty(
                     "#Session.matte.centerPoint",
                     [float(m["centerX"]), float(m["centerY"])],
@@ -82,7 +75,6 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         self.setMenuAndBindings()
 
     def setMenuAndBindings(self):
-
         # Walk through all of the mattes adding a menu entry as well as a
         # hotkey binding for alt + index number
         # NOTE: The bindings will only matter for the first 9 mattes since you
@@ -90,9 +82,7 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         matteItems = []
         bindings = []
         if len(self._order) > 0:
-            matteItems.append(
-                ("No Matte", self.selectMatte(""), "alt `", self.currentMatteState(""))
-            )
+            matteItems.append(("No Matte", self.selectMatte(""), "alt `", self.currentMatteState("")))
             bindings.append(("key-down--alt--`", ""))
 
             for i, m in enumerate(self._order):
@@ -126,24 +116,16 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         # Create hotkeys for each matte
         for b in bindings:
             (event, matte) = b
-            commands.bind(
-                "custom-mattes-mode", "global", event, self.selectMatte(matte), ""
-            )
+            commands.bind("custom-mattes-mode", "global", event, self.selectMatte(matte), "")
 
     def updateMattesFromFile(self, filename):
-
         # Make sure the definition file exists
         if not os.path.exists(filename):
-            raise KnownError(
-                "ERROR: Custom Mattes Mode: Non-existent mattes"
-                + " definition file: '%s'" % filename
-            )
+            raise KnownError("ERROR: Custom Mattes Mode: Non-existent mattes" + " definition file: '%s'" % filename)
 
         # Clear existing key bindings
         for i in range(len(self._order)):
-            commands.unbind(
-                "custom-mattes-mode", "global", "key-down--alt--%d" % (i + 1)
-            )
+            commands.unbind("custom-mattes-mode", "global", "key-down--alt--%d" % (i + 1))
 
         # Walk through the lines of the definition file collecting matte
         # parameters
@@ -166,10 +148,7 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         if len(order) == 0:
             self._order = []
             self._mattes = {}
-            raise KnownError(
-                "ERROR: Custom Mattes Mode: Empty mattes"
-                + " definition file: '%s'" % filename
-            )
+            raise KnownError("ERROR: Custom Mattes Mode: Empty mattes" + " definition file: '%s'" % filename)
 
         # Save the definition path and assign the mattes
         commands.writeSettings("CUSTOM_MATTES", "customMattesDefinition", filename)

--- a/src/plugins/rv-packages/media_library_demo/media_library_environment_variable_reader_plugin.py
+++ b/src/plugins/rv-packages/media_library_demo/media_library_environment_variable_reader_plugin.py
@@ -23,26 +23,26 @@ from urllib.parse import urlparse
 # If you want to enable this package to play around it, you can set the following environment variable.
 #
 # !!!!! W A R N I N G !!!!!
-ENABLED_ENV = 'RV_MEDIA_LIBRARY_UNSECURE_DEMO_ENABLED'
+ENABLED_ENV = "RV_MEDIA_LIBRARY_UNSECURE_DEMO_ENABLED"
 
 # The environment variables is used to set the cookies for the media library.
 # The cookies are set as a string of the form:
 #   cookie1=value1; [Domain=domain1; Path=path1;] cookie2=value2; [Domain=domain1; Path=path2;]...
 # The cookies are set for all urls. However, the cookies can be set for specific urls
 # by using the url parameter in the get_http_cookies function and your own logic.
-COOKIES_ENV = 'RV_MEDIA_LIBRARY_UNSECURE_DEMO_COOKIES'
+COOKIES_ENV = "RV_MEDIA_LIBRARY_UNSECURE_DEMO_COOKIES"
 
 # The environment variables that is used to set the headers for the media library.
 # The headers are set as a string of the form:
 #   header1: value1; header2: value2; ...
 # The headers are set for all urls. However, the headers can be set for specific urls
 # by using the url parameter in the get_http_headers function and your own logic.
-HEADERS_ENV = 'RV_MEDIA_LIBRARY_UNSECURE_DEMO_HEADERS'
+HEADERS_ENV = "RV_MEDIA_LIBRARY_UNSECURE_DEMO_HEADERS"
 
 
 # The environment variables that is used to enable the redirection of the urls to disk.
 # The redirection is enabled if the environment variable is set.
-DOWNLOAD_ENV = 'RV_MEDIA_LIBRARY_UNSECURE_DEMO_FORCE_LOCAL_CACHE'
+DOWNLOAD_ENV = "RV_MEDIA_LIBRARY_UNSECURE_DEMO_FORCE_LOCAL_CACHE"
 
 
 def is_plugin_enabled() -> bool:
@@ -111,15 +111,9 @@ def get_http_cookies(url: str) -> Iterable[Dict]:
     for cookie in cookies.values():
         print(cookie)
 
-        yield {
-            "name": cookie.key,
-            "value": cookie.value,
-            "domain": cookie["domain"],
-            "path": cookie["path"]
-        }
+        yield {"name": cookie.key, "value": cookie.value, "domain": cookie["domain"], "path": cookie["path"]}
 
     yield from ()
-
 
 
 def get_http_headers(url: str) -> Iterable[Dict]:
@@ -144,12 +138,10 @@ def get_http_headers(url: str) -> Iterable[Dict]:
         print(header)
 
         name, value = header.split(":", 1)
-        yield {
-            "name": name.strip(),
-            "value": value.strip()
-        }
+        yield {"name": name.strip(), "value": value.strip()}
 
     yield from ()
+
 
 redirection_cache = {}
 

--- a/src/plugins/rv-packages/media_library_demo/media_library_event_plugin.py
+++ b/src/plugins/rv-packages/media_library_demo/media_library_event_plugin.py
@@ -1,22 +1,21 @@
 # Note that this event based Media Library's implementation is not available
 # from rvio because rvio does not support modes.
-plugin_enabled = True
-try:
-    from rv.commands import sendInternalEvent
-except:
-    plugin_enabled = False
 
 from ast import literal_eval
 from typing import Dict, Iterable
+
+plugin_enabled = True
+try:
+    from rv.commands import sendInternalEvent
+except Exception:
+    plugin_enabled = False
 
 
 def is_plugin_enabled() -> bool:
     """
     Returns True if the media library plugin is enabled.
     """
-    return plugin_enabled and bool(
-        literal_eval(sendInternalEvent("media-library-events-are-enabled") or "True")
-    )
+    return plugin_enabled and bool(literal_eval(sendInternalEvent("media-library-events-are-enabled") or "True"))
 
 
 def is_library_media_url(url: str) -> bool:
@@ -31,9 +30,7 @@ def is_streaming(url: str) -> bool:
     Returns True if the given url is a streaming url and should receive cookies and headers.
     """
 
-    return bool(
-        literal_eval(sendInternalEvent("media-library-is-streaming", url) or "True")
-    )
+    return bool(literal_eval(sendInternalEvent("media-library-is-streaming", url) or "True"))
 
 
 def is_redirecting(url: str) -> bool:
@@ -41,9 +38,7 @@ def is_redirecting(url: str) -> bool:
     Returns True if the given url will get redirected by the media library.
     """
 
-    return bool(
-        literal_eval(sendInternalEvent("media-library-is-streaming", url) or "False")
-    )
+    return bool(literal_eval(sendInternalEvent("media-library-is-streaming", url) or "False"))
 
 
 def get_http_cookies(url: str) -> Iterable[Dict]:

--- a/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep.py
+++ b/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep.py
@@ -42,16 +42,7 @@ class MediaRepresentationItem(QtWidgets.QWidgetAction):
         # and take care of the background color.
         widget = QtWidgets.QWidget()
         widget.setStyleSheet(
-            "QWidget"
-            "{"
-            "margin: 0px;"
-            "padding: 0px;"
-            "margin-top: 5px;"
-            "}"
-            "QWidget::hover"
-            "{"
-            "background-color: rgb(62, 62, 132);"
-            "}"
+            "QWidget{margin: 0px;padding: 0px;margin-top: 5px;}QWidget::hover{background-color: rgb(62, 62, 132);}"
         )
 
         # Using a layout to position the labels.
@@ -69,13 +60,7 @@ class MediaRepresentationItem(QtWidgets.QWidgetAction):
         policy = check_mark.sizePolicy()
         policy.setRetainSizeWhenHidden(True)
         check_mark.setSizePolicy(policy)
-        check_mark.setStyleSheet(
-            "background: none;"
-            "margin: 0px;"
-            "padding: 0px;"
-            "color: DarkGray;"
-            "font-size: 12px;"
-        )
+        check_mark.setStyleSheet("background: none;margin: 0px;padding: 0px;color: DarkGray;font-size: 12px;")
         check_mark.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
         layout.addWidget(check_mark)
         self._check_mark = check_mark
@@ -84,7 +69,7 @@ class MediaRepresentationItem(QtWidgets.QWidgetAction):
         # No background so that it uses the parent's one.
         # Does not listen for mouse events.
         label = QtWidgets.QLabel(widget)
-        label.setStyleSheet("background: none;" "margin: 0px;" "padding: 0px;")
+        label.setStyleSheet("background: none;margin: 0px;padding: 0px;")
         label.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
         layout.addWidget(label)
         self._label = label
@@ -96,9 +81,7 @@ class MediaRepresentationItem(QtWidgets.QWidgetAction):
         rep_txt = "<font color='DarkGray'>%s</font>" % rep
         res_txt = "<font color='DarkGray' size='0.6em'>%s</font>" % resolution
         ext_txt = "<font color='DarkGray' size='0.6em'>%s</font>" % extension
-        self._label.setText(
-            "%s<br>%s&nbsp;&nbsp;&nbsp;%s" % (rep_txt, res_txt, ext_txt)
-        )
+        self._label.setText("%s<br>%s&nbsp;&nbsp;&nbsp;%s" % (rep_txt, res_txt, ext_txt))
 
         self.setData({"rep": rep, "switch_nodes": switch_nodes})
 
@@ -172,7 +155,6 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
     # at higher resolution. If this representation is not available, then the
     # 'Movie' media representation will be selected, and so on.
     def sourceMediaUnavailable(self, event):
-
         package_logger.debug("%s in sourceMediaUnavailable" % event.name())
 
         #  event.reject() is done to allow other functions bound to
@@ -191,9 +173,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         expectedNumberOfArgs = 3
         if len(args) != expectedNumberOfArgs:
             package_logger.error(
-                "source-media-unavailable has {} parameters, expected={}".format(
-                    len(args), expectedNumberOfArgs
-                )
+                "source-media-unavailable has {} parameters, expected={}".format(len(args), expectedNumberOfArgs)
             )
             return
 
@@ -202,9 +182,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         mediaRepName = args[2]
 
         # Determine the media rep name to fall back to since this one is not available
-        fallbackMediaRepName = self._getFallbackMediaRepName(
-            sourceNodeName, mediaRepName
-        )
+        fallbackMediaRepName = self._getFallbackMediaRepName(sourceNodeName, mediaRepName)
 
         package_logger.debug(
             "sourceMediaUnavailable()-sourceNodeName={}, mediaRepName={}, fallbackMediaRepName={}".format(
@@ -327,21 +305,13 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
 
         # Media resolution.
         self._media_resolution_lbl = QtWidgets.QLabel("", self._bottomToolBar)
-        self._media_resolution_lbl.setStyleSheet(
-            "color: gray; background-color: transparent; margin-right: 5px"
-        )
-        self._bottomToolBar.insertWidget(
-            playback_style_action, self._media_resolution_lbl
-        )
+        self._media_resolution_lbl.setStyleSheet("color: gray; background-color: transparent; margin-right: 5px")
+        self._bottomToolBar.insertWidget(playback_style_action, self._media_resolution_lbl)
 
         # Media extension.
         self._media_extension_lbl = QtWidgets.QLabel("", self._bottomToolBar)
-        self._media_extension_lbl.setStyleSheet(
-            "color: gray; background-color: transparent"
-        )
-        self._bottomToolBar.insertWidget(
-            playback_style_action, self._media_extension_lbl
-        )
+        self._media_extension_lbl.setStyleSheet("color: gray; background-color: transparent")
+        self._bottomToolBar.insertWidget(playback_style_action, self._media_extension_lbl)
 
     def _populate_media_rep_menu(self, menu, switch_nodes):
         """
@@ -365,9 +335,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         # The menu items are composed of the media rep name, the extension and
         # the resolution.
         for rep in reps_and_source_nodes.keys():
-            source_media_infos = utils.get_common_source_media_infos(
-                reps_and_source_nodes[rep]
-            )
+            source_media_infos = utils.get_common_source_media_infos(reps_and_source_nodes[rep])
 
             action = MediaRepresentationItem(menu)
             action.set_values(
@@ -452,9 +420,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         Note: when there are multiple sources at the current frame then the
         resolution and extension is only shown when they are common to all
         """
-        common_source_media_infos = utils.get_common_source_media_infos(
-            self._current_sources
-        )
+        common_source_media_infos = utils.get_common_source_media_infos(self._current_sources)
 
         self._media_resolution_lbl.setText(common_source_media_infos.resolution)
         self._media_extension_lbl.setText(common_source_media_infos.extension)
@@ -520,9 +486,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         # source group.
         if self._current_sources is None:
             return
-        if (source_deleted in self._current_sources) or (
-            source_deleted + "_source" in self._current_sources
-        ):
+        if (source_deleted in self._current_sources) or (source_deleted + "_source" in self._current_sources):
             self._current_sources = None
 
     def _on_force_update_media_info(self, event):
@@ -553,9 +517,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
           - media-relocated, source-media-rep-activated (media not ready)
           - source-group-complete (media ready)
         """
-        package_logger.debug(
-            "%s in _on_postpone_force_update_media_info" % event.name()
-        )
+        package_logger.debug("%s in _on_postpone_force_update_media_info" % event.name())
 
         event.reject()
         self._force_update_media_info = True

--- a/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep_utils.py
+++ b/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep_utils.py
@@ -120,13 +120,7 @@ def get_extension_from_info_file(info_file):
     """
     Returns the extension from the infos["file"] media info
     """
-    return (
-        ""
-        if not info_file
-        else "URL"
-        if is_url(info_file)
-        else info_file.split(".")[-1].upper()
-    )
+    return "" if not info_file else "URL" if is_url(info_file) else info_file.split(".")[-1].upper()
 
 
 def get_common_source_media_infos(sources):

--- a/src/plugins/rv-packages/node_graph_viz/node_graph_viz.py
+++ b/src/plugins/rv-packages/node_graph_viz/node_graph_viz.py
@@ -17,9 +17,7 @@ try:
     import matplotlib.pyplot as plt
 except:
     print("Exception occurred while importing and initializing matplotlib.")
-    print(
-        "'py-interp -m pip install matplotlib networkx' to install it into RV's environment."
-    )
+    print("'py-interp -m pip install matplotlib networkx' to install it into RV's environment.")
     raise
 
 import itertools
@@ -77,9 +75,7 @@ class RVNodeGraphViz(rv.rvtypes.MinorMode):
 
     def _show_graph(self):
         """Draw and display the graph."""
-        nx.draw_networkx(
-            self.dag, pos=nx.spring_layout(self.dag), with_labels=True, font_size=6
-        )
+        nx.draw_networkx(self.dag, pos=nx.spring_layout(self.dag), with_labels=True, font_size=6)
         plt.axis("off")
         plt.show()
 

--- a/src/plugins/rv-packages/os_dependent_path_conversion/os_dependent_path_conversion_mode.py
+++ b/src/plugins/rv-packages/os_dependent_path_conversion/os_dependent_path_conversion_mode.py
@@ -1,15 +1,15 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
-from rv import rvtypes, commands, rvui
-import platform, re
+# SPDX-License-Identifier: Apache-2.0
+#
+from rv import rvtypes
+import platform
+import re
 
 
 class OSDependentPathConversionModeMinorMode(rvtypes.MinorMode):
     def fixpath(self, event):
-
         #
         #  The contents of the "incoming-source-path" looks like
         #  "filename;;tag".
@@ -21,7 +21,7 @@ class OSDependentPathConversionModeMinorMode(rvtypes.MinorMode):
             try:
                 remainder = m1.group(2) if m1 and m1.group(1) != "" else m2.group(2)
                 final = prefix + remainder
-            except:
+            except Exception:
                 final = path
             return final
 
@@ -45,17 +45,11 @@ class OSDependentPathConversionModeMinorMode(rvtypes.MinorMode):
 
         if len(parts) > 1 and parts[1] == "session":
             if os == "Darwin":
-                outpath = choosePath(
-                    self._macPrefix, self._windowsRE, self._linuxRE, inpath
-                )
+                outpath = choosePath(self._macPrefix, self._windowsRE, self._linuxRE, inpath)
             elif os == "Linux":
-                outpath = choosePath(
-                    self._linuxPrefix, self._windowsRE, self._macRE, inpath
-                )
+                outpath = choosePath(self._linuxPrefix, self._windowsRE, self._macRE, inpath)
             elif os == "Windows":
-                outpath = choosePath(
-                    self._windowsPrefix, self._linuxRE, self._macRE, inpath
-                )
+                outpath = choosePath(self._windowsPrefix, self._linuxRE, self._macRE, inpath)
 
         event.setReturnContent(outpath)
 
@@ -83,20 +77,14 @@ class OSDependentPathConversionModeMinorMode(rvtypes.MinorMode):
         self._windowsRE = re.compile("(%s)(.*)" % self._windowsPrefix)
         self._macRE = re.compile("(%s)(.*)" % self._macPrefix)
 
-        initBindings = [
-            ("incoming-source-path", self.fixpath, "Change path for this platform")
-        ]
+        initBindings = [("incoming-source-path", self.fixpath, "Change path for this platform")]
 
         #
         #  NOTE: All prefix values must be set for any translation
         #  to occur.
         #
 
-        if (
-            self._linuxPrefix == None
-            or self._windowsPrefix == None
-            or self._macPrefix == None
-        ):
+        if self._linuxPrefix is None or self._windowsPrefix is None or self._macPrefix is None:
             initBindings = None
 
         self.init("os-dependent-path-conversion", initBindings, None, None)

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -12,30 +12,20 @@ import opentimelineio as otio
 from rv import commands, extra_commands
 
 
-def hook_function(
-    in_timeline: otio.schemadef.Annotation.Annotation, argument_map: dict | None = None
-) -> None:
+def hook_function(in_timeline: otio.schemadef.Annotation.Annotation, argument_map: dict | None = None) -> None:
     """A hook for the annotation schema"""
 
     try:
         if argument_map["effect_metadata"]:
             effect_metadata = argument_map["effect_metadata"]
-            commands.setIntProperty(
-                "#Session.paintEffects.hold", [effect_metadata.get("hold", 0)]
-            )
-            commands.setIntProperty(
-                "#Session.paintEffects.ghost", [effect_metadata.get("ghost", 0)]
-            )
+            commands.setIntProperty("#Session.paintEffects.hold", [effect_metadata.get("hold", 0)])
+            commands.setIntProperty("#Session.paintEffects.ghost", [effect_metadata.get("ghost", 0)])
         else:
             commands.setIntProperty("#Session.paintEffects.hold", [in_timeline.hold])
             commands.setIntProperty("#Session.paintEffects.ghost", [in_timeline.ghost])
 
-        commands.setIntProperty(
-            "#Session.paintEffects.ghostBefore", [in_timeline.ghost_before]
-        )
-        commands.setIntProperty(
-            "#Session.paintEffects.ghostAfter", [in_timeline.ghost_after]
-        )
+        commands.setIntProperty("#Session.paintEffects.ghostBefore", [in_timeline.ghost_before])
+        commands.setIntProperty("#Session.paintEffects.ghostAfter", [in_timeline.ghost_after])
     except Exception:
         logging.exception("Unable to set Hold and Ghost properties")
 
@@ -44,9 +34,7 @@ def hook_function(
             if isinstance(layer.layer_range, otio.opentime.TimeRange):
                 time_range = layer.layer_range
             else:
-                time_range = otio.opentime.TimeRange(
-                    layer.layer_range["start_time"], layer.layer_range["duration"]
-                )
+                time_range = otio.opentime.TimeRange(layer.layer_range["start_time"], layer.layer_range["duration"])
 
             relative_time = time_range.end_time_inclusive()
             frame = relative_time.to_frames()
@@ -85,28 +73,20 @@ def hook_function(
             if not commands.propertyExists(f"{frame_component}.order"):
                 commands.newProperty(f"{frame_component}.order", commands.StringType, 1)
 
-            commands.insertStringProperty(
-                f"{frame_component}.order", [f"pen:{stroke_id}:{frame}:annotation"]
-            )
+            commands.insertStringProperty(f"{frame_component}.order", [f"pen:{stroke_id}:{frame}:annotation"])
 
             global_scale = argument_map.get("global_scale")
             if global_scale is None:
-                logging.warning(
-                    "Unable to get the global scale, using the aspect ratio of the first media file"
-                )
+                logging.warning("Unable to get the global scale, using the aspect ratio of the first media file")
                 try:
                     media_switch = commands.nodeConnections("MediaTrack")[0][0]
                     media_source_group = commands.nodeConnections(media_switch)[0][0]
-                    first_source_node = extra_commands.nodesInGroupOfType(
-                        media_source_group, "RVFileSource"
-                    )[0]
+                    first_source_node = extra_commands.nodesInGroupOfType(media_source_group, "RVFileSource")[0]
                     media_info = commands.sourceMediaInfo(first_source_node)
                     height = media_info["height"]
                     aspect_ratio = media_info["width"] / height
                 except Exception:
-                    logging.exception(
-                        "Unable to determine aspect ratio, using default value of 16:9"
-                    )
+                    logging.exception("Unable to determine aspect ratio, using default value of 16:9")
                     aspect_ratio = 1920 / 1080
                 finally:
                     scale = aspect_ratio / 16
@@ -127,6 +107,4 @@ def hook_function(
                     points_property,
                     [point.x * global_scale.x, point.y * global_scale.y],
                 )
-                commands.insertFloatProperty(
-                    width_property, [point.width * global_width]
-                )
+                commands.insertFloatProperty(width_property, [point.width * global_width])

--- a/src/plugins/rv-packages/otio_reader/annotation_schema.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_schema.py
@@ -63,13 +63,9 @@ class Annotation(otio.schema.Effect):
     def layers(self, val: list):
         self._layers = val
 
-    hold = otio.core.serializable_field(
-        "hold", required_type=bool, doc=("hold: expects either true or false")
-    )
+    hold = otio.core.serializable_field("hold", required_type=bool, doc=("hold: expects either true or false"))
 
-    ghost = otio.core.serializable_field(
-        "ghost", required_type=bool, doc=("ghost: expects either true or false")
-    )
+    ghost = otio.core.serializable_field("ghost", required_type=bool, doc=("ghost: expects either true or false"))
 
     ghost_before = otio.core.serializable_field(
         "ghost_before", required_type=int, doc=("ghost_before: expects an integer")

--- a/src/plugins/rv-packages/otio_reader/cdlExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/cdlExportHook.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, extra_commands
 import opentimelineio as otio

--- a/src/plugins/rv-packages/otio_reader/cdlHook.py
+++ b/src/plugins/rv-packages/otio_reader/cdlHook.py
@@ -1,10 +1,10 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
-from rv import extra_commands
-from effectHook import *
+# SPDX-License-Identifier: Apache-2.0
+#
+from rv import extra_commands, commands
+from effectHook import set_rv_effect_props, add_otio_metadata
 
 
 def modify_source(source, otio_cdl):

--- a/src/plugins/rv-packages/otio_reader/cdlSchema.py
+++ b/src/plugins/rv-packages/otio_reader/cdlSchema.py
@@ -45,13 +45,9 @@ class CDL(otio.schema.Effect):
         self.power = power
         self.saturation = saturation
 
-    visible = otio.core.serializable_field(
-        "visible", required_type=bool, doc=("Visible: expects either true or false")
-    )
+    visible = otio.core.serializable_field("visible", required_type=bool, doc=("Visible: expects either true or false"))
 
-    _slope = otio.core.serializable_field(
-        "slope", required_type=list, doc=("Slope: expects a list of three floats")
-    )
+    _slope = otio.core.serializable_field("slope", required_type=list, doc=("Slope: expects a list of three floats"))
 
     @property
     def slope(self):
@@ -66,9 +62,7 @@ class CDL(otio.schema.Effect):
                 raise Exception("Invalid slope element type")
         self._slope = val
 
-    _offset = otio.core.serializable_field(
-        "offset", required_type=list, doc=("Offset: expects a list of three floats")
-    )
+    _offset = otio.core.serializable_field("offset", required_type=list, doc=("Offset: expects a list of three floats"))
 
     @property
     def offset(self):
@@ -83,9 +77,7 @@ class CDL(otio.schema.Effect):
                 raise Exception("Invalid offset element type")
         self._offset = val
 
-    _power = otio.core.serializable_field(
-        "power", required_type=list, doc=("Visible: expects a list of three floats")
-    )
+    _power = otio.core.serializable_field("power", required_type=list, doc=("Visible: expects a list of three floats"))
 
     @property
     def power(self):
@@ -100,9 +92,7 @@ class CDL(otio.schema.Effect):
                 raise Exception("Invalid power element type")
         self._power = val
 
-    saturation = otio.core.serializable_field(
-        "saturation", required_type=float, doc=("Saturation: expects a float")
-    )
+    saturation = otio.core.serializable_field("saturation", required_type=float, doc=("Saturation: expects a float"))
 
     def __str__(self):
         return 'CDL("{}", "{}", "{}", "{}", "{}", "{}", "{}")'.format(

--- a/src/plugins/rv-packages/otio_reader/clipHook.py
+++ b/src/plugins/rv-packages/otio_reader/clipHook.py
@@ -1,10 +1,10 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
-from rv import commands
-from effectHook import *
+# SPDX-License-Identifier: Apache-2.0
+#
+from effectHook import *  # noqa: F403
+
 
 # this is an example for clip that can be removed or augmented as required
 def hook_function(in_timeline, argument_map=None):

--- a/src/plugins/rv-packages/otio_reader/compare_hook.py
+++ b/src/plugins/rv-packages/otio_reader/compare_hook.py
@@ -3,14 +3,12 @@ import opentimelineio as otio
 from rv import commands, extra_commands
 
 
-def hook_function(
-    in_timeline: otio.schemadef.Compare.Compare, argument_map: dict | None = None
-) -> None:
+def hook_function(in_timeline: otio.schemadef.Compare.Compare, argument_map: dict | None = None) -> None:
     """A hook for the compare schema"""
     compare_mode = in_timeline.mode
     is_swapped = in_timeline.is_swapped
 
-    match (compare_mode.lower()):
+    match compare_mode.lower():
         case "side_by_side":
             # Only the bounds need to be handled for this mode, and this is done in
             # the Live Review plugin, so nothing to do here
@@ -20,9 +18,7 @@ def hook_function(
             opacity = float(in_timeline.over_with_opacity["opacity"])
 
             sequence_group = argument_map["sequence"]
-            sequence_node = extra_commands.nodesInGroupOfType(
-                sequence_group, "RVSequence"
-            )[0]
+            sequence_node = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[0]
             composite_property = f"{sequence_node}.composite"
 
             effectHook.add_rv_effect_props(
@@ -35,13 +31,9 @@ def hook_function(
 
         case "difference":
             sequence_group = argument_map["sequence"]
-            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[
-                0
-            ]
+            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[0]
             composite_property = f"{sequence}.composite"
-            effectHook.set_rv_effect_props(
-                composite_property, {"inputBlendModes": ["difference"]}
-            )
+            effectHook.set_rv_effect_props(composite_property, {"inputBlendModes": ["difference"]})
 
         case "angular_mask":
             angle_in_radians = in_timeline.angular_mask["angle_in_radians"]
@@ -58,18 +50,12 @@ def hook_function(
                 global_translate_vec = otio.schema.V2d(0.0, 0.0)
                 global_scale_vec = otio.schema.V2d(1.0, 1.0)
 
-                if commands.propertyExists(
-                    f"{transform}.otio.global_translate"
-                ) and commands.propertyExists(f"{transform}.otio.global_scale"):
-                    global_translate = commands.getFloatProperty(
-                        f"{transform}.otio.global_translate"
-                    )
-                    global_scale = commands.getFloatProperty(
-                        f"{transform}.otio.global_scale"
-                    )
-                    global_translate_vec = otio.schema.V2d(
-                        global_translate[0], global_translate[1]
-                    )
+                if commands.propertyExists(f"{transform}.otio.global_translate") and commands.propertyExists(
+                    f"{transform}.otio.global_scale"
+                ):
+                    global_translate = commands.getFloatProperty(f"{transform}.otio.global_translate")
+                    global_scale = commands.getFloatProperty(f"{transform}.otio.global_scale")
+                    global_translate_vec = otio.schema.V2d(global_translate[0], global_translate[1])
                     global_scale_vec = otio.schema.V2d(global_scale[0], global_scale[1])
 
                 translate = commands.getFloatProperty(
@@ -87,9 +73,7 @@ def hook_function(
                 aspect_ratio = 1.0 if height == 0 else media_info["width"] / height
 
                 bounds_size = scale_vec / global_scale_vec
-                bounds_center = (
-                    translate_vec + global_translate_vec
-                ) / global_scale_vec
+                bounds_center = (translate_vec + global_translate_vec) / global_scale_vec
 
                 # Since pivot coordinates are not local to the source,
                 # we must remove the source transformation from them when
@@ -104,9 +88,7 @@ def hook_function(
                 pivot_y += 0.5
 
             sequence_group = argument_map["sequence"]
-            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[
-                0
-            ]
+            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[0]
             composite_property = f"{sequence}.composite"
 
             effectHook.set_rv_effect_props(

--- a/src/plugins/rv-packages/otio_reader/compare_schema.py
+++ b/src/plugins/rv-packages/otio_reader/compare_schema.py
@@ -51,13 +51,9 @@ class Compare(otio.schema.Effect):
         self.secondary_element_id = secondary_element_id
         self.is_swapped = is_swapped
 
-    visible = otio.core.serializable_field(
-        "visible", required_type=bool, doc="visible: expects either true or false"
-    )
+    visible = otio.core.serializable_field("visible", required_type=bool, doc="visible: expects either true or false")
 
-    mode = otio.core.serializable_field(
-        "mode", required_type=str, doc="mode: expects a string"
-    )
+    mode = otio.core.serializable_field("mode", required_type=str, doc="mode: expects a string")
 
     _side_by_side = otio.core.serializable_field(
         "side_by_side",

--- a/src/plugins/rv-packages/otio_reader/customTransitionHook.py
+++ b/src/plugins/rv-packages/otio_reader/customTransitionHook.py
@@ -1,15 +1,13 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands
 
 
 def _create_node(in_transition, context={}):
-    return commands.newNode(
-        "CustomTransition", in_transition.name or "custom_transition"
-    )
+    return commands.newNode("CustomTransition", in_transition.name or "custom_transition")
 
 
 def hook_function(in_timeline, argument_map=None):

--- a/src/plugins/rv-packages/otio_reader/effectHook.py
+++ b/src/plugins/rv-packages/otio_reader/effectHook.py
@@ -23,8 +23,8 @@ ADD_NODE_TYPE_MAP = {
 }
 
 if sys.version_info < (3,):
-    SET_NODE_TYPE_MAP[unicode] = commands.StringType
-    ADD_NODE_TYPE_MAP[unicode] = commands.StringType
+    SET_NODE_TYPE_MAP[unicode] = commands.StringType  # noqa: F821
+    ADD_NODE_TYPE_MAP[unicode] = commands.StringType  # noqa: F821
 
 
 class NoMappingForRvNode(Exception):
@@ -63,9 +63,7 @@ def add_rv_effect_props(node_component, prop_map):
             prop_name = "{}.{}".format(node_component, prop)
             rv_value = _get_rv_value(value)
 
-            commands.newProperty(
-                prop_name, ADD_NODE_TYPE_MAP[type(rv_value[0])], len(rv_value)
-            )
+            commands.newProperty(prop_name, ADD_NODE_TYPE_MAP[type(rv_value[0])], len(rv_value))
             _set_rv_prop(prop_name, rv_value)
 
 
@@ -84,11 +82,7 @@ def add_otio_metadata(node_component, otio_node):
     if otio_node.metadata:
         add_rv_effect_props(
             node_component,
-            {
-                "otio_metadata": otio.core.serialize_json_to_string(
-                    otio_node.metadata, indent=-1
-                )
-            },
+            {"otio_metadata": otio.core.serialize_json_to_string(otio_node.metadata, indent=-1)},
         )
 
 
@@ -110,7 +104,7 @@ def get_otio_metadata(node_component):
 
 
 def _get_rv_value(value):
-    if type(value) == bool:
+    if type(value) is bool:
         return [1] if value is True else [0]
 
     # OTIO returns AnyVector, so ensure anything iterable is a list

--- a/src/plugins/rv-packages/otio_reader/genericEffectHook.py
+++ b/src/plugins/rv-packages/otio_reader/genericEffectHook.py
@@ -1,8 +1,9 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
+
 
 def hook_function(in_timeline, argument_map=None):
     print("Warning: Unhandled effect (named {})".format(in_timeline.effect_name))

--- a/src/plugins/rv-packages/otio_reader/multiRepPostExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/multiRepPostExportHook.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, extra_commands
 import opentimelineio as otio

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -83,9 +83,7 @@ def _run_hook(hook_name, otio_obj, context={}, optional=True):
         return otio.hooks.run(hook_name, otio_obj, context)
     except KeyError:
         if not optional:
-            raise NoMappingForOtioTypeError(
-                str(type(otio_obj)) + " on object: {}".format(otio_obj)
-            )
+            raise NoMappingForOtioTypeError(str(type(otio_obj)) + " on object: {}".format(otio_obj))
 
 
 def create_rv_node_from_otio(otio_obj, context=None):
@@ -100,9 +98,7 @@ def create_rv_node_from_otio(otio_obj, context=None):
     }
 
     if type(otio_obj) in WRITE_TYPE_MAP:
-        process_schema = _run_hook(
-            "pre_hook_{}".format(otio_obj.schema_name()), otio_obj, context
-        )
+        process_schema = _run_hook("pre_hook_{}".format(otio_obj.schema_name()), otio_obj, context)
         if process_schema is False:
             return None
 
@@ -111,9 +107,7 @@ def create_rv_node_from_otio(otio_obj, context=None):
             _run_hook("post_hook_{}".format(otio_obj.schema_name()), otio_obj, context)
         return result
 
-    return _run_hook(
-        "{}_to_rv".format(otio_obj.schema_name()), otio_obj, context, optional=False
-    )
+    return _run_hook("{}_to_rv".format(otio_obj.schema_name()), otio_obj, context, optional=False)
 
 
 def _retime_trx_input(pre_item, post_item, context=None):
@@ -152,9 +146,7 @@ def _create_dissolve(in_dissolve, context=None):
 def _create_custom(in_transition, context=None):
     rv_trx = _run_hook("CustomTransition_to_rv", in_transition, context)
     if not rv_trx:
-        raise NoNodeFromHook(
-            "Custom Transition found but no node was returned from the hook"
-        )
+        raise NoNodeFromHook("Custom Transition found but no node was returned from the hook")
     return rv_trx
 
 
@@ -173,23 +165,15 @@ def _create_transition(pre_item, in_trx, post_item, context=None):
 
     commands.setFloatProperty(rv_trx + ".parameters.startFrame", [1.0], True)
 
-    num_frames = (
-        (in_trx.in_offset + in_trx.out_offset)
-        .rescaled_to(pre_item.trimmed_range().duration.rate)
-        .value
-    )
+    num_frames = (in_trx.in_offset + in_trx.out_offset).rescaled_to(pre_item.trimmed_range().duration.rate).value
 
     in_offset_prop = "{}.otio.in_offset".format(rv_trx)
     commands.newProperty(in_offset_prop, commands.IntType, 1)
     commands.setIntProperty(in_offset_prop, [in_trx.in_offset.to_frames()], True)
 
-    commands.setFloatProperty(
-        rv_trx + ".parameters.numFrames", [float(num_frames)], True
-    )
+    commands.setFloatProperty(rv_trx + ".parameters.numFrames", [float(num_frames)], True)
 
-    commands.setFloatProperty(
-        rv_trx + ".output.fps", [float(pre_item.trimmed_range().duration.rate)], True
-    )
+    commands.setFloatProperty(rv_trx + ".output.fps", [float(pre_item.trimmed_range().duration.rate)], True)
 
     trx_inputs = []
     with set_context(context, transition=rv_trx):
@@ -221,9 +205,7 @@ def _create_stack(in_stack, context=None):
 
     # disable reversed order blending so the top node is on top
     stack_node = extra_commands.nodesInGroupOfType(new_stack, "RVStack")[0]
-    commands.setIntProperty(
-        "{}.mode.supportReversedOrderBlending".format(stack_node), [0]
-    )
+    commands.setIntProperty("{}.mode.supportReversedOrderBlending".format(stack_node), [0])
 
     return new_stack
 
@@ -241,9 +223,7 @@ def _create_track(in_seq, context=None):
 
         edl_time = context.get("global_start_time")
         if not edl_time and len(items_to_serialize) > 0:
-            edl_time = otio.opentime.RationalTime(
-                0, items_to_serialize[0].trimmed_range().start_time.rate
-            )
+            edl_time = otio.opentime.RationalTime(0, items_to_serialize[0].trimmed_range().start_time.rate)
         edl = {
             "in": [],
             "out": [],
@@ -281,9 +261,7 @@ def _create_track(in_seq, context=None):
         _add_metadata_to_node(in_seq, new_seq)
 
         # disable reversed order blending so the top node is on top
-        commands.setIntProperty(
-            "{}.mode.supportReversedOrderBlending".format(seq_node), [0]
-        )
+        commands.setIntProperty("{}.mode.supportReversedOrderBlending".format(seq_node), [0])
 
     return new_seq
 
@@ -297,9 +275,7 @@ def _get_global_transform(tl, context) -> dict:
             try:
                 # get active clip and start prelodaing the movie in the background
                 if isinstance(clip.media_reference, otio.schema.ExternalReference):
-                    media_path = _get_media_path(
-                        str(clip.media_reference.target_url), context
-                    )
+                    media_path = _get_media_path(str(clip.media_reference.target_url), context)
                     # print("PRELOADING MOVIE: {}".format(media_path))
                     commands.startPreloadingMedia(media_path)
 
@@ -365,9 +341,7 @@ def _set_sequence_edl(sequence, edl_time, edl):
     commands.setIntProperty("{}.edl.in".format(sequence), edl["in"])
     commands.setIntProperty("{}.edl.out".format(sequence), edl["out"])
     commands.setIntProperty("{}.edl.frame".format(sequence), edl["frame"])
-    commands.setIntProperty(
-        "{}.edl.source".format(sequence), list(range(len(edl["frame"])))
-    )
+    commands.setIntProperty("{}.edl.source".format(sequence), list(range(len(edl["frame"]))))
     commands.setIntProperty("{}.mode.autoEDL".format(sequence), [0])
 
 
@@ -375,22 +349,13 @@ def _get_in_out_frame(it, range_to_read, seq_rate=None):
     in_frame = out_frame = None
 
     if hasattr(it, "media_reference") and it.media_reference:
-        if (
-            isinstance(it.media_reference, otio.schema.ImageSequenceReference)
-            and it.media_reference.available_range
-        ):
-            in_frame, out_frame = it.media_reference.frame_range_for_time_range(
-                range_to_read
-            )
+        if isinstance(it.media_reference, otio.schema.ImageSequenceReference) and it.media_reference.available_range:
+            in_frame, out_frame = it.media_reference.frame_range_for_time_range(range_to_read)
 
     if not in_frame and not out_frame:
         rate = seq_rate if seq_rate is not None else range_to_read.duration.rate
-        in_frame = otio.opentime.to_frames(
-            range_to_read.start_time.rescaled_to(rate), rate=rate
-        )
-        out_frame = otio.opentime.to_frames(
-            range_to_read.end_time_inclusive().rescaled_to(rate), rate=rate
-        )
+        in_frame = otio.opentime.to_frames(range_to_read.start_time.rescaled_to(rate), rate=rate)
+        out_frame = otio.opentime.to_frames(range_to_read.end_time_inclusive().rescaled_to(rate), rate=rate)
     return (in_frame, out_frame)
 
 
@@ -444,11 +409,7 @@ def _create_media(media_ref, trimmed_range, context=None):
     elif isinstance(media_ref, otio.schema.ImageSequenceReference):
         return [
             _get_media_path(
-                str(
-                    media_ref.abstract_target_url(
-                        symbol="%0{n}d".format(n=media_ref.frame_zero_padding)
-                    )
-                ),
+                str(media_ref.abstract_target_url(symbol="%0{n}d".format(n=media_ref.frame_zero_padding))),
                 context,
             )
         ]
@@ -486,9 +447,7 @@ def _create_sources(item, context=None):
             error_media = _create_movieproc(item.trimmed_range(), "smptebars")
             src = commands.addSourceVerbose([error_media])
 
-        commands.setFloatProperty(
-            src + ".group.fps", [item.trimmed_range().duration.rate]
-        )
+        commands.setFloatProperty(src + ".group.fps", [item.trimmed_range().duration.rate])
 
         _add_metadata_to_node(media_ref, src)
         active_src = cmd_args[0] if cmd_args else src
@@ -498,17 +457,11 @@ def _create_sources(item, context=None):
         return src
 
     if isinstance(item, otio.schema.Gap):
-        src = commands.addSourceVerbose(
-            [_create_movieproc(item.trimmed_range(), "blank")]
-        )
+        src = commands.addSourceVerbose([_create_movieproc(item.trimmed_range(), "blank")])
         return commands.nodeGroup(src), src
 
     active_source = None
-    active_key = (
-        item.active_media_reference_key
-        if hasattr(item, "active_media_reference_key")
-        else None
-    )
+    active_key = item.active_media_reference_key if hasattr(item, "active_media_reference_key") else None
     if hasattr(item, "media_reference") and item.media_reference:
         active_source = add_media(
             item.media_reference,
@@ -587,11 +540,7 @@ def _create_item(it, context=None):
         context,
         src=active_src,
         source_group=commands.nodeGroup(active_src),
-        switch_group=(
-            src_or_switch_group
-            if commands.nodeType(src_or_switch_group) == "RVSwitchGroup"
-            else None
-        ),
+        switch_group=(src_or_switch_group if commands.nodeType(src_or_switch_group) == "RVSwitchGroup" else None),
     ):
         if context.get("transition"):
             _add_transition_timings(it, range_to_read, src_or_switch_group)
@@ -641,12 +590,8 @@ def _add_markers(it, node):
             [color for rgba in colors for color in rgba],
             True,
         )
-        commands.newProperty(
-            "{}.markers.otio_metadata".format(node), commands.StringType, 1
-        )
-        commands.setStringProperty(
-            "{}.markers.otio_metadata".format(node), metadata, True
-        )
+        commands.newProperty("{}.markers.otio_metadata".format(node), commands.StringType, 1)
+        commands.setStringProperty("{}.markers.otio_metadata".format(node), metadata, True)
 
 
 def _get_color_from_name(name, defaultColor="PURPLE"):
@@ -695,9 +640,7 @@ def _add_source_bounds(media_ref, src, active_src, context=None):
         height = media_info["height"]
         aspect_ratio = media_info["width"] / height
     except Exception:
-        logging.exception(
-            "Unable to determine aspect ratio, using default value of 16:9"
-        )
+        logging.exception("Unable to determine aspect ratio, using default value of 16:9")
         aspect_ratio = 1920 / 1080
 
     translate = bounds.center() * global_scale - global_translate
@@ -705,21 +648,13 @@ def _add_source_bounds(media_ref, src, active_src, context=None):
 
     transform_node = extra_commands.associatedNode("RVTransform2D", src)
 
-    commands.setFloatProperty(
-        "{}.transform.scale".format(transform_node), [scale.x / aspect_ratio, scale.y]
-    )
-    commands.setFloatProperty(
-        "{}.transform.translate".format(transform_node), [translate.x, translate.y]
-    )
+    commands.setFloatProperty("{}.transform.scale".format(transform_node), [scale.x / aspect_ratio, scale.y])
+    commands.setFloatProperty("{}.transform.translate".format(transform_node), [translate.x, translate.y])
 
     # write the bounds global_scale and global_translate to the node so we can
     # preserve the original values if we round-trip
-    commands.newProperty(
-        "{}.otio.global_scale".format(transform_node), commands.FloatType, 2
-    )
-    commands.newProperty(
-        "{}.otio.global_translate".format(transform_node), commands.FloatType, 2
-    )
+    commands.newProperty("{}.otio.global_scale".format(transform_node), commands.FloatType, 2)
+    commands.newProperty("{}.otio.global_translate".format(transform_node), commands.FloatType, 2)
     commands.setFloatProperty(
         "{}.otio.global_scale".format(transform_node),
         [global_scale.x, global_scale.y],

--- a/src/plugins/rv-packages/otio_reader/otio_reader_plugin.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader_plugin.py
@@ -148,18 +148,14 @@ class ExampleOTIOReaderPlugin(rvtypes.MinorMode):
         Adds OTIO to Open File dialog filters
         """
         event.reject()
-        event.setReturnContent(
-            "{}:{}".format(event.returnContents(), "otio;OpenTimelineIO")
-        )
+        event.setReturnContent("{}:{}".format(event.returnContents(), "otio;OpenTimelineIO"))
 
     def otio_export(self, event):
         """
         Exports the currently viewed node to the OTIO file from the event
         """
         event.reject()
-        otio_timeline = otio_writer.write_otio_file(
-            commands.viewNode(), event.contents()
-        )
+        otio_writer.write_otio_file(commands.viewNode(), event.contents())
 
     def expand_sources(self):
         """
@@ -179,11 +175,7 @@ class ExampleOTIOReaderPlugin(rvtypes.MinorMode):
                     continue
 
                 # get the source file name
-                paths = [
-                    info["file"]
-                    for info in commands.sourceMediaInfoList(src)
-                    if "file" in info
-                ]
+                paths = [info["file"] for info in commands.sourceMediaInfoList(src) if "file" in info]
                 for info_path in paths:
                     # Looking for: 'blank,otioFile=/foo.otio.movieproc'
                     parts = info_path.split("=", 1)
@@ -223,16 +215,12 @@ def _remove_source_from_views(source_group):
 
 
 def createMode():
-    support_files_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "..", "SupportFiles", "otio_reader"
-    )
+    support_files_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "SupportFiles", "otio_reader")
 
     manifest_path = os.environ.get("OTIO_PLUGIN_MANIFEST_PATH", "")
     if manifest_path:
         manifest_path += os.pathsep
-    os.environ["OTIO_PLUGIN_MANIFEST_PATH"] = manifest_path + os.path.join(
-        support_files_path, "manifest.json"
-    )
+    os.environ["OTIO_PLUGIN_MANIFEST_PATH"] = manifest_path + os.path.join(support_files_path, "manifest.json")
     sys.path.append(support_files_path)
 
     return ExampleOTIOReaderPlugin()

--- a/src/plugins/rv-packages/otio_reader/paint_schema.py
+++ b/src/plugins/rv-packages/otio_reader/paint_schema.py
@@ -51,9 +51,7 @@ class Paint(otio.core.SerializableObject):
         self.layer_range = layer_range
         self.visible = visible
 
-    name = otio.core.serializable_field(
-        "name", required_type=str, doc=("name: expects a string")
-    )
+    name = otio.core.serializable_field("name", required_type=str, doc=("name: expects a string"))
 
     _points = otio.core.serializable_field(
         "points", required_type=list, doc=("points: expects a list of point objects")
@@ -67,9 +65,7 @@ class Paint(otio.core.SerializableObject):
     def points(self, val: list):
         self._points = val
 
-    _rgba = otio.core.serializable_field(
-        "rgba", required_type=list, doc=("rgba: expects a list of four floats")
-    )
+    _rgba = otio.core.serializable_field("rgba", required_type=list, doc=("rgba: expects a list of four floats"))
 
     @property
     def rgba(self) -> list:
@@ -79,13 +75,9 @@ class Paint(otio.core.SerializableObject):
     def rgba(self, val: list) -> None:
         self._rgba = val
 
-    type = otio.core.serializable_field(
-        "type", required_type=str, doc=("type: expects a string")
-    )
+    type = otio.core.serializable_field("type", required_type=str, doc=("type: expects a string"))
 
-    brush = otio.core.serializable_field(
-        "brush", required_type=str, doc=("brush: expects a string")
-    )
+    brush = otio.core.serializable_field("brush", required_type=str, doc=("brush: expects a string"))
 
     _layer_range = otio.core.serializable_field(
         "layer_range",
@@ -101,9 +93,7 @@ class Paint(otio.core.SerializableObject):
     def layer_range(self, val):
         self._layer_range = val
 
-    visible = otio.core.serializable_field(
-        "visible", required_type=bool, doc=("visible: expects either true or false")
-    )
+    visible = otio.core.serializable_field("visible", required_type=bool, doc=("visible: expects either true or false"))
 
     def __str__(self) -> str:
         return (

--- a/src/plugins/rv-packages/otio_reader/point_schema.py
+++ b/src/plugins/rv-packages/otio_reader/point_schema.py
@@ -31,30 +31,20 @@ class Point(otio.core.SerializableObject):
     _serializable_label = "Point.1"
     _name = "Point"
 
-    def __init__(
-        self, width: float | None = None, x: float | None = None, y: float | None = None
-    ) -> None:
+    def __init__(self, width: float | None = None, x: float | None = None, y: float | None = None) -> None:
         super().__init__()
         self.width = width
         self.x = x
         self.y = y
 
-    width = otio.core.serializable_field(
-        "width", required_type=float, doc=("width: expects a float")
-    )
+    width = otio.core.serializable_field("width", required_type=float, doc=("width: expects a float"))
 
-    x = otio.core.serializable_field(
-        "x", required_type=float, doc=("x: expects a float")
-    )
+    x = otio.core.serializable_field("x", required_type=float, doc=("x: expects a float"))
 
-    y = otio.core.serializable_field(
-        "y", required_type=float, doc=("y: expects a float")
-    )
+    y = otio.core.serializable_field("y", required_type=float, doc=("y: expects a float"))
 
     def __str__(self) -> str:
         return f"Point({self.width}, {self.x}, {self.y})"
 
     def __repr__(self) -> str:
-        return (
-            f"otio.schema.Point(width={self.width!r}, x={self.x!r}, " f"y={self.y!r})"
-        )
+        return f"otio.schema.Point(width={self.width!r}, x={self.x!r}, y={self.y!r})"

--- a/src/plugins/rv-packages/otio_reader/retimeExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/retimeExportHook.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, extra_commands
 import opentimelineio as otio
@@ -24,9 +24,7 @@ def hook_function(in_timeline, argument_map):
     scalar = 1 / commands.getFloatProperty("{}.audio.scale".format(rv_node_name))[0]
 
     if is_close(scalar, 1.0):
-        scalar = (
-            1 / commands.getFloatProperty("{}.visual.scale".format(rv_node_name))[0]
-        )
+        scalar = 1 / commands.getFloatProperty("{}.visual.scale".format(rv_node_name))[0]
 
     key_frames = commands.getIntProperty("{}.warp.keyFrames".format(rv_node_name))
 
@@ -40,6 +38,4 @@ def hook_function(in_timeline, argument_map):
         return otio.schema.FreezeFrame(
             name=extra_commands.uiName(rv_node_name),
         )
-    return otio.schema.LinearTimeWarp(
-        name=extra_commands.uiName(rv_node_name), time_scalar=scalar
-    )
+    return otio.schema.LinearTimeWarp(name=extra_commands.uiName(rv_node_name), time_scalar=scalar)

--- a/src/plugins/rv-packages/otio_reader/sourcePostExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/sourcePostExportHook.py
@@ -1,10 +1,10 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, extra_commands
-from effectHook import *
+from effectHook import get_otio_metadata
 import opentimelineio as otio
 
 
@@ -24,9 +24,7 @@ def hook_function(in_timeline, argument_map):
             slope=commands.getFloatProperty("{}.CDL.slope".format(linearize)),
             power=commands.getFloatProperty("{}.CDL.power".format(linearize)),
             offset=commands.getFloatProperty("{}.CDL.offset".format(linearize)),
-            saturation=commands.getFloatProperty("{}.CDL.saturation".format(linearize))[
-                0
-            ],
+            saturation=commands.getFloatProperty("{}.CDL.saturation".format(linearize))[0],
             visible=True,
         )
 
@@ -40,18 +38,12 @@ def hook_function(in_timeline, argument_map):
             global_translate_vec = otio.schema.V2d(0.0, 0.0)
             global_scale_vec = otio.schema.V2d(1.0, 1.0)
 
-            if commands.propertyExists(
-                "{}.otio.global_translate".format(transform)
-            ) and commands.propertyExists("{}.otio.global_scale".format(transform)):
-                global_translate = commands.getFloatProperty(
-                    "{}.otio.global_translate".format(transform)
-                )
-                global_scale = commands.getFloatProperty(
-                    "{}.otio.global_scale".format(transform)
-                )
-                global_translate_vec = otio.schema.V2d(
-                    global_translate[0], global_translate[1]
-                )
+            if commands.propertyExists("{}.otio.global_translate".format(transform)) and commands.propertyExists(
+                "{}.otio.global_scale".format(transform)
+            ):
+                global_translate = commands.getFloatProperty("{}.otio.global_translate".format(transform))
+                global_scale = commands.getFloatProperty("{}.otio.global_scale".format(transform))
+                global_translate_vec = otio.schema.V2d(global_translate[0], global_translate[1])
                 global_scale_vec = otio.schema.V2d(global_scale[0], global_scale[1])
 
             translate = commands.getFloatProperty(

--- a/src/plugins/rv-packages/otio_reader/timeWarpHook.py
+++ b/src/plugins/rv-packages/otio_reader/timeWarpHook.py
@@ -1,12 +1,12 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import sys
 
 from rv import commands
-from effectHook import *
+from effectHook import set_rv_effect_props
 
 
 def hook_function(in_timeline, argument_map=None):

--- a/src/plugins/rv-packages/pyhello/pyhello.py
+++ b/src/plugins/rv-packages/pyhello/pyhello.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import rvtypes, commands
 

--- a/src/plugins/rv-packages/rvnuke/rvNetwork.py
+++ b/src/plugins/rv-packages/rvnuke/rvNetwork.py
@@ -12,7 +12,7 @@ import time
 import os
 
 doDebug = False
-if os.getenv("RV_NUKE_DEBUG") != None:
+if os.getenv("RV_NUKE_DEBUG") is not None:
     doDebug = True
 
 
@@ -74,9 +74,7 @@ class RvCommunicator:
 
         try:
             greeting = "%s rvController" % self.name
-            self.sock.sendall(
-                b"NEWGREETING %d %s" % (len(greeting), greeting.encode("utf-8"))
-            )
+            self.sock.sendall(b"NEWGREETING %d %s" % (len(greeting), greeting.encode("utf-8")))
             if self.noPingPong:
                 self.sock.sendall(b"PINGPONGCONTROL 1 0")
         except socket.error as msg:
@@ -151,8 +149,7 @@ class RvCommunicator:
         except socket.error as msg:
             if (
                 msg.strerror != "Resource temporarily unavailable"
-                and msg.strerror
-                != "A non-blocking socket operation could not be completed immediately"
+                and msg.strerror != "A non-blocking socket operation could not be completed immediately"
                 and msg.errno != 10035
             ):
                 print("ERROR: peek for messages failed: %s\n" % msg, file=sys.stderr)
@@ -174,7 +171,6 @@ class RvCommunicator:
         return field
 
     def _receiveSingleMessage(self):
-
         messType = 0
         messContents = 0
 
@@ -260,7 +256,6 @@ class RvCommunicator:
         self._processEvents()
 
     def _processEvents(self, processReturnOnly=False):
-
         while 1:
             noMessage = True
             while noMessage:
@@ -283,7 +278,7 @@ class RvCommunicator:
                     try:
                         self.sock.shutdown(socket.SHUT_RDWR)
                         self.sock.close()
-                    except:
+                    except Exception:
                         pass
                     self.connected = False
                     return ""
@@ -299,20 +294,13 @@ class RvCommunicator:
                             file=sys.stderr,
                         )
                         return ""
-                elif (
-                    len(self.eventQueue) == 0
-                    or (event, contents) != self.eventQueue[-1:]
-                ):
+                elif len(self.eventQueue) == 0 or (event, contents) != self.eventQueue[-1:]:
                     self.eventQueue.append((event, contents))
 
             elif messType == "PING":
                 self.sock.sendall(b"PONG 1 p")
 
-            elif (
-                messType == "GREETING"
-                or messType == "NEWGREETING"
-                or messType == "PONG"
-            ):
+            elif messType == "GREETING" or messType == "NEWGREETING" or messType == "PONG":
                 #   ignore
                 pass
             else:

--- a/src/plugins/rv-packages/stereo_autoload/stereo_autoload.py
+++ b/src/plugins/rv-packages/stereo_autoload/stereo_autoload.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from __future__ import print_function
 
@@ -27,17 +27,10 @@ class StereoAutoloadMode(rvtypes.MinorMode):
             )
         )
 
-        self._autoLoadStereo = bool(
-            commands.readSettings("stereo_autoload", "autoStereo", False)
-        )
-        self._autoLoadAlways = bool(
-            commands.readSettings("stereo_autoload", "autoAlways", False)
-        )
+        self._autoLoadStereo = bool(commands.readSettings("stereo_autoload", "autoStereo", False))
+        self._autoLoadAlways = bool(commands.readSettings("stereo_autoload", "autoAlways", False))
 
-        deb(
-            "    after read: %s %s\n"
-            % (str(self._autoLoadStereo), str(self._autoLoadAlways))
-        )
+        deb("    after read: %s %s\n" % (str(self._autoLoadStereo), str(self._autoLoadAlways)))
 
     def writePrefs(self):
         deb("writing settings %s %s\n" % (self._autoLoadStereo, self._autoLoadAlways))
@@ -76,8 +69,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
             elems = val.split(":")
             if len(elems) % 2 != 0:
                 print(
-                    "ERROR: eyes env var '%s' does not have even number of elements.\n"
-                    % varName,
+                    "ERROR: eyes env var '%s' does not have even number of elements.\n" % varName,
                     file=sys.stderr,
                 )
                 return
@@ -127,7 +119,6 @@ class StereoAutoloadMode(rvtypes.MinorMode):
         return (nviews, leftMedia)
 
     def swapLeftForRight(self, leftMedia):
-
         rightMedia = leftMedia
         for pair in self._pairs:
             rightMedia = re.sub(
@@ -152,7 +143,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
                 rightMedia,
             )
 
-        if not rightMedia in ret:
+        if rightMedia not in ret:
             ret.append(rightMedia)
 
         #
@@ -166,7 +157,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
                 rightMedia,
             )
 
-        if not rightMedia in ret:
+        if rightMedia not in ret:
             ret.append(rightMedia)
 
         return ret
@@ -206,9 +197,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
 
         if not rightMedia:
             for m in rightMediaList:
-                print(
-                    "INFO: Right eye media '%s' does not exist\n" % m, file=sys.stderr
-                )
+                print("INFO: Right eye media '%s' does not exist\n" % m, file=sys.stderr)
             return
 
         #
@@ -228,9 +217,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
             self.updateSource(s, "force")
 
     def viewStereoOn(self):
-        return (
-            "off" != commands.getStringProperty("#RVDisplayStereo.stereo.type", 0, 1)[0]
-        )
+        return "off" != commands.getStringProperty("#RVDisplayStereo.stereo.type", 0, 1)[0]
 
     def presentationStereoOn(self):
         s = commands.videoState()
@@ -313,7 +300,6 @@ class StereoAutoloadMode(rvtypes.MinorMode):
             self.updateAllSources()
 
     def __init__(self):
-
         rvtypes.MinorMode.__init__(self)
 
         self.initStereoPairs()

--- a/src/plugins/rv-packages/stereo_disassembly/stereo_disassembly.py
+++ b/src/plugins/rv-packages/stereo_disassembly/stereo_disassembly.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from __future__ import print_function
 
@@ -9,11 +9,8 @@ from rv import commands as rvc
 from rv import extra_commands as rve
 from rv import rvtypes as rvt
 
-import rv.runtime
 
-import os
 import sys
-import re
 
 
 def deb(s):
@@ -46,23 +43,17 @@ class StereoDisMode(rvt.MinorMode):
         return nodeType
 
     def readPrefs(self):
-
-        self._expectTopBot = rvc.readSettings(
-            "stereo_disassembly", "expectTopBot", True
-        )
+        self._expectTopBot = rvc.readSettings("stereo_disassembly", "expectTopBot", True)
         self._swapEyes = rvc.readSettings("stereo_disassembly", "swapEyes", True)
         self._squeezed = rvc.readSettings("stereo_disassembly", "squeezed", True)
 
     def writePrefs(self):
-
         rvc.writeSettings("stereo_disassembly", "expectTopBot", self._expectTopBot)
         rvc.writeSettings("stereo_disassembly", "swapEyes", self._swapEyes)
         rvc.writeSettings("stereo_disassembly", "squeezed", self._squeezed)
 
     def addDisNode(self, event):
-
         for pg in linPipeGroups():
-
             deb("addDisNode: checking g %s hasSD %s" % (pg, str(groupHasStereoDis(pg))))
 
             if not groupHasStereoDis(pg):
@@ -102,13 +93,8 @@ class StereoDisMode(rvt.MinorMode):
                     rvc.setIntProperty(sd + ".output.size", size, True)
 
     def removeDisNode(self, event):
-
         for pg in linPipeGroups():
-
-            deb(
-                "removeDisNode: checking g %s hasSD %s"
-                % (pg, str(groupHasStereoDis(pg)))
-            )
+            deb("removeDisNode: checking g %s hasSD %s" % (pg, str(groupHasStereoDis(pg))))
 
             if groupHasStereoDis(pg):
                 sd = stereoDisOfGroup(pg)
@@ -120,28 +106,22 @@ class StereoDisMode(rvt.MinorMode):
                 rvc.setStringProperty(pg + ".pipeline.nodes", newNodes, True)
 
     def toggleTopBotPref(self, event):
-
         self._expectTopBot = not self._expectTopBot
         self.writePrefs()
 
     def toggleSwapEyesPref(self, event):
-
         self._swapEyes = not self._swapEyes
         self.writePrefs()
 
     def toggleSqueezed(self, event):
-
         self._squeezed = not self._squeezed
         self.writePrefs()
 
     def disabledMenuState(self):
-
         return rvc.DisabledMenuState
 
     def noDisNodesState(self):
-
         for pg in linPipeGroups():
-
             deb("checking g %s hasSD %s" % (pg, str(groupHasStereoDis(pg))))
 
             if not groupHasStereoDis(pg):
@@ -150,7 +130,6 @@ class StereoDisMode(rvt.MinorMode):
         return rvc.DisabledMenuState
 
     def haveDisNodesState(self):
-
         for pg in linPipeGroups():
             if groupHasStereoDis(pg):
                 return rvc.UncheckedMenuState
@@ -158,28 +137,24 @@ class StereoDisMode(rvt.MinorMode):
         return rvc.DisabledMenuState
 
     def expectTopBotState(self):
-
         if self._expectTopBot:
             return rvc.CheckedMenuState
 
         return rvc.UncheckedMenuState
 
     def swapEyesState(self):
-
         if self._swapEyes:
             return rvc.CheckedMenuState
 
         return rvc.UncheckedMenuState
 
     def squeezedState(self):
-
         if not self._squeezed:
             return rvc.CheckedMenuState
 
         return rvc.UncheckedMenuState
 
     def __init__(self):
-
         deb("__init__")
         rvt.MinorMode.__init__(self)
 
@@ -243,5 +218,4 @@ class StereoDisMode(rvt.MinorMode):
 
 
 def createMode():
-
     return StereoDisMode()


### PR DESCRIPTION
### Lint and format Python code with Ruff

### Summarize your change.

- [X] Add `ruff.toml` to the project root
- [X] Run `ruff check --fix` on all Python files to lint and fix linting issues
- [X] Run `ruff format` on all Python files to format the Python code
- [X] Add Ruff to pre-commit-config to lint and format code on commit
- [X] Add steps to validate all Python code is correctly linted and formatted in the CI

Note that multiple files had too many issues that would need to manually be reviewed to follow best practices and pass Ruff linting rules. The idea here was not to fix everything but rather to add tools to make working on this project easier. For that reason, these files were added to the exclude section of `ruff.toml`. Since some files were added recently, we might want to take the time to fix them properly and make sure the code is following Python's conventions.

### Describe the reason for the change.

The project had a formatter but no linter. Ruff is a tool that can do exactly what Black was doing as a formatter while also being able to lint and fix the code at the same time. 