### PR TITLE
Add Ruff linter and formatter

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,8 @@
 # Format all C++ files with clang-format
 9d6b1be0e431a570d1475ceb4293106669b7c20c
+
+# Lint all Python files with Ruff
+53ef69e9d4e6749aae189b56c2e66f73fb7fc2d4
+
+# Format all Python files with Ruff
+a2cc106bb29a20d0ab268173f335adaebfe099c4

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,7 +2,7 @@
 9d6b1be0e431a570d1475ceb4293106669b7c20c
 
 # Lint all Python files with Ruff
-53ef69e9d4e6749aae189b56c2e66f73fb7fc2d4
+534a7f084f444df93678061a682068f589889737
 
 # Format all Python files with Ruff
-a2cc106bb29a20d0ab268173f335adaebfe099c4
+c2f5280d213a71e4b20da0025bfa705bfc7fab1b

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,11 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install ruff
       - name: Run Ruff check
+        # Check if all the files are linted correctly
+        # Output errors as inline annotations
         run: ruff check --output-format=github
       - name: Run Ruff format
+        # Check if all the files are formatted correctly
         run: ruff format --check
   rocky-linux:
     if : ${{ github.repository_owner == 'AcademySoftwareFoundation' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,23 @@ env:
   WINDOWS_QT6_ARCHIVES: 'd3dcompiler_47 opengl32sw qtbase qtdeclarative qtsvg qttools qttranslations'
 
 jobs:
+  lint-format:
+    name: "Lint and Format"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff check
+        run: ruff check --output-format=github
+      - name: Run Ruff format
+        run: ruff format --check
   rocky-linux:
     if : ${{ github.repository_owner == 'AcademySoftwareFoundation' }}
     name: 'Rocky Linux ${{ matrix.rocky-version }} ${{ matrix.vfx-platform }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,13 @@ repos:
     hooks:
       - id: cmake-format
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.2
+    hooks:
+      - id: ruff-check
+        args: [ --fix ]
+      - id: ruff-format
+
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v19.1.4'
     hooks:

--- a/docs/build_system/config_common_build.md
+++ b/docs/build_system/config_common_build.md
@@ -48,7 +48,6 @@ source rvcmds.sh
 
 By default, the commands and aliases will be configured for a release build, but you can swith between debug and release configurations by calling "rvdebug" or "rvrelease"
 
-
 #### 1.4 First-time build only: rvbootstrap
 
 This step only needs to be done on a freshly cloned git repository, after you source rvcmds.sh. 
@@ -73,7 +72,6 @@ rvbootstrap
 Note 1: launch the default optimized build unless you have a reason to want the unoptimized debug build.
 
 Note 2: It's possible that after boostrapping the build fails. If this happens, building again often fixes the problem. From the command line, call rvmk to complete the build.
-
 
 ### 2. Building Open RV after the first time
 
@@ -103,7 +101,6 @@ rvmk
 ```
 ````
 
-
 #### 2.2 Rebuilding the dependencies
 
 Building the source dependencies is done automatically the first time we build Open RV with "rvbootstrap/d" so you typically never need to rebuild them. In the rare event you would need to fix a bug or update one such third-party source dependency, dependencies can be rebuild this way:
@@ -117,7 +114,6 @@ rvbuildt dependencies
 rvbuildt dependencies
 ```
 ````
-
 
 ### 3. Starting the Open RV executable
 
@@ -150,8 +146,7 @@ OpenRV/_build_debug/stage/app/RV.app/Contents/MacOS/RV
 
 You can access the directory where the compiled binary is located by using the command "rvappdir" which should "cd" right into the correct directory (release or debug).
 
-
-### 4. Contributing to Open RV 
+### 4. Contributing to Open RV
 
 Before you can submit any code for a pull request, this repository uses the `pre-commit` tool to perform basic checks and to execute formatting hooks before a commit. To install the pre-commit hooks, run the following command:
 
@@ -180,13 +175,26 @@ Although not strictly enforced, it is highly suggested to enable clang-tidy loca
     ln -s _build/compile_commands.json compile_commands.json
     ```
 
-### 6. Cleaning up your build directory
+### 6. Ruff
+
+Ruff is used in this project for both Python linting and formatting, and its checks are enforced through a pre-commit hook and our Github actions CI. You can run Ruff through the `pre-commit` tool with the following commands:
+
+```bash
+pre-commit run ruff-check --fix --all-files # Lint and fix issues found on all files
+pre-commit run ruff-format --all-files # Format all files
+```
+
+For more details on the Ruff commands you can run, please take a look at the [Ruff documentation](https://docs.astral.sh/ruff/).
+
+It is highly recommended to also add Ruff to your IDE. For VSCode users, you can activate Ruff by installing the [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff). For other IDEs, please refer to the [Editor Integration page](https://docs.astral.sh/ruff/editors/setup/).
+
+### 7. Cleaning up your build directory
 
 To clean your build directory and restart from a clean slate, use the `rvclean` alias, or delete the `_build` (or `_build_debug`) directory.
 
 To keep your third-party build between cleanups, set: `-DRV_DEPS_BASE_DIR=/path/to/third/party`.
 
-### 7. Installing Blackmagicdesign&reg; Video Output Support (Optional)
+### 8. Installing Blackmagicdesign&reg; Video Output Support (Optional)
 
 Download the Blackmagicdesign&reg; SDK to add Blackmagicdesign&reg; output capability to Open RV (optional): https://www.blackmagicdesign.com/desktopvideo_sdk<br>
 Then set RV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH to the path of the downloaded zip file on the rvcfg line.<br>
@@ -195,13 +203,13 @@ Example:
 rvcfg -DRV_DEPS_BMD_DECKLINK_SDK_ZIP_PATH='<downloads_path>/Blackmagic_DeckLink_SDK_14.1.zip'
 ```
 
-### 8. NDI&reg; Video Output Support (Optional)
+### 9. NDI&reg; Video Output Support (Optional)
 
 Download and install the NDI&reg; SDK to add NDI&reg; output capability to Open RV (optional): https://ndi.video/<br>
 
 Installing the NDI SDK must be done before building Open RV for the first time (if you add it later, it's easiest to just delete your build folder, and execute the first-time build procedure again)
 
-### 9. How to enable non-free FFmpeg codecs
+### 10. How to enable non-free FFmpeg codecs
 
 Legal Notice: Non-free FFmpeg codecs are disabled by default. Please check with your legal department whether you have the proper licenses and rights to use these codecs. 
 ASWF is not responsible for any unlicensed use of these codecs.
@@ -214,9 +222,7 @@ For example:
 rvcfg -DRV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE="aac;hevc" -DRV_FFMPEG_NON_FREE_ENCODERS_TO_ENABLE="aac"
 ```
 
-
-
-### 10. Apple ProRes on Apple Silicon
+### 11. Apple ProRes on Apple Silicon
 
 On Apple Silicon machines, Open RV supports hardware decoding through Apple's VideoToolbox framework. This feature is enabled by default but can be controlled using the `-DRV_FFMPEG_USE_VIDEOTOOLBOX` option. Set this option to `ON` to enable or `OFF` to disable VideoToolbox hardware decoding.
 
@@ -230,9 +236,7 @@ Note that you should always have `-DRV_FFMPEG_USE_VIDEOTOOLBOX` enabled when dec
 
 **Important:** Before enabling ProRes decoding, you are required to obtain a proper license agreement from Apple by contacting [ProRes@apple.com](mailto:ProRes@apple.com).
 
-
-
-### 11. Running the automated tests
+### 12. Running the automated tests
 
 Open RV uses ctest to run its automated tests.
 
@@ -248,44 +252,38 @@ To run tests manually,
 ctest --test-dir _build
 ```
 
-#### 11.1 Running The Tests In Parallel
+#### 12.1 Running The Tests In Parallel
 
 You can run the `test` in parallel by specifying `--parallel X`, where X is the number of tests to run in parallel.
 
-#### 11.2 Running A Subset Of The Tests
+#### 12.2 Running A Subset Of The Tests
 
 You can apply a filter with the `-R` flag to specify a regex.
 
-#### 11.3 Running The Tests Verbose
+#### 12.3 Running The Tests Verbose
 
 You can run the tests with extra verbosity with the flag `--extra-verbose`.
 
 > **Important:** You cannot use `--extra-verbose` with `--parallel`. It's one or the other, not both.
 
-
-
-
-### 12. Creating the installation package
+### 13. Creating the installation package
 
 To create the installation package, invoke the `install` step using cmake. The install step prepares Open RV for packaging by building a copy of Open RV in the `_install` folder. This step will strip debug symbols from the executable if required.
 
 Afterwards, it's up to you to either sign or package the result, or to do both. The result should contain the minimum required to have a functional Open RV.
 
-#### 12.1 Creating the installation package automatically
+#### 13.1 Creating the installation package automatically
 
 ```shell
 rvinst
 ```
 
-#### 12.2 Creating the installation package manually
+#### 13.2 Creating the installation package manually
 
 ```shell
 cmake --install _build --prefix _install
 ```
 
-
-### 13. Building with Docker
+### 14. Building with Docker
 
 Building with Docker is currently only supported on Rocky Linux. Please refer to the Rocky Linux setup instructions for details.
-
-

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,21 @@
+line-length = 120
+target-version = 'py311'
+exclude = [
+    "src/pub", # Ruff shouldn't run on the pub submodule
+]
+
+# TODO: Fix linting issues that are temporarily ignore in the following files for the linter check to pass
+[lint.per-file-ignores]
+"src/plugins/rv-packages/webview2/webview2.py" = ["F401"]
+"src/plugins/rv-packages/pyside_example/pyside_example.py" = ["F401", "F403", "F405", "F811"]
+"src/plugins/rv-packages/lat_long_viewer/lat_long_viewer.py" = ["F821"]
+"src/plugins/rv-packages/data_display_indicators/data_display_indicator_mode.py" = ["F403", "F405"]
+"src/plugins/rv-packages/custom_lut_menu_mode/custom_lut_menu_mode.py" = ["F821"]
+"src/plugins/python/gtoContainer/gtoContainer.py" = ["F403", "F405"]
+"src/lib/mu/MuQt6/qt6_to_mu.py" = ["E731", "F821", "F841"]
+"src/lib/mu/MuQt6/qt2mu.py" = ["E731", "F821", "F841"]
+"src/lib/mu/MuQt5/qt515_to_mu.py" = ["E731", "F821", "F841"]
+"src/lib/mu/MuQt5/qt512_to_mu.py" = ["E731", "F821", "F841"]
+"src/lib/mu/MuQt5/qt2mu.py" = ["E731", "F821", "F841"]
+"src/lib/app/py_rvui/rv_commands_setup.py" = ["F821"]
+"src/lib/app/py_rvui/rv/qtutils.py" = ["F401", "F403", "F405"]


### PR DESCRIPTION
### Add Ruff linter and formatter

### Summarize your change.

Note that multiple files had too many issues that would need to manually be reviewed to follow best practices and pass Ruff linting rules. The idea here was not to fix everything but rather to add tools to make working on this project easier. For that reason, some rules were ignore in specific files in `ruff.toml` that is added in another PR. Since some of these files were added recently, we should to take the time to fix them properly and make sure the code is following Python's conventions.

This PR adds a `Lint and Format` step in our Github actions CI and Ruff as a `pre-commit` hook to lint and format our Python code. I also added some documentation on how to use these tool to contribute to the project when working on Python files.

The files to review are:

- [docs/build_system/config_common_build.md](https://github.com/AcademySoftwareFoundation/OpenRV/pull/934/commits/34b7e9d8444afa85ece243ea0cb1443bef690f18#diff-65b028884e1988b5969e57e20e487c25afe94b933b9df3e69a07f5953b15be23)
- [ruff.toml](https://github.com/AcademySoftwareFoundation/OpenRV/pull/934/commits/e8d09fbf31721e8f4e1c351bc451c2aa6d93cb81#diff-26f436cb29eecc7bb4f9066747b43df8da81ac808955ce95c109f5d7aa778989)
- [.github/workflows/ci.yml](https://github.com/AcademySoftwareFoundation/OpenRV/pull/934/commits/ba5ba30702862e35073775c982ee2203adf1a313#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f)

### Describe the reason for the change.

The project had a formatter but no linter. Ruff is a tool that can do exactly what Black was doing as a formatter while also being able to lint and fix the code following PEP8 at the same time. We were also not enforcing the use of a linter and a formatter for Python in our CI.