### PR TITLE
Lint Python code with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,6 @@ repos:
     hooks:
       - id: cmake-format
 
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
-
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v19.1.4'
     hooks:

--- a/src/bin/mu/mu-interp/test/mandelbrot.py
+++ b/src/bin/mu/mu-interp/test/mandelbrot.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python
-# 
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+#
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 # by Daniel Rosengren
 
-import sys, time
+import sys
+import time
 
 stdout = sys.stdout
 

--- a/src/bin/mu/mu-interp/test/rng.py
+++ b/src/bin/mu/mu-interp/test/rng.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-# 
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
 #
-import sys
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 IM = 139968
 IA = 3877
@@ -20,7 +19,6 @@ def gen_random(max):
 
 
 def main(N):
-
     if N < 1:
         N = 1
     gr = gen_random

--- a/src/bin/python/py-interp/tests/test_SSL.py
+++ b/src/bin/python/py-interp/tests/test_SSL.py
@@ -8,6 +8,8 @@
 #
 # *****************************************************************************
 
+import unittest
+
 
 def _fetch(name, func, url):
     try:
@@ -102,14 +104,9 @@ def fetch_all(url, is_valid_url):
         raise AssertionError(f"FAILED: One of the libraries failed to fetch {url}")
 
     elif is_valid_url is False and any(results) is True:
-        raise AssertionError(
-            f"FAILED: One of the libraries failed to raise an error for {url}"
-        )
+        raise AssertionError(f"FAILED: One of the libraries failed to raise an error for {url}")
 
     print(f" - All libraries behaved well on {url}\n")
-
-
-import unittest
 
 
 class TestSSL(unittest.TestCase):

--- a/src/bin/python/py-interp/tests/test_misc_failures.py
+++ b/src/bin/python/py-interp/tests/test_misc_failures.py
@@ -1,19 +1,20 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 """
 Simple tests asserting that our testing setup
 does report failures.
 """
+
 import unittest
 
 
 class TestMiscFailures(unittest.TestCase):
     def test_importing_invalid_package(self):
         with self.assertRaises(ImportError):
-            import non_existing_package
+            import non_existing_package  # noqa: F401
 
     # def test_invalid_syntax(self):
     #    with self.assertRaises(SyntaxError):
@@ -22,7 +23,7 @@ class TestMiscFailures(unittest.TestCase):
 
     def test_calling_non_existing_method(self):
         with self.assertRaises(NameError):
-            pirnt("Hello from Python!")
+            pirnt("Hello from Python!")  # noqa: F821
 
 
 if __name__ == "__main__":

--- a/src/bin/python/py-interp/tests/test_rv_package.py
+++ b/src/bin/python/py-interp/tests/test_rv_package.py
@@ -1,18 +1,19 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 """
-Simple test just asserting that our application 
+Simple test just asserting that our application
 setup is allowing the import of RV's main package.
 """
+
 import unittest
 
 
 class TestRvPackage(unittest.TestCase):
     def test_importing_rv_package(self):
-        import rv
+        import rv  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/src/build/make_pyside.py
+++ b/src/build/make_pyside.py
@@ -23,7 +23,6 @@ from utils import (
     download_file,
     extract_7z_archive,
     verify_7z_archive,
-    source_widows_msvc_env,
     update_env_path,
 )
 from make_python import get_python_interpreter_args
@@ -142,12 +141,8 @@ def prepare() -> None:
     print(f"Installing numpy with {install_numpy_args}")
     subprocess.run(install_numpy_args).check_returncode()
 
-    cmakelist_path = os.path.join(
-        SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt"
-    )
-    old_cmakelist_path = os.path.join(
-        SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt.old"
-    )
+    cmakelist_path = os.path.join(SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt")
+    old_cmakelist_path = os.path.join(SOURCE_DIR, "sources", "shiboken2", "ApiExtractor", "CMakeLists.txt.old")
     if os.path.exists(old_cmakelist_path):
         os.remove(old_cmakelist_path)
 
@@ -222,15 +217,13 @@ def build() -> None:
     # We force Visual Studio 2017 here to make it build without errors.
     if platform.system() == "Windows":
         # Add Qt jom to the path to build in parallel
-        jom_path = os.path.abspath(
-            os.path.join(QT_OUTPUT_DIR, "..", "..", "Tools", "QtCreator", "bin", "jom")
-        )
+        jom_path = os.path.abspath(os.path.join(QT_OUTPUT_DIR, "..", "..", "Tools", "QtCreator", "bin", "jom"))
         if os.path.exists(os.path.join(jom_path, "jom.exe")):
             print(f"jom.exe was successfully located at: {jom_path}")
             update_env_path([jom_path])
         else:
             print(f"Could not find jom.exe at the expected location: {jom_path}")
-            print(f"Build performance might be impacted")
+            print("Build performance might be impacted")
 
         # Add the debug switch to match build type but only on Windows
         # (on other platforms, PySide2 is built in release)
@@ -270,9 +263,7 @@ def build() -> None:
     subprocess.run(generator_cleanup_args).check_returncode()
 
     if OPENSSL_OUTPUT_DIR and platform.system() == "Windows":
-        pyside_folder = glob.glob(
-            os.path.join(python_home, "**", "site-packages", "PySide2"), recursive=True
-        )[0]
+        pyside_folder = glob.glob(os.path.join(python_home, "**", "site-packages", "PySide2"), recursive=True)[0]
         openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "bin", "lib*"))
 
         for lib in openssl_libs:
@@ -292,14 +283,11 @@ if __name__ == "__main__":
     parser.add_argument("--source-dir", dest="source", type=pathlib.Path, required=True)
     parser.add_argument("--python-dir", dest="python", type=pathlib.Path, required=True)
     parser.add_argument("--qt-dir", dest="qt", type=pathlib.Path, required=True)
-    parser.add_argument(
-        "--openssl-dir", dest="openssl", type=pathlib.Path, required=False
-    )
+    parser.add_argument("--openssl-dir", dest="openssl", type=pathlib.Path, required=False)
     parser.add_argument("--temp-dir", dest="temp", type=pathlib.Path, required=True)
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
     parser.add_argument("--variant", dest="variant", type=str, required=True)
-
 
     # Major and minor version with dots.
     parser.add_argument("--python-version", dest="python_version", type=str, required=True, default="")
@@ -316,7 +304,7 @@ if __name__ == "__main__":
     QT_OUTPUT_DIR = args.qt
     VARIANT = args.variant
     PYTHON_VERSION = args.python_version
-    
+
     print(args)
 
     if args.prepare:

--- a/src/build/make_pyside6.py
+++ b/src/build/make_pyside6.py
@@ -23,8 +23,6 @@ from utils import (
     download_file,
     extract_7z_archive,
     verify_7z_archive,
-    source_widows_msvc_env,
-    update_env_path,
 )
 from make_python import get_python_interpreter_args
 
@@ -90,7 +88,7 @@ def prepare() -> None:
             version_search = re.search(r"version (\d+)\.(\d+)\.(\d+)", version_output)
             if version_search:
                 return version_search.groups()
-            print(f"ERROR: Could not extract clang --version")
+            print("ERROR: Could not extract clang --version")
             return None
 
         def get_clang_filename_suffix(version):
@@ -110,9 +108,7 @@ def prepare() -> None:
         clang_version = get_clang_version()
         if clang_version:
             clang_filename_suffix = get_clang_filename_suffix(clang_version)
-            fallback_clang_filename_suffix = get_fallback_clang_filename_suffix(
-                clang_version
-            )
+            fallback_clang_filename_suffix = get_fallback_clang_filename_suffix(clang_version)
 
     elif system == "Linux":
         clang_filename_suffix = "19.1.0-based-linux-Rhel8.8-gcc10.3-x86_64.7z"
@@ -132,17 +128,11 @@ def prepare() -> None:
         download_ok = download_file(download_url, libclang_zip)
         if not download_ok and fallback_clang_filename_suffix:
             fallback_download_url = LIBCLANG_URL_BASE + fallback_clang_filename_suffix
-            print(
-                f"WARNING: Could not download or version does not exist: {download_url}"
-            )
-            print(
-                f"WARNING: Attempting to fallback on known version: {fallback_download_url}..."
-            )
+            print(f"WARNING: Could not download or version does not exist: {download_url}")
+            print(f"WARNING: Attempting to fallback on known version: {fallback_download_url}...")
             download_ok = download_file(fallback_download_url, libclang_zip)
         if not download_ok:
-            print(
-                f"ERROR: Could not download or version does not exist: {download_url}"
-            )
+            print(f"ERROR: Could not download or version does not exist: {download_url}")
 
     # clean up previous failed extraction
     libclang_tmp = os.path.join(TEMP_DIR, "libclang-tmp")
@@ -179,12 +169,8 @@ def prepare() -> None:
     print(f"Installing numpy with {install_numpy_args}")
     subprocess.run(install_numpy_args).check_returncode()
 
-    cmakelist_path = os.path.join(
-        SOURCE_DIR, "sources", "shiboken6", "ApiExtractor", "CMakeLists.txt"
-    )
-    old_cmakelist_path = os.path.join(
-        SOURCE_DIR, "sources", "shiboken6", "ApiExtractor", "CMakeLists.txt.old"
-    )
+    cmakelist_path = os.path.join(SOURCE_DIR, "sources", "shiboken6", "ApiExtractor", "CMakeLists.txt")
+    old_cmakelist_path = os.path.join(SOURCE_DIR, "sources", "shiboken6", "ApiExtractor", "CMakeLists.txt.old")
     if os.path.exists(old_cmakelist_path):
         os.remove(old_cmakelist_path)
 
@@ -295,9 +281,7 @@ def build() -> None:
     subprocess.run(generator_cleanup_args).check_returncode()
 
     if OPENSSL_OUTPUT_DIR and platform.system() == "Windows":
-        pyside_folder = glob.glob(
-            os.path.join(python_home, "**", "site-packages", "PySide6"), recursive=True
-        )[0]
+        pyside_folder = glob.glob(os.path.join(python_home, "**", "site-packages", "PySide6"), recursive=True)[0]
         openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "bin", "lib*"))
 
         for lib in openssl_libs:
@@ -317,18 +301,14 @@ if __name__ == "__main__":
     parser.add_argument("--source-dir", dest="source", type=pathlib.Path, required=True)
     parser.add_argument("--python-dir", dest="python", type=pathlib.Path, required=True)
     parser.add_argument("--qt-dir", dest="qt", type=pathlib.Path, required=True)
-    parser.add_argument(
-        "--openssl-dir", dest="openssl", type=pathlib.Path, required=False
-    )
+    parser.add_argument("--openssl-dir", dest="openssl", type=pathlib.Path, required=False)
     parser.add_argument("--temp-dir", dest="temp", type=pathlib.Path, required=True)
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
     parser.add_argument("--variant", dest="variant", type=str, required=True)
 
     # Major and minor version with dots.
-    parser.add_argument(
-        "--python-version", dest="python_version", type=str, required=True, default=""
-    )
+    parser.add_argument("--python-version", dest="python_version", type=str, required=True, default="")
 
     parser.set_defaults(prepare=False, build=False)
 

--- a/src/build/make_python.py
+++ b/src/build/make_python.py
@@ -112,7 +112,7 @@ except Exception as e:
 '''
 
 
-def get_python_interpreter_args(python_home: str, variant : str) -> List[str]:
+def get_python_interpreter_args(python_home: str, variant: str) -> List[str]:
     """
     Return the path to the python interpreter given a Python home
 
@@ -123,25 +123,19 @@ def get_python_interpreter_args(python_home: str, variant : str) -> List[str]:
     build_opentimelineio = platform.system() == "Windows" and variant == "Debug"
     python_name_pattern = "python*" if not build_opentimelineio else "python_d*"
 
-    python_interpreters = glob.glob(
-        os.path.join(python_home, python_name_pattern), recursive=True
-    )
-    python_interpreters += glob.glob(
-        os.path.join(python_home, "bin", python_name_pattern)
-    )
+    python_interpreters = glob.glob(os.path.join(python_home, python_name_pattern), recursive=True)
+    python_interpreters += glob.glob(os.path.join(python_home, "bin", python_name_pattern))
 
     # sort put python# before python#-config, prioritize debug on Windows debug builds
     python_interpreters = sorted(
-        [
-            p
-            for p in python_interpreters
-            if os.path.islink(p) is False and os.access(p, os.X_OK)
-        ],
+        [p for p in python_interpreters if os.path.islink(p) is False and os.access(p, os.X_OK)],
         key=lambda p: (
             "-config" in os.path.basename(p),  # config variants last
-            not ("_d" in os.path.basename(p) and platform.system() == "Windows" and variant.lower() == "debug"),  # prioritize _d on Windows debug
-            os.path.basename(p)  # alphabetical
-        )
+            not (
+                "_d" in os.path.basename(p) and platform.system() == "Windows" and variant.lower() == "debug"
+            ),  # prioritize _d on Windows debug
+            os.path.basename(p),  # alphabetical
+        ),
     )
 
     if not python_interpreters or os.path.exists(python_interpreters[0]) is False:
@@ -162,9 +156,7 @@ def patch_python_distribution(python_home: str) -> None:
     :param python_home: Home of the Python to patch.
     """
 
-    for failed_lib in glob.glob(
-        os.path.join(python_home, "lib", "**", "*_failed.so"), recursive=True
-    ):
+    for failed_lib in glob.glob(os.path.join(python_home, "lib", "**", "*_failed.so"), recursive=True):
         # The Python build mark some so as _failed if it cannot load OpenSSL. In our case it's expected because
         # out OpenSSL package works with RPATH and the RPATH is not set on the python build tests. If the lib failed
         # for other reasons, it will fail later in our build script.
@@ -173,10 +165,8 @@ def patch_python_distribution(python_home: str) -> None:
             shutil.move(failed_lib, failed_lib.replace("_failed.so", ".so"))
     if OPENSSL_OUTPUT_DIR:
         if platform.system() == "Darwin":
-            openssl_libs = glob.glob(
-                os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.dylib*")
-            )
-            openssl_libs = [l for l in openssl_libs if os.path.islink(l) is False]
+            openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, "lib", "lib*.dylib*"))
+            openssl_libs = [lib for lib in openssl_libs if os.path.islink(lib) is False]
 
             python_openssl_libs = []
 
@@ -186,9 +176,7 @@ def patch_python_distribution(python_home: str) -> None:
                 shutil.copyfile(lib_path, dest)
                 python_openssl_libs.append(dest)
 
-            libs_to_patch = glob.glob(
-                os.path.join(python_home, "lib", "**", "*.so"), recursive=True
-            )
+            libs_to_patch = glob.glob(os.path.join(python_home, "lib", "**", "*.so"), recursive=True)
 
             for lib_path in python_openssl_libs:
                 lib_name = os.path.basename(lib_path)
@@ -207,9 +195,7 @@ def patch_python_distribution(python_home: str) -> None:
                     subprocess.run(install_name_tool_change_args).check_returncode()
 
         elif platform.system() == "Linux":
-            openssl_libs = glob.glob(
-                os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR, "lib*.so*")
-            )
+            openssl_libs = glob.glob(os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR, "lib*.so*"))
 
             for lib_path in openssl_libs:
                 print(f"Copying {lib_path} to the python home")
@@ -256,9 +242,7 @@ def patch_python_distribution(python_home: str) -> None:
     print(f"Installing wheel with {wheel_install_args}")
     subprocess.run(wheel_install_args).check_returncode()
 
-    site_packages = glob.glob(
-        os.path.join(python_home, "**", "site-packages"), recursive=True
-    )[0]
+    site_packages = glob.glob(os.path.join(python_home, "**", "site-packages"), recursive=True)[0]
 
     if os.path.exists(site_packages) is False:
         raise FileNotFoundError()
@@ -272,9 +256,7 @@ def patch_python_distribution(python_home: str) -> None:
     print(f"Installing the sitecustomize.py payload at {site_customize_path}")
     site_customize_path = os.path.join(site_packages, "sitecustomize.py")
     if os.path.exists(site_customize_path):
-        print(
-            "Found a sitecustomize.py in the site-packages, the content of the file will be overwritten"
-        )
+        print("Found a sitecustomize.py in the site-packages, the content of the file will be overwritten")
         os.remove(site_customize_path)
 
     with open(site_customize_path, "w") as sitecustomize_file:
@@ -302,7 +284,7 @@ def test_python_distribution(python_home: str) -> None:
         #       python while RV uses the debug version.
         build_opentimelineio = platform.system() == "Windows" and VARIANT == "Debug"
         if build_opentimelineio:
-            print(f"Building opentimelineio")
+            print("Building opentimelineio")
 
             # Request an opentimelineio debug build
             my_env = os.environ.copy()
@@ -310,12 +292,8 @@ def test_python_distribution(python_home: str) -> None:
 
             # Specify the location of the debug python import lib (eg. python39_d.lib)
             python_include_dirs = os.path.join(tmp_python_home, "include")
-            python_lib = os.path.join(
-                tmp_python_home, "libs", f"python{PYTHON_VERSION}_d.lib"
-            )
-            my_env["CMAKE_ARGS"] = (
-                f"-DPython_LIBRARY={python_lib} -DCMAKE_INCLUDE_PATH={python_include_dirs}"
-            )
+            python_lib = os.path.join(tmp_python_home, "libs", f"python{PYTHON_VERSION}_d.lib")
+            my_env["CMAKE_ARGS"] = f"-DPython_LIBRARY={python_lib} -DCMAKE_INCLUDE_PATH={python_include_dirs}"
 
             opentimelineio_install_arg = python_interpreter_args + [
                 "-m",
@@ -324,7 +302,7 @@ def test_python_distribution(python_home: str) -> None:
                 ".",
             ]
 
-            result = subprocess.run(
+            subprocess.run(
                 opentimelineio_install_arg,
                 env=my_env,
                 cwd=OPENTIMELINEIO_SOURCE_DIR,
@@ -334,16 +312,12 @@ def test_python_distribution(python_home: str) -> None:
             # Example: _opentimed_d.cp39-win_amd64.pyd instead of _opentime_d.pyd
             # and _otiod_d.cp39-win_amd64.pyd instead of _otio_d.pyd
             # We fix those names here
-            otio_module_dir = os.path.join(
-                tmp_python_home, "lib", "site-packages", "opentimelineio"
-            )
+            otio_module_dir = os.path.join(tmp_python_home, "lib", "site-packages", "opentimelineio")
             for _file in os.listdir(otio_module_dir):
                 if _file.endswith("pyd"):
                     otio_lib_name_split = os.path.basename(_file).split(".")
                     if len(otio_lib_name_split) > 2:
-                        new_otio_lib_name = (
-                            otio_lib_name_split[0].replace("d_d", "_d") + ".pyd"
-                        )
+                        new_otio_lib_name = otio_lib_name_split[0].replace("d_d", "_d") + ".pyd"
                         src_file = os.path.join(otio_module_dir, _file)
                         dst_file = os.path.join(otio_module_dir, new_otio_lib_name)
                         shutil.copyfile(src_file, dst_file)
@@ -400,9 +374,7 @@ def test_python_distribution(python_home: str) -> None:
             ),
         ]
         print(f"Validating the python package with {python_validation2_args}")
-        subprocess.run(
-            python_validation2_args, env={**os.environ, "SSL_CERT_FILE": dummy_ssl_file}
-        ).check_returncode()
+        subprocess.run(python_validation2_args, env={**os.environ, "SSL_CERT_FILE": dummy_ssl_file}).check_returncode()
 
         python_validation3_args = python_interpreter_args + [
             "-c",
@@ -471,9 +443,7 @@ def configure() -> None:
 
             if platform.system() == "Linux":
                 # This option prevent Python to build the _ssl module correctly on Darwin.
-                configure_args.append(
-                    f"--with-openssl-rpath={OPENSSL_OUTPUT_DIR}/{LIB_DIR}"
-                )
+                configure_args.append(f"--with-openssl-rpath={OPENSSL_OUTPUT_DIR}/{LIB_DIR}")
 
         if VARIANT == "Release":
             configure_args.append("--enable-optimizations")
@@ -483,62 +453,32 @@ def configure() -> None:
         PKG_CONFIG_PATH = []
 
         if platform.system() == "Darwin":
-            readline_prefix_proc = subprocess.run(
-                ["brew", "--prefix", "readline"], capture_output=True
-            )
+            readline_prefix_proc = subprocess.run(["brew", "--prefix", "readline"], capture_output=True)
             readline_prefix_proc.check_returncode()
 
-            tcl_prefix_proc = subprocess.run(
-                ["brew", "--prefix", "tcl-tk@8"], capture_output=True
-            )
+            tcl_prefix_proc = subprocess.run(["brew", "--prefix", "tcl-tk@8"], capture_output=True)
             tcl_prefix_proc.check_returncode()
 
-            python_tk_prefix_proc = subprocess.run(
-                ["brew", "--prefix", "python-tk"], capture_output=True
-            )
+            python_tk_prefix_proc = subprocess.run(["brew", "--prefix", "python-tk"], capture_output=True)
             python_tk_prefix_proc.check_returncode()
 
-            xz_prefix_proc = subprocess.run(
-                ["brew", "--prefix", "xz"], capture_output=True
-            )
+            xz_prefix_proc = subprocess.run(["brew", "--prefix", "xz"], capture_output=True)
             xz_prefix_proc.check_returncode()
 
-            sdk_prefix_proc = subprocess.run(
-                ["xcrun", "--show-sdk-path"], capture_output=True
-            )
+            sdk_prefix_proc = subprocess.run(["xcrun", "--show-sdk-path"], capture_output=True)
             sdk_prefix_proc.check_returncode()
 
-            readline_prefix = (
-                pathlib.Path(readline_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
-            tcl_prefix = (
-                pathlib.Path(tcl_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
-            xz_prefix = (
-                pathlib.Path(xz_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
-            sdk_prefix = (
-                pathlib.Path(sdk_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
-            python_tk_prefix = (
-                pathlib.Path(python_tk_prefix_proc.stdout.strip().decode("utf-8"))
-                .resolve()
-                .__str__()
-            )
+            readline_prefix = pathlib.Path(readline_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
+            tcl_prefix = pathlib.Path(tcl_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
+            xz_prefix = pathlib.Path(xz_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
+            sdk_prefix = pathlib.Path(sdk_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
+            python_tk_prefix = pathlib.Path(python_tk_prefix_proc.stdout.strip().decode("utf-8")).resolve().__str__()
 
-            CPPFLAGS.append(f'-I{os.path.join(readline_prefix, "include")}')
-            CPPFLAGS.append(f'-I{os.path.join(tcl_prefix, "include")}')
-            CPPFLAGS.append(f'-I{os.path.join(xz_prefix, "include")}')
-            CPPFLAGS.append(f'-I{os.path.join(sdk_prefix, "usr", "include")}')
-            CPPFLAGS.append(f'-I{os.path.join(python_tk_prefix, "include")}')
+            CPPFLAGS.append(f"-I{os.path.join(readline_prefix, 'include')}")
+            CPPFLAGS.append(f"-I{os.path.join(tcl_prefix, 'include')}")
+            CPPFLAGS.append(f"-I{os.path.join(xz_prefix, 'include')}")
+            CPPFLAGS.append(f"-I{os.path.join(sdk_prefix, 'usr', 'include')}")
+            CPPFLAGS.append(f"-I{os.path.join(python_tk_prefix, 'include')}")
 
             LD_LIBRARY_PATH.append(os.path.join(readline_prefix, "lib"))
             LD_LIBRARY_PATH.append(os.path.join(tcl_prefix, "lib"))
@@ -552,14 +492,10 @@ def configure() -> None:
 
         if OPENSSL_OUTPUT_DIR:
             if platform.system() == "Darwin":
-                configure_args.append(
-                    f"LC_RPATH={os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR)}"
-                )
-                configure_args.append(f'LDFLAGS={" ".join(LDFLAGS)}')
-                configure_args.append(f'CPPFLAGS={" ".join(CPPFLAGS)}')
-                configure_args.append(
-                    f"DYLD_LIBRARY_PATH={os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR)}"
-                )
+                configure_args.append(f"LC_RPATH={os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR)}")
+                configure_args.append(f"LDFLAGS={' '.join(LDFLAGS)}")
+                configure_args.append(f"CPPFLAGS={' '.join(CPPFLAGS)}")
+                configure_args.append(f"DYLD_LIBRARY_PATH={os.path.join(OPENSSL_OUTPUT_DIR, LIB_DIR)}")
             else:
                 # Linux (NOT Windows was checked before)
                 configure_args.append(f"LDFLAGS=-L{OPENSSL_OUTPUT_DIR}/{LIB_DIR}")
@@ -571,9 +507,7 @@ def configure() -> None:
 
         print(f"Executing {configure_args} from {SOURCE_DIR}")
 
-        subprocess.run(
-            configure_args, cwd=SOURCE_DIR, env=subprocess_env
-        ).check_returncode()
+        subprocess.run(configure_args, cwd=SOURCE_DIR, env=subprocess_env).check_returncode()
 
         makefile_path = os.path.join(SOURCE_DIR, "Makefile")
         old_makefile_path = os.path.join(SOURCE_DIR, "Makefile.old")
@@ -590,9 +524,7 @@ def configure() -> None:
                     if new_line.startswith("LINKFORSHARED="):
                         if platform.system() == "Linux":
                             makefile.write(
-                                new_line.strip()
-                                + " -Wl,-rpath,'$$ORIGIN/../lib',-rpath,'$$ORIGIN/../Qt'"
-                                + "\n"
+                                new_line.strip() + " -Wl,-rpath,'$$ORIGIN/../lib',-rpath,'$$ORIGIN/../Qt'" + "\n"
                             )
                         elif platform.system() == "Darwin":
                             makefile.write(
@@ -610,7 +542,6 @@ def build() -> None:
     """
 
     if platform.system() == "Windows":
-
         build_args = [
             os.path.join(SOURCE_DIR, "PCBuild", "build.bat"),
             "-p",
@@ -682,9 +613,7 @@ def install_python_vfx2023() -> None:
         # libs - required by pyside2
         dst_dir = os.path.join(OUTPUT_DIR, "libs")
         os.mkdir(dst_dir)
-        python_libs = glob.glob(
-            os.path.join(SOURCE_DIR, "PCBuild", "amd64", "python*.lib")
-        )
+        python_libs = glob.glob(os.path.join(SOURCE_DIR, "PCBuild", "amd64", "python*.lib"))
         if python_libs:
             for python_lib in python_libs:
                 shutil.copy(python_lib, dst_dir)
@@ -723,6 +652,7 @@ def install_python_vfx2023() -> None:
 
     patch_python_distribution(OUTPUT_DIR)
     test_python_distribution(OUTPUT_DIR)
+
 
 def install_python_vfx2024() -> None:
     """
@@ -769,10 +699,7 @@ def install_python_vfx2024() -> None:
 
         print(f"Executing {install_args}")
 
-        subprocess.run(
-            install_args,
-            cwd=SOURCE_DIR
-        ).check_returncode()
+        subprocess.run(install_args, cwd=SOURCE_DIR).check_returncode()
 
         # bin
         libs_dir = os.path.join(OUTPUT_DIR, "libs")
@@ -793,7 +720,7 @@ def install_python_vfx2024() -> None:
 
         # Move files under root directory into the bin folder.
         for filename in os.listdir(os.path.join(OUTPUT_DIR)):
-            file_path = os.path.join(OUTPUT_DIR, filename)  
+            file_path = os.path.join(OUTPUT_DIR, filename)
             if os.path.isfile(file_path):
                 shutil.move(file_path, os.path.join(dst_dir, filename))
 
@@ -840,6 +767,7 @@ def install_python_vfx2024() -> None:
     patch_python_distribution(OUTPUT_DIR)
     test_python_distribution(OUTPUT_DIR)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
@@ -849,9 +777,7 @@ if __name__ == "__main__":
     parser.add_argument("--install", dest="install", action="store_true")
 
     parser.add_argument("--source-dir", dest="source", type=pathlib.Path, required=True)
-    parser.add_argument(
-        "--openssl-dir", dest="openssl", type=pathlib.Path, required=False
-    )
+    parser.add_argument("--openssl-dir", dest="openssl", type=pathlib.Path, required=False)
     parser.add_argument("--temp-dir", dest="temp", type=pathlib.Path, required=True)
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
@@ -914,7 +840,7 @@ if __name__ == "__main__":
         build()
 
     if args.install:
-        # The install functions has a lot of similiarity but I think it is better to have two differents 
+        # The install functions has a lot of similiarity but I think it is better to have two differents
         # functions because it will be easier to drop the support for a VFX platform.
         if VFX_PLATFORM == 2023:
             install_python_vfx2023()

--- a/src/build/patch_OCIO/ocio_pyopencolorio_patch.py
+++ b/src/build/patch_OCIO/ocio_pyopencolorio_patch.py
@@ -1,4 +1,7 @@
-import argparse, shutil, pathlib, re, sys
+import argparse
+import shutil
+import pathlib
+import re
 
 
 def patch_execute(filename):

--- a/src/build/quoteFile.py
+++ b/src/build/quoteFile.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2001, Tweak Films
 # Copyright (c) 2008, Tweak Software
 #
-# SPDX-License-Identifier: Apache-2.0 
+# SPDX-License-Identifier: Apache-2.0
 #
 # Quote a text file in C++ form for inclusion into a C++ source file
 #
 import sys
-import string
 
 index = 1
 varlist = []
@@ -36,10 +35,10 @@ outfile.write("//\n")
 outfile.write("const char* " + cppname + " = ")
 
 for line in lines:
-    l = line.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    line = line.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
     for subst in varlist:
-        l = l.replace(subst[0], subst[1])
-    outfile.write('"' + l + '"\n')
+        line = line.replace(subst[0], subst[1])
+    outfile.write('"' + line + '"\n')
 
 outfile.write(";\n")
 outfile.close()

--- a/src/build/utils.py
+++ b/src/build/utils.py
@@ -261,11 +261,7 @@ def get_cygpath_windows(cygpath: str) -> str:
     Returns the windows path corresponding to the cygpath passed as parameter.
     :param string cygpath: cygpath to be translated. Example: C:/git/OpenRV/_build
     """
-    return (
-        subprocess.check_output(["cygpath", "--windows", "--absolute", f"{cygpath}"])
-        .rstrip()
-        .decode("utf-8")
-    )
+    return subprocess.check_output(["cygpath", "--windows", "--absolute", f"{cygpath}"]).rstrip().decode("utf-8")
 
 
 def update_env_path(newpaths: str) -> None:
@@ -274,7 +270,7 @@ def update_env_path(newpaths: str) -> None:
     """
     paths = os.environ["PATH"].lower().split(os.pathsep)
     for path in newpaths:
-        if not path.lower() in paths:
+        if path.lower() not in paths:
             paths.insert(0, path)
             os.environ["PATH"] = "{}{}{}".format(path, os.pathsep, os.environ["PATH"])
 
@@ -303,7 +299,7 @@ def source_widows_msvc_env(msvc_year: str) -> None:
                 if not (len(ob) == 2):
                     print("Unexpected result: {}".format(ob))
                     raise ValueError
-            except:
+            except Exception:
                 return False
             return True
 
@@ -330,10 +326,10 @@ def source_widows_msvc_env(msvc_year: str) -> None:
             # make sure the lines are strings
             lines = map(lambda s: s.decode(), lines)
         # consume whatever output occurs until the tag is reached
-        consume(itertools.takewhile(lambda l: tag not in l, lines))
+        consume(itertools.takewhile(lambda line: tag not in line, lines))
         # define a way to handle each KEY=VALUE line
         # parse key/values into pairs
-        pairs = map(lambda l: l.rstrip().split("=", 1), lines)
+        pairs = map(lambda line: line.rstrip().split("=", 1), lines)
         # make sure the pairs are valid
         valid_pairs = filter(validate_pair, pairs)
         # construct a dictionary of the pairs
@@ -378,24 +374,16 @@ def source_widows_msvc_env(msvc_year: str) -> None:
             )
 
     if not os.path.exists(vcvars_path):
-        print(
-            "ERROR: Failed to find the MSVC compiler environment init script (vcvars64.bat) on your system."
-        )
+        print("ERROR: Failed to find the MSVC compiler environment init script (vcvars64.bat) on your system.")
         return
     else:
-        print(
-            f"Found MSVC compiler environment init script (vcvars64.bat):\n{vcvars_path}"
-        )
+        print(f"Found MSVC compiler environment init script (vcvars64.bat):\n{vcvars_path}")
 
     # Get MSVC env
     vcvars_cmd = [vcvars_path]
     msvc_env = get_environment_from_batch_command(vcvars_cmd)
-    msvc_env_paths = os.pathsep.join(
-        [msvc_env[k] for k in msvc_env if k.upper() == "PATH"]
-    ).split(os.pathsep)
-    msvc_env_without_paths = dict(
-        [(k, msvc_env[k]) for k in msvc_env if k.upper() != "PATH"]
-    )
+    msvc_env_paths = os.pathsep.join([msvc_env[k] for k in msvc_env if k.upper() == "PATH"]).split(os.pathsep)
+    msvc_env_without_paths = dict([(k, msvc_env[k]) for k in msvc_env if k.upper() != "PATH"])
 
     # Extend os.environ with MSVC env
     update_env_path(msvc_env_paths)
@@ -414,16 +402,13 @@ def get_mingw64_path_on_windows(winpath: str) -> str:
         return winpath
 
     return (
-        subprocess.check_output(
-            ["c:\\msys64\\usr\\bin\\cygpath.exe", "--mixed", "--absolute", f"{winpath}"]
-        )
+        subprocess.check_output(["c:\\msys64\\usr\\bin\\cygpath.exe", "--mixed", "--absolute", f"{winpath}"])
         .rstrip()
         .decode("utf-8")
     )
 
 
 def get_mingw64_args(cmd_args: List[str]) -> List[str]:
-
     updated_cmd_args = cmd_args
     updated_cmd_args.append(";sleep 10")
 

--- a/src/lib/app/RvCommon/generate_theme.py
+++ b/src/lib/app/RvCommon/generate_theme.py
@@ -26,10 +26,10 @@ Features:
 Usage Examples:
     # Use config file (auto-detects platform template)
     python generate_theme.py --config rv_theme_variables.conf --output rv_dark.qss
-    
+
     # Override variables from command line (will prompt for missing ones)
     python generate_theme.py --config rv_theme_variables.conf --output rv_blue.qss --set ACCENT_PRIMARY=rgb(0,100,200) --set ACCENT_SECONDARY=rgb(50,150,255)
-    
+
     # No config file (will prompt for all required variables)
     python generate_theme.py --output rv_custom.qss --set PRIMARY_BACKGROUND=rgb(40,40,40)
 """
@@ -61,11 +61,7 @@ def get_platform_template() -> str:
     """Get the appropriate template file for the current platform"""
     system = platform.system().lower()
     # Windows and Linux both use the Linux template, only macOS uses the macOS template
-    template_name = (
-        "rv_mac_dark.qss.template"
-        if system == "darwin"
-        else "rv_linux_dark.qss.template"
-    )
+    template_name = "rv_mac_dark.qss.template" if system == "darwin" else "rv_linux_dark.qss.template"
 
     # Check if we're being run from OpenRV root directory
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -96,9 +92,7 @@ def adjust_output_path(output_file: str) -> str:
         if os.path.exists(rvcommon_path):
             # Only adjust if output path is just a filename (no directory)
             if not os.path.dirname(output_file):
-                adjusted_path = os.path.join(
-                    "src", "lib", "app", "RvCommon", output_file
-                )
+                adjusted_path = os.path.join("src", "lib", "app", "RvCommon", output_file)
                 logger.info(f"Placing output in RvCommon directory: {adjusted_path}")
                 return adjusted_path
 
@@ -121,14 +115,10 @@ def adjust_config_path(config_file: Optional[str]) -> Optional[str]:
         if os.path.exists(rvcommon_path):
             # Only adjust if config path is just a filename (no directory)
             if not os.path.dirname(config_file):
-                adjusted_path = os.path.join(
-                    "src", "lib", "app", "RvCommon", config_file
-                )
+                adjusted_path = os.path.join("src", "lib", "app", "RvCommon", config_file)
                 # Check if the adjusted path exists, if not, try the original
                 if os.path.exists(adjusted_path):
-                    logger.info(
-                        f"Using config from RvCommon directory: {adjusted_path}"
-                    )
+                    logger.info(f"Using config from RvCommon directory: {adjusted_path}")
                     return adjusted_path
 
     return config_file
@@ -162,9 +152,7 @@ def load_variables_from_config(config_file: Optional[str]) -> Dict[str, str]:
                             continue
 
                         if not value:
-                            logger.warning(
-                                f"Empty value in {config_file} line {line_num}: {key} = (empty)"
-                            )
+                            logger.warning(f"Empty value in {config_file} line {line_num}: {key} = (empty)")
                             invalid_count += 1
                             continue
 
@@ -178,21 +166,15 @@ def load_variables_from_config(config_file: Optional[str]) -> Dict[str, str]:
                         if validate_css_value(key, value):
                             variables[key] = value
                         else:
-                            logger.warning(
-                                f"Skipping invalid value in {config_file} line {line_num}: {key} = {value}"
-                            )
+                            logger.warning(f"Skipping invalid value in {config_file} line {line_num}: {key} = {value}")
                             example = get_example_value(key)
                             logger.info(f"Example: {key} = {example}")
-                            logger.info(
-                                f"Variable will remain as {{{{{key}}}}} placeholder"
-                            )
+                            logger.info(f"Variable will remain as {{{{{key}}}}} placeholder")
                             invalid_count += 1
                             # Skip invalid values - don't include them
                     else:
-                        logger.warning(
-                            f"Malformed line in {config_file} line {line_num}: {original_line.strip()}"
-                        )
-                        logger.info(f"Expected format: VARIABLE = value")
+                        logger.warning(f"Malformed line in {config_file} line {line_num}: {original_line.strip()}")
+                        logger.info("Expected format: VARIABLE = value")
                         invalid_count += 1
     except UnicodeDecodeError as e:
         logger.error(f"Config file {config_file} has encoding issues: {e}")
@@ -203,9 +185,7 @@ def load_variables_from_config(config_file: Optional[str]) -> Dict[str, str]:
         return {}
 
     if invalid_count > 0:
-        logger.warning(
-            f"Found {invalid_count} invalid value(s) in config file. Please fix them to ensure proper CSS."
-        )
+        logger.warning(f"Found {invalid_count} invalid value(s) in config file. Please fix them to ensure proper CSS.")
 
     return variables
 
@@ -246,9 +226,7 @@ def validate_css_value(var_name: str, value: str) -> bool:
         # Check for valid CSS color formats
 
         # RGB format: rgb(r, g, b) with proper range validation
-        rgb_match = re.match(
-            r"^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$", value
-        )
+        rgb_match = re.match(r"^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$", value)
         if rgb_match:
             r, g, b = map(int, rgb_match.groups())
             return 0 <= r <= 255 and 0 <= g <= 255 and 0 <= b <= 255
@@ -278,10 +256,7 @@ def validate_css_value(var_name: str, value: str) -> bool:
         }
 
         # Check Hex format or named colors (case insensitive)
-        return (
-            re.match(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$", value) is not None
-            or value.lower() in named_colors
-        )
+        return re.match(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$", value) is not None or value.lower() in named_colors
 
     # Non-color variables: for now all variables are colors
     return len(value.strip()) > 0
@@ -302,9 +277,7 @@ def get_example_value(var_name: str) -> str:
 def collect_missing_variables(missing_vars: Set[str]) -> Dict[str, str]:
     """Interactive collection of missing variables with validation"""
     print("\nMissing variables detected. Please provide values:")
-    print(
-        "('quit' to abort, 'default' to use default value, 'help' for examples, Ctrl+C to cancel)"
-    )
+    print("('quit' to abort, 'default' to use default value, 'help' for examples, Ctrl+C to cancel)")
 
     # Read the config file and get the default value for the variable
     config_file = adjust_config_path("rv_theme_variables.conf")
@@ -336,9 +309,7 @@ def collect_missing_variables(missing_vars: Set[str]) -> Dict[str, str]:
                             print(f"Set: {var_name} = {variables[var_name]}")
                             break
                         else:
-                            print(
-                                f"No default value found for {var_name}. Please provide a valid CSS value."
-                            )
+                            print(f"No default value found for {var_name}. Please provide a valid CSS value.")
                             continue
                     else:
                         # Validate the value
@@ -374,9 +345,7 @@ def process_template(template_file: str, variables: Dict[str, str]) -> str:
         with open(template_file, "r", encoding="utf-8") as f:
             content = f.read()
     except UnicodeDecodeError as e:
-        raise ValueError(
-            f"Template file {template_file} has encoding issues: {e}. Please save as UTF-8."
-        )
+        raise ValueError(f"Template file {template_file} has encoding issues: {e}. Please save as UTF-8.")
     except Exception as e:
         raise ValueError(f"Failed to read template file {template_file}: {e}")
 
@@ -389,9 +358,7 @@ def process_template(template_file: str, variables: Dict[str, str]) -> str:
     # Check for variables in config that don't exist in template
     extra_vars = set(variables.keys()) - template_vars
     if extra_vars:
-        logger.warning(
-            f"Found {len(extra_vars)} variables in config that don't exist in template:"
-        )
+        logger.warning(f"Found {len(extra_vars)} variables in config that don't exist in template:")
         for var in sorted(extra_vars):
             logger.info(f"  {var} = {variables[var]}")
         logger.info("These variables will be ignored.")
@@ -399,9 +366,7 @@ def process_template(template_file: str, variables: Dict[str, str]) -> str:
     # Check for missing variables
     missing_vars = template_vars - set(variables.keys())
     if missing_vars:
-        logger.info(
-            f"Found {len(missing_vars)} missing variables: {', '.join(sorted(missing_vars))}"
-        )
+        logger.info(f"Found {len(missing_vars)} missing variables: {', '.join(sorted(missing_vars))}")
 
         # Collect missing variables interactively
         new_vars = collect_missing_variables(missing_vars)
@@ -500,9 +465,7 @@ def main():
         help="Set variable (format: KEY=VALUE). Can be used multiple times",
     )
 
-    parser.add_argument(
-        "--list-variables", help="List all variables found in a config file"
-    )
+    parser.add_argument("--list-variables", help="List all variables found in a config file")
 
     args = parser.parse_args()
 

--- a/src/lib/app/py_rvui/rv/qtutils.py
+++ b/src/lib/app/py_rvui/rv/qtutils.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0 
 #
 import rv.commands
-import os
 
 try:
     from PySide2 import QtGui, QtWidgets

--- a/src/lib/app/py_rvui/rv/rvtypes.py
+++ b/src/lib/app/py_rvui/rv/rvtypes.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import rv.commands
 import os
@@ -75,9 +75,7 @@ class Mode(object):
             rv.commands.deactivateMode(self._modeName)
 
         rv.commands.redraw()
-        rv.commands.sendInternalEvent(
-            "mode-toggled", "%s|%s" % (self._modeName, self._active), "Mode"
-        )
+        rv.commands.sendInternalEvent("mode-toggled", "%s|%s" % (self._modeName, self._active), "Mode")
 
     def layout(self, event):
         "Layout any margins or precompute anything necessary for rendering"
@@ -88,7 +86,7 @@ class Mode(object):
         pass
 
     def supportPath(self, module, packageName=None):
-        if packageName == None:
+        if packageName is None:
             packageName = module.__name__
         return os.path.join(
             os.path.dirname(os.path.dirname(module.__file__)),
@@ -97,18 +95,14 @@ class Mode(object):
         )
 
     def qmlPath(self, module, packageName=None):
-        if packageName == None:
+        if packageName is None:
             packageName = module.__name__
-        return os.path.join(
-            os.path.dirname(os.path.dirname(module.__file__)), "QML", packageName
-        )
+        return os.path.join(os.path.dirname(os.path.dirname(module.__file__)), "QML", packageName)
 
     def configPath(self, packageName):
         """Returns a path to a writable directory where temporary, and
         configuration files specific to a package are/should be located. The
         directory will be created if it does not yet exist."""
-
-        import platform
 
         envvar = os.getenv("TWK_APP_SUPPORT_PATH")
         userDir = envvar.split(concat_seperator())[0]
@@ -117,7 +111,7 @@ class Mode(object):
         try:
             if not os.path.exists(directory):
                 sys.mkdir(directory, 0x1FF)
-        except:
+        except Exception:
             print("ERROR: mode config path failed to create directory %s" % directory)
 
         return directory
@@ -158,13 +152,13 @@ class MinorMode(Mode):
         self.setMenu(menu)
 
     def setMenu(self, menu):
-        if menu == None:
+        if menu is None:
             menu = []
         self._menu = menu
         rv.commands.defineModeMenu(self._modeName, self._menu, False)
 
     def setMenuStrict(self, menu):
-        if menu == None:
+        if menu is None:
             menu = []
         self._menu = menu
         rv.commands.defineModeMenu(self._modeName, self._menu, True)
@@ -217,9 +211,7 @@ class Widget(MinorMode):
         self._inCloseArea = False
         self._containsPointer = False
         self._whichMargin = -1
-        MinorMode.init(
-            self, name, globalBindings, overrideBindings, menu, sortKey, ordering
-        )
+        MinorMode.init(self, name, globalBindings, overrideBindings, menu, sortKey, ordering)
 
     def toggle(self):
         self._active = not self._active
@@ -233,9 +225,7 @@ class Widget(MinorMode):
 
         rv.commands.redraw()
 
-        rv.commands.sendInternalEvent(
-            "mode-toggled", "%s|%s" % (self._modeName, self._active), "Mode"
-        )
+        rv.commands.sendInternalEvent("mode-toggled", "%s|%s" % (self._modeName, self._active), "Mode")
 
     def updateMargins(self, activated):
         #
@@ -278,12 +268,7 @@ class Widget(MinorMode):
             self.updateMargins(True)
 
     def contains(self, p):
-        if (
-            p[0] >= self._x
-            and p[0] <= self._x + self._w
-            and p[1] >= self._y
-            and p[1] <= self._y + self._h
-        ):
+        if p[0] >= self._x and p[0] <= self._x + self._w and p[1] >= self._y and p[1] <= self._y + self._h:
             return True
 
         return False

--- a/src/lib/app/py_rvui/rv/rvui.py
+++ b/src/lib/app/py_rvui/rv/rvui.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import rv.commands
 import rv.rvtypes
@@ -43,9 +43,9 @@ def remotePyEval(event):
     "python eval() event contents"
     try:
         val = eval(event.contents())
-        if val != None:
+        if val is not None:
             event.setReturnContent(str(val))
-    except:
+    except Exception:
         import sys
 
         e = sys.exc_info()

--- a/src/lib/app/py_rvui/rv_commands_setup.py
+++ b/src/lib/app/py_rvui/rv_commands_setup.py
@@ -451,7 +451,7 @@ def bind_symbols(symbol_list, module_name, mod):
         try:
             s = MuSymbol(module_name + "." + sym)
             setattr(mod, sym, s)
-        except:
+        except Exception:
             print("Bind to python failed:", sym)
 
 
@@ -459,7 +459,7 @@ def bind_constants(constant_list, mod):
     for const_pair in constant_list:
         try:
             setattr(mod, const_pair[0], const_pair[1])
-        except:
+        except Exception:
             print("Bind to python failed:", sym)
 
 

--- a/src/lib/mu/MuQt5/qt512_to_mu.py
+++ b/src/lib/mu/MuQt5/qt512_to_mu.py
@@ -982,8 +982,6 @@ exclusionMap = {
     "QPixmap::NoAlpha": None,
     "QPixmap::PremultipliedAlpha": None,
     "QPixmap::Alpha": None,
-    "QPixmap::HBitmapFormat": None,
-    "QPixmap::ShareMode": None,
     "QPixmap::ImplicitlyShared": None,
     "QPixmap::ExplicitlyShared": None,
     "QPixmap::fromImage": [
@@ -1035,7 +1033,6 @@ exclusionMap = {
     "QFileDialog::getSaveFileName": None,
     "QFileDialog::getExistingDirectoryUrl": None,
     "QFileDialog::getOpenFileUrls": None,
-    "QFileDialog::getSaveFileName": None,
     "QFileDialog::getSaveFileUrl": None,
     # these are shadowing get prop funcs of the same names"
     "QCoreApplication::applicationName": None,
@@ -1129,9 +1126,6 @@ exclusionMap = {
     # so these have to be done manually
     "QFileInfo::QFileInfo": [
         ("QFileInfo", "", [("file", "const QFile &", None)], "", False)
-    ],
-    "QFileInfo::setFile": [
-        ("setFile", "", [("file", "const QFile &", None)], "void", False)
     ],
     "QFileInfo::setFile": [
         ("setFile", "", [("file", "const QFile &", None)], "void", False)
@@ -1252,13 +1246,13 @@ excludedDefaultValues = [
 
 
 def isFunctionExcluded(qtnamespace, qtfunc):
-    if qtnamespace != None:
+    if qtnamespace is not None:
         cppname = qtnamespace.name + "::" + qtfunc[0]
     else:
         cppname = qtfunc[0]
     if cppname in exclusionMap:
         e = exclusionMap[cppname]
-        if e == None:
+        if e is None:
             return True
         inname = str(qtfunc)
         for f in e:
@@ -1268,7 +1262,7 @@ def isFunctionExcluded(qtnamespace, qtfunc):
 
 
 def doesFunctionAllowDefaultValues(qtnamespace, funcname):
-    if qtnamespace != None:
+    if qtnamespace is not None:
         cppname = qtnamespace.name + "::" + funcname
     else:
         cppname = qtfunc[0]
@@ -1507,7 +1501,7 @@ class API:
         # an enum in the class not qualified
         # test whether the type name needs to be fully qualified
         # e.g. "InsertPolicy" -> "QComboBox::InsertPolicy"
-        # if inclass != None:
+        # if inclass is not None:
         # for e in inclass.enums:
         #    if e.name == cpptype or e.flags == cpptype:
         #        return "flags %s::%s" % (inclass.name, cpptype)
@@ -1554,8 +1548,8 @@ def parseType(t):
 
 def indexInList(el, list):
     i = 0
-    for l in list:
-        if l == el:
+    for list in list:
+        if list == el:
             return i
         i += 1
     return i
@@ -1589,7 +1583,7 @@ def parseParameter(param, n):
     else:
         name = parts[-1]
         del parts[-1]
-    if parts == [] and name == None and default == None:
+    if parts == [] and name is None and default is None:
         return None
     else:
         type = parseType(parts[:])
@@ -1725,7 +1719,7 @@ class NamespaceInfo:
         if self.properties:
             print("--props--")
             for i in self.properties:
-                if i != None:
+                if i is not None:
                     print(i)
         if self.enums:
             print("--enums--")
@@ -1737,37 +1731,37 @@ class NamespaceInfo:
         if self.publicfuncs:
             print("--public member functions--")
             for i in self.publicfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.protectedfuncs:
             print("--protected member functions--")
             for i in self.protectedfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.signals:
             print("--signals functions--")
             for i in self.signals:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.slots:
             print("--slot functions--")
             for i in self.slots:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.staticfuncs:
             print("--static functions--")
             for i in self.staticfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.globalfuncs:
             print("--global functions--")
             for i in self.globalfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
     def enumInHierarchy(self, name):
@@ -1800,7 +1794,7 @@ class NamespaceInfo:
             ):
                 return i.name
             for p in self.inherits:
-                if not p in api.classes.keys():
+                if p not in api.classes.keys():
                     print(
                         "WARNING:",
                         p,
@@ -1896,7 +1890,7 @@ class MuEnum:
                 if self.protected:
                     # for protected enums use actual value instead of symbolic
                     val = e.value
-                if not xmap or (not val in xmap):
+                if not xmap or (val not in xmap):
                     self.symbols.append((n, val))
 
     def aliasDeclation(self):
@@ -1980,7 +1974,7 @@ class MuFunction:
 
         for aname, atype, aval in args:
             mutype = api.translate(atype, c)
-            if mutype == None:
+            if mutype is None:
                 self.failed = True
                 # message("%s failed because api.translate(%s,%s) return None" % (name, atype, c))
                 mutype = '"%s"' % atype
@@ -1992,7 +1986,7 @@ class MuFunction:
             self.rtype = name
             if len(self.args) == 2:
                 if self.args[1][1] == self.name:
-                    if not "*" in qtfunc[2][0][1]:  # not a pointer
+                    if "*" not in qtfunc[2][0][1]:  # not a pointer
                         self.iscopyconstructor = True
         else:
             self.rtype = api.translate(rtype, c)
@@ -2001,7 +1995,7 @@ class MuFunction:
             self.failed = True
             # message("%s failed because its a copy constructor" % name)
 
-        if self.rtype == None:
+        if self.rtype is None:
             self.failed = True
             self.rtype = '"%s"' % rtype
             # message("%s failed because rtype == %s" % (name, rtype))
@@ -2051,7 +2045,7 @@ class MuFunction:
     def unpackReturnValue(self, expr):
         rtype = conditionType(self.rtype)
         rep = repMapFind(rtype)
-        if rep != None:
+        if rep is not None:
             (repType, instType) = rep
             return expr + "._" + repType
         else:
@@ -2089,7 +2083,7 @@ class MuFunction:
                 # this for some value types. Generally Qt rarely used
                 # default parameter values before Qt 5
                 # right now only ints, flags, and enums are supported
-                if aval != None and doesFunctionAllowDefaultValues(
+                if aval is not None and doesFunctionAllowDefaultValues(
                     self.muclass, self.name
                 ):
                     if atype == "int":
@@ -2106,7 +2100,7 @@ class MuFunction:
         if self.isprotected and self.isconstructor:
             return "// NO NODE: CONSTRUCTOR IS PROTECTED: %s" % self.muDeclaration()
         rep = repMapFind(self.rtype)
-        if rep == None:
+        if rep is None:
             return None
         (repType, instType) = rep
         out = "static NODE_IMPLEMENTATION(%s, %s)\n{\n    " % (self.node, repType)
@@ -2298,7 +2292,7 @@ class MuFunction:
             if i == 0 and self.ismember and muclass.iscopyonwrite:
                 if ntype[-1] != "&":
                     ntype += "&"
-                if self.isconst and not "const" in ntype:
+                if self.isconst and "const" not in ntype:
                     ntype = "const " + ntype
             elif ntype[-1] == "&":
                 ntype = ntype[0:-1]
@@ -2338,8 +2332,8 @@ class MuFunction:
         rtypeLayoutItem = muapi.isAByName(self.rtype, "QLayoutItem")
         rtypePaintDevice = (
             muapi.isAByName(self.rtype, "QPaintDevice")
-            and not self.rtype.split(".")[-1] in pointerTypes
-            and not self.rtype.split(".")[-1] in primitiveTypes
+            and self.rtype.split(".")[-1] not in pointerTypes
+            and self.rtype.split(".")[-1] not in primitiveTypes
         )
         rmaker = None
 
@@ -2565,7 +2559,7 @@ class MuClass:
             qtnamespace = api.classes[qtname]
             for f in qtnamespace.functions:
                 if "virtual" in f[3]:
-                    if not self.hasFunction(f[0]) and not "~" in f[0]:
+                    if not self.hasFunction(f[0]) and "~" not in f[0]:
                         # if self.name == "QLayout":
                         #    print " -> ",str(f)
                         self.inheritedVirtuals.append(
@@ -2776,7 +2770,7 @@ class MuClass:
 
     def hasFlagType(self, flagName):
         for e in self.enums:
-            if e.flags != None and flagName == e.flags:
+            if e.flags is not None and flagName == e.flags:
                 return True
         return False
 
@@ -2791,7 +2785,7 @@ class MuClass:
         return False
 
     def needsLocalQualification(self, name):
-        if name == None or intRE.match(name):
+        if name is None or intRE.match(name):
             return False
         return self.hasEnumType(name) or self.hasFlagType(name)
 
@@ -2802,7 +2796,7 @@ class MuClass:
                 value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
             )
             for p in parts:
-                if p != "" and p != None:
+                if p != "" and p is not None:
                     if self.needsLocalQualification(p):
                         newvalue = newvalue.replace(p, "%s::%s" % (self.name, p))
             return newvalue
@@ -3048,7 +3042,7 @@ class MuClass:
                                 out += ptype + " " + pname
                             out += ") " + fconst
                             out += " { "
-                            if not "void" in rtype:
+                            if "void" not in rtype:
                                 out += "return "
                             if parent:
                                 out += self.name + "::"
@@ -3196,7 +3190,7 @@ class MuClass:
         cppout.writelines(cpplines)
         cppout.close()
 
-        if not (self.name in noHFileOutput):
+        if self.name not in noHFileOutput:
             hfile = open(templateH, "r")
             hlines = []
             while True:
@@ -3317,7 +3311,7 @@ class MuAPI:
             isQLayoutItem = c.isAByName("QLayoutItem")
             c.inheritable = (
                 (isQObject or isQLayoutItem or isQPaintDevice)
-                and (not c.name in notInheritableTypes)
+                and (c.name not in notInheritableTypes)
                 and allowInheritance
             )
 
@@ -3441,9 +3435,6 @@ class QtDocParser(SGMLParser):
 
     def end_span(self):
         self.modulespan = False
-
-    def end_table(self):
-        self.defenum = False
 
     def start_pre(self, attrs):
         self.precount += 1
@@ -3578,7 +3569,7 @@ class QtDocParser(SGMLParser):
                 self.enums[-1].flags = c + n
             elif self.defenum:
                 n = self.enums[-1].name
-                if n == None:
+                if n is None:
                     self.enums[-1].name = data
                 elif n[-2:] == "::":
                     self.enums[-1].name = n + data
@@ -3661,7 +3652,7 @@ class QtDocParser(SGMLParser):
                 self.buffer += data
 
     def convertFunctions(self):
-        F = lambda x: x != None
+        F = lambda x: x is not None
         P = lambda x: parseFunction(x, self.qtnamespace)
         self.qtnamespace.publicfuncs = filter(F, map(P, self.public))
         self.qtnamespace.slots = filter(F, map(P, self.slots))
@@ -3756,7 +3747,7 @@ def recursiveParse(url):
             recursiveParse(u)
     except IOError:
         print("FAILED: (IOError)", url)
-    except:
+    except Exception:
         print("FAILED:", url)
         print(traceback.print_exc())
 

--- a/src/lib/mu/MuQt5/qt515_to_mu.py
+++ b/src/lib/mu/MuQt5/qt515_to_mu.py
@@ -937,8 +937,6 @@ exclusionMap = {
     "QPixmap::NoAlpha": None,
     "QPixmap::PremultipliedAlpha": None,
     "QPixmap::Alpha": None,
-    "QPixmap::HBitmapFormat": None,
-    "QPixmap::ShareMode": None,
     "QPixmap::ImplicitlyShared": None,
     "QPixmap::ExplicitlyShared": None,
     "QPixmap::fromImage": [
@@ -994,7 +992,6 @@ exclusionMap = {
     "QFileDialog::getSaveFileName": None,
     "QFileDialog::getExistingDirectoryUrl": None,
     "QFileDialog::getOpenFileUrls": None,
-    "QFileDialog::getSaveFileName": None,
     "QFileDialog::getSaveFileUrl": None,
     # Issue with std::function
     "QFileDialog::getOpenFileContent": None,
@@ -1309,7 +1306,6 @@ exclusionMap = {
     "QTextDocument::resourceProvider": None,
     "QTextDocument::setResourceProvider": None,
     "QTextDocument::defaultResourceProvider": None,
-    "QTextDocument::setDefaultResourceProvider": None,
     "QTextEdit::extraSelections": None,
     # Issue with const QList<QTextOption::Tab>  arg1 = (&)(param_tabStops);
     "QTextOption::setTabs": None,
@@ -1494,13 +1490,13 @@ excludedDefaultValues = [
 
 
 def isFunctionExcluded(qtnamespace, qtfunc):
-    if qtnamespace != None:
+    if qtnamespace is not None:
         cppname = qtnamespace.name + "::" + qtfunc[0]
     else:
         cppname = qtfunc[0]
     if cppname in exclusionMap:
         e = exclusionMap[cppname]
-        if e == None:
+        if e is None:
             return True
         inname = str(qtfunc)
         for f in e:
@@ -1510,7 +1506,7 @@ def isFunctionExcluded(qtnamespace, qtfunc):
 
 
 def doesFunctionAllowDefaultValues(qtnamespace, funcname):
-    if qtnamespace != None:
+    if qtnamespace is not None:
         cppname = qtnamespace.name + "::" + funcname
     else:
         cppname = qtfunc[0]
@@ -1751,7 +1747,7 @@ class API:
         # an enum in the class not qualified
         # test whether the type name needs to be fully qualified
         # e.g. "InsertPolicy" -> "QComboBox::InsertPolicy"
-        # if inclass != None:
+        # if inclass is not None:
         # for e in inclass.enums:
         #    if e.name == cpptype or e.flags == cpptype:
         #        return "flags %s::%s" % (inclass.name, cpptype)
@@ -1798,8 +1794,8 @@ def parseType(t):
 
 def indexInList(el, list):
     i = 0
-    for l in list:
-        if l == el:
+    for list in list:
+        if list == el:
             return i
         i += 1
     return i
@@ -1833,7 +1829,7 @@ def parseParameter(param, n):
     else:
         name = parts[-1]
         del parts[-1]
-    if parts == [] and name == None and default == None:
+    if parts == [] and name is None and default is None:
         return None
     else:
         type = parseType(parts[:])
@@ -1906,7 +1902,7 @@ def parseFunction(func, qtnamespace):
     #     thistype = groups[3]
     #     message("CEDRIK Parts: " + str(parts))
     #     message("CEDRIK thistype: " + groups[3])
-    # except:
+    # except Exception:
     #     # Fall back to previous method
     #     sindex = func.find("(")
     #     eindex = func.rfind(")")
@@ -1988,7 +1984,7 @@ def parseFunction(func, qtnamespace):
                 return v
             else:
                 message("WARNING: Nameproto empty for " + func)
-    except:
+    except Exception:
         # Skip any function that has issue with the simple parsing above.
         print("Error parsing function.. skipping: {0}".format(orig_func))
         return None
@@ -2046,7 +2042,7 @@ class NamespaceInfo:
         if self.properties:
             print("--props--")
             for i in self.properties:
-                if i != None:
+                if i is not None:
                     print(i)
         if self.enums:
             print("--enums--")
@@ -2058,37 +2054,37 @@ class NamespaceInfo:
         if self.publicfuncs:
             print("--public member functions--")
             for i in self.publicfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.protectedfuncs:
             print("--protected member functions--")
             for i in self.protectedfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.signals:
             print("--signals functions--")
             for i in self.signals:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.slots:
             print("--slot functions--")
             for i in self.slots:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.staticfuncs:
             print("--static functions--")
             for i in self.staticfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.globalfuncs:
             print("--global functions--")
             for i in self.globalfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
     def enumInHierarchy(self, name):
@@ -2121,7 +2117,7 @@ class NamespaceInfo:
             ):
                 return i.name
             for p in self.inherits:
-                if not p in api.classes.keys():
+                if p not in api.classes.keys():
                     print(
                         "WARNING:",
                         p,
@@ -2224,7 +2220,7 @@ class MuEnum:
                 if self.protected:
                     # for protected enums use actual value instead of symbolic
                     val = e.value
-                if not xmap or (not val in xmap):
+                if not xmap or (val not in xmap):
                     self.symbols.append((n, val))
 
     def aliasDeclation(self):
@@ -2319,7 +2315,7 @@ class MuFunction:
         for aname, atype, aval in args:
             message("Trying to translate (%s, %s) for %s" % (atype, c, name))
             mutype = api.translate(atype, c)
-            if mutype == None:
+            if mutype is None:
                 self.failed = True
                 message(
                     "%s failed because api.translate(%s,%s) return None"
@@ -2334,7 +2330,7 @@ class MuFunction:
             self.rtype = name
             if len(self.args) == 2:
                 if self.args[1][1] == self.name:
-                    if not "*" in qtfunc[2][0][1]:  # not a pointer
+                    if "*" not in qtfunc[2][0][1]:  # not a pointer
                         self.iscopyconstructor = True
         else:
             self.rtype = api.translate(rtype, c)
@@ -2343,7 +2339,7 @@ class MuFunction:
             self.failed = True
             message("%s failed because its a copy constructor" % name)
 
-        if self.rtype == None:
+        if self.rtype is None:
             self.failed = True
             self.rtype = '"%s"' % rtype
             message("%s failed because rtype == %s" % (name, rtype))
@@ -2395,7 +2391,7 @@ class MuFunction:
     def unpackReturnValue(self, expr):
         rtype = conditionType(self.rtype)
         rep = repMapFind(rtype)
-        if rep != None:
+        if rep is not None:
             (repType, instType) = rep
             return expr + "._" + repType
         else:
@@ -2433,7 +2429,7 @@ class MuFunction:
                 # this for some value types. Generally Qt rarely used
                 # default parameter values before Qt 5
                 # right now only ints, flags, and enums are supported
-                if aval != None and doesFunctionAllowDefaultValues(
+                if aval is not None and doesFunctionAllowDefaultValues(
                     self.muclass, self.name
                 ):
                     if atype == "int":
@@ -2451,7 +2447,7 @@ class MuFunction:
         if self.isprotected and self.isconstructor:
             return "// NO NODE: CONSTRUCTOR IS PROTECTED: %s" % self.muDeclaration()
         rep = repMapFind(self.rtype)
-        if rep == None:
+        if rep is None:
             return None
         (repType, instType) = rep
         out = "static NODE_IMPLEMENTATION(%s, %s)\n{\n    " % (self.node, repType)
@@ -2651,7 +2647,7 @@ class MuFunction:
             if i == 0 and self.ismember and muclass.iscopyonwrite:
                 if ntype[-1] != "&":
                     ntype += "&"
-                if self.isconst and not "const" in ntype:
+                if self.isconst and "const" not in ntype:
                     ntype = "const " + ntype
             elif ntype[-1] == "&":
                 ntype = ntype[0:-1]
@@ -2691,8 +2687,8 @@ class MuFunction:
         rtypeLayoutItem = muapi.isAByName(self.rtype, "QLayoutItem")
         rtypePaintDevice = (
             muapi.isAByName(self.rtype, "QPaintDevice")
-            and not self.rtype.split(".")[-1] in pointerTypes
-            and not self.rtype.split(".")[-1] in primitiveTypes
+            and self.rtype.split(".")[-1] not in pointerTypes
+            and self.rtype.split(".")[-1] not in primitiveTypes
         )
         rtypeIODeviceBase = muapi.isAByName(self.rtype, "QIODeviceBase")
         rmaker = None
@@ -2930,7 +2926,7 @@ class MuClass:
             qtnamespace = api.classes[qtname]
             for f in qtnamespace.functions:
                 if "virtual" in f[3]:
-                    if not self.hasFunction(f[0]) and not "~" in f[0]:
+                    if not self.hasFunction(f[0]) and "~" not in f[0]:
                         # if self.name == "QLayout":
                         #    print " -> ",str(f)
                         self.inheritedVirtuals.append(
@@ -3143,7 +3139,7 @@ class MuClass:
 
     def hasFlagType(self, flagName):
         for e in self.enums:
-            if e.flags != None and flagName == e.flags:
+            if e.flags is not None and flagName == e.flags:
                 return True
         return False
 
@@ -3158,7 +3154,7 @@ class MuClass:
         return False
 
     def needsLocalQualification(self, name):
-        if name == None or intRE.match(name):
+        if name is None or intRE.match(name):
             return False
         return self.hasEnumType(name) or self.hasFlagType(name)
 
@@ -3169,7 +3165,7 @@ class MuClass:
                 value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
             )
             for p in parts:
-                if p != "" and p != None:
+                if p != "" and p is not None:
                     if self.needsLocalQualification(p):
                         newvalue = newvalue.replace(p, "%s::%s" % (self.name, p))
             return newvalue
@@ -3417,7 +3413,7 @@ class MuClass:
                                 out += ptype + " " + pname
                             out += ") " + fconst
                             out += " { "
-                            if not "void" in rtype:
+                            if "void" not in rtype:
                                 out += "return "
                             if parent:
                                 out += self.name + "::"
@@ -3568,7 +3564,7 @@ class MuClass:
         cppout.writelines(cpplines)
         cppout.close()
 
-        if not (self.name in noHFileOutput):
+        if self.name not in noHFileOutput:
             hfile = open(templateH, "r")
             hlines = []
             while True:
@@ -3695,7 +3691,7 @@ class MuAPI:
             isQIODeviceBase = c.isAByName("QIODeviceBase")
             c.inheritable = (
                 (isQObject or isQLayoutItem or isQPaintDevice or isQIODeviceBase)
-                and (not c.name in notInheritableTypes)
+                and (c.name not in notInheritableTypes)
                 and allowInheritance
             )
 
@@ -3819,9 +3815,6 @@ class QtDocParser(SGMLParser):
 
     def end_span(self):
         self.modulespan = False
-
-    def end_table(self):
-        self.defenum = False
 
     def start_pre(self, attrs):
         self.precount += 1
@@ -3956,7 +3949,7 @@ class QtDocParser(SGMLParser):
                 self.enums[-1].flags = c + n
             elif self.defenum:
                 n = self.enums[-1].name
-                if n == None:
+                if n is None:
                     self.enums[-1].name = data
                 elif n[-2:] == "::":
                     self.enums[-1].name = n + data
@@ -4039,7 +4032,7 @@ class QtDocParser(SGMLParser):
                 self.buffer += data
 
     def convertFunctions(self):
-        F = lambda x: x != None
+        F = lambda x: x is not None
         P = lambda x: parseFunction(x, self.qtnamespace)
         self.qtnamespace.publicfuncs = filter(F, map(P, self.public))
         self.qtnamespace.slots = filter(F, map(P, self.slots))
@@ -4137,7 +4130,7 @@ def recursiveParse(url):
             recursiveParse(absPath)
     except IOError:
         print("FAILED: (IOError)", url)
-    except:
+    except Exception:
         sys.stdout.flush()
         print("FAILED:", url)
         print(traceback.print_exc())

--- a/src/lib/mu/MuQt6/qt6_to_mu.py
+++ b/src/lib/mu/MuQt6/qt6_to_mu.py
@@ -937,8 +937,6 @@ exclusionMap = {
     "QPixmap::NoAlpha": None,
     "QPixmap::PremultipliedAlpha": None,
     "QPixmap::Alpha": None,
-    "QPixmap::HBitmapFormat": None,
-    "QPixmap::ShareMode": None,
     "QPixmap::ImplicitlyShared": None,
     "QPixmap::ExplicitlyShared": None,
     "QPixmap::fromImage": [
@@ -994,7 +992,6 @@ exclusionMap = {
     "QFileDialog::getSaveFileName": None,
     "QFileDialog::getExistingDirectoryUrl": None,
     "QFileDialog::getOpenFileUrls": None,
-    "QFileDialog::getSaveFileName": None,
     "QFileDialog::getSaveFileUrl": None,
     # Issue with std::function
     "QFileDialog::getOpenFileContent": None,
@@ -1309,7 +1306,6 @@ exclusionMap = {
     "QTextDocument::resourceProvider": None,
     "QTextDocument::setResourceProvider": None,
     "QTextDocument::defaultResourceProvider": None,
-    "QTextDocument::setDefaultResourceProvider": None,
     "QTextEdit::extraSelections": None,
     # Issue with const QList<QTextOption::Tab>  arg1 = (&)(param_tabStops);
     "QTextOption::setTabs": None,
@@ -1494,13 +1490,13 @@ excludedDefaultValues = [
 
 
 def isFunctionExcluded(qtnamespace, qtfunc):
-    if qtnamespace != None:
+    if qtnamespace is not None:
         cppname = qtnamespace.name + "::" + qtfunc[0]
     else:
         cppname = qtfunc[0]
     if cppname in exclusionMap:
         e = exclusionMap[cppname]
-        if e == None:
+        if e is None:
             return True
         inname = str(qtfunc)
         for f in e:
@@ -1510,7 +1506,7 @@ def isFunctionExcluded(qtnamespace, qtfunc):
 
 
 def doesFunctionAllowDefaultValues(qtnamespace, funcname):
-    if qtnamespace != None:
+    if qtnamespace is not None:
         cppname = qtnamespace.name + "::" + funcname
     else:
         cppname = qtfunc[0]
@@ -1751,7 +1747,7 @@ class API:
         # an enum in the class not qualified
         # test whether the type name needs to be fully qualified
         # e.g. "InsertPolicy" -> "QComboBox::InsertPolicy"
-        # if inclass != None:
+        # if inclass is not None:
         # for e in inclass.enums:
         #    if e.name == cpptype or e.flags == cpptype:
         #        return "flags %s::%s" % (inclass.name, cpptype)
@@ -1798,8 +1794,8 @@ def parseType(t):
 
 def indexInList(el, list):
     i = 0
-    for l in list:
-        if l == el:
+    for list in list:
+        if list == el:
             return i
         i += 1
     return i
@@ -1833,7 +1829,7 @@ def parseParameter(param, n):
     else:
         name = parts[-1]
         del parts[-1]
-    if parts == [] and name == None and default == None:
+    if parts == [] and name is None and default is None:
         return None
     else:
         type = parseType(parts[:])
@@ -1988,7 +1984,7 @@ def parseFunction(func, qtnamespace):
                 return v
             else:
                 message("WARNING: Nameproto empty for " + func)
-    except:
+    except Exception:
         # Skip any function that has issue with the simple parsing above.
         print("Error parsing function.. skipping: {0}".format(orig_func))
         return None
@@ -2046,7 +2042,7 @@ class NamespaceInfo:
         if self.properties:
             print("--props--")
             for i in self.properties:
-                if i != None:
+                if i is not None:
                     print(i)
         if self.enums:
             print("--enums--")
@@ -2058,37 +2054,37 @@ class NamespaceInfo:
         if self.publicfuncs:
             print("--public member functions--")
             for i in self.publicfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.protectedfuncs:
             print("--protected member functions--")
             for i in self.protectedfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.signals:
             print("--signals functions--")
             for i in self.signals:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.slots:
             print("--slot functions--")
             for i in self.slots:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.staticfuncs:
             print("--static functions--")
             for i in self.staticfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
         if self.globalfuncs:
             print("--global functions--")
             for i in self.globalfuncs:
-                if i != None:
+                if i is not None:
                     print(i)
 
     def enumInHierarchy(self, name):
@@ -2121,7 +2117,7 @@ class NamespaceInfo:
             ):
                 return i.name
             for p in self.inherits:
-                if not p in api.classes.keys():
+                if p not in api.classes.keys():
                     print(
                         "WARNING:",
                         p,
@@ -2224,7 +2220,7 @@ class MuEnum:
                 if self.protected:
                     # for protected enums use actual value instead of symbolic
                     val = e.value
-                if not xmap or (not val in xmap):
+                if not xmap or (val not in xmap):
                     self.symbols.append((n, val))
 
     def aliasDeclation(self):
@@ -2319,7 +2315,7 @@ class MuFunction:
         for aname, atype, aval in args:
             message("Trying to translate (%s, %s) for %s" % (atype, c, name))
             mutype = api.translate(atype, c)
-            if mutype == None:
+            if mutype is None:
                 self.failed = True
                 message(
                     "%s failed because api.translate(%s,%s) return None"
@@ -2334,7 +2330,7 @@ class MuFunction:
             self.rtype = name
             if len(self.args) == 2:
                 if self.args[1][1] == self.name:
-                    if not "*" in qtfunc[2][0][1]:  # not a pointer
+                    if "*" not in qtfunc[2][0][1]:  # not a pointer
                         self.iscopyconstructor = True
         else:
             self.rtype = api.translate(rtype, c)
@@ -2343,7 +2339,7 @@ class MuFunction:
             self.failed = True
             message("%s failed because its a copy constructor" % name)
 
-        if self.rtype == None:
+        if self.rtype is None:
             self.failed = True
             self.rtype = '"%s"' % rtype
             message("%s failed because rtype == %s" % (name, rtype))
@@ -2395,7 +2391,7 @@ class MuFunction:
     def unpackReturnValue(self, expr):
         rtype = conditionType(self.rtype)
         rep = repMapFind(rtype)
-        if rep != None:
+        if rep is not None:
             (repType, instType) = rep
             return expr + "._" + repType
         else:
@@ -2433,7 +2429,7 @@ class MuFunction:
                 # this for some value types. Generally Qt rarely used
                 # default parameter values before Qt 5
                 # right now only ints, flags, and enums are supported
-                if aval != None and doesFunctionAllowDefaultValues(
+                if aval is not None and doesFunctionAllowDefaultValues(
                     self.muclass, self.name
                 ):
                     if atype == "int":
@@ -2451,7 +2447,7 @@ class MuFunction:
         if self.isprotected and self.isconstructor:
             return "// NO NODE: CONSTRUCTOR IS PROTECTED: %s" % self.muDeclaration()
         rep = repMapFind(self.rtype)
-        if rep == None:
+        if rep is None:
             return None
         (repType, instType) = rep
         out = "static NODE_IMPLEMENTATION(%s, %s)\n{\n    " % (self.node, repType)
@@ -2651,7 +2647,7 @@ class MuFunction:
             if i == 0 and self.ismember and muclass.iscopyonwrite:
                 if ntype[-1] != "&":
                     ntype += "&"
-                if self.isconst and not "const" in ntype:
+                if self.isconst and "const" not in ntype:
                     ntype = "const " + ntype
             elif ntype[-1] == "&":
                 ntype = ntype[0:-1]
@@ -2691,8 +2687,8 @@ class MuFunction:
         rtypeLayoutItem = muapi.isAByName(self.rtype, "QLayoutItem")
         rtypePaintDevice = (
             muapi.isAByName(self.rtype, "QPaintDevice")
-            and not self.rtype.split(".")[-1] in pointerTypes
-            and not self.rtype.split(".")[-1] in primitiveTypes
+            and self.rtype.split(".")[-1] not in pointerTypes
+            and self.rtype.split(".")[-1] not in primitiveTypes
         )
         rtypeIODeviceBase = muapi.isAByName(self.rtype, "QIODeviceBase")
         rmaker = None
@@ -2930,7 +2926,7 @@ class MuClass:
             qtnamespace = api.classes[qtname]
             for f in qtnamespace.functions:
                 if "virtual" in f[3]:
-                    if not self.hasFunction(f[0]) and not "~" in f[0]:
+                    if not self.hasFunction(f[0]) and "~" not in f[0]:
                         # if self.name == "QLayout":
                         #    print " -> ",str(f)
                         self.inheritedVirtuals.append(
@@ -3143,7 +3139,7 @@ class MuClass:
 
     def hasFlagType(self, flagName):
         for e in self.enums:
-            if e.flags != None and flagName == e.flags:
+            if e.flags is not None and flagName == e.flags:
                 return True
         return False
 
@@ -3158,7 +3154,7 @@ class MuClass:
         return False
 
     def needsLocalQualification(self, name):
-        if name == None or intRE.match(name):
+        if name is None or intRE.match(name):
             return False
         return self.hasEnumType(name) or self.hasFlagType(name)
 
@@ -3169,7 +3165,7 @@ class MuClass:
                 value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
             )
             for p in parts:
-                if p != "" and p != None:
+                if p != "" and p is not None:
                     if self.needsLocalQualification(p):
                         newvalue = newvalue.replace(p, "%s::%s" % (self.name, p))
             return newvalue
@@ -3417,7 +3413,7 @@ class MuClass:
                                 out += ptype + " " + pname
                             out += ") " + fconst
                             out += " { "
-                            if not "void" in rtype:
+                            if "void" not in rtype:
                                 out += "return "
                             if parent:
                                 out += self.name + "::"
@@ -3568,7 +3564,7 @@ class MuClass:
         cppout.writelines(cpplines)
         cppout.close()
 
-        if not (self.name in noHFileOutput):
+        if self.name not in noHFileOutput:
             hfile = open(templateH, "r")
             hlines = []
             while True:
@@ -3695,7 +3691,7 @@ class MuAPI:
             isQIODeviceBase = c.isAByName("QIODeviceBase")
             c.inheritable = (
                 (isQObject or isQLayoutItem or isQPaintDevice or isQIODeviceBase)
-                and (not c.name in notInheritableTypes)
+                and (c.name not in notInheritableTypes)
                 and allowInheritance
             )
 
@@ -3819,9 +3815,6 @@ class QtDocParser(SGMLParser):
 
     def end_span(self):
         self.modulespan = False
-
-    def end_table(self):
-        self.defenum = False
 
     def start_pre(self, attrs):
         self.precount += 1
@@ -3956,7 +3949,7 @@ class QtDocParser(SGMLParser):
                 self.enums[-1].flags = c + n
             elif self.defenum:
                 n = self.enums[-1].name
-                if n == None:
+                if n is None:
                     self.enums[-1].name = data
                 elif n[-2:] == "::":
                     self.enums[-1].name = n + data
@@ -4039,7 +4032,7 @@ class QtDocParser(SGMLParser):
                 self.buffer += data
 
     def convertFunctions(self):
-        F = lambda x: x != None
+        F = lambda x: x is not None
         P = lambda x: parseFunction(x, self.qtnamespace)
         self.qtnamespace.publicfuncs = filter(F, map(P, self.public))
         self.qtnamespace.slots = filter(F, map(P, self.slots))
@@ -4137,7 +4130,7 @@ def recursiveParse(url):
             recursiveParse(absPath)
     except IOError:
         print("FAILED: (IOError)", url)
-    except:
+    except Exception:
         sys.stdout.flush()
         print("FAILED:", url)
         print(traceback.print_exc())

--- a/src/plugins/python/gtoContainer/gtoContainer.py
+++ b/src/plugins/python/gtoContainer/gtoContainer.py
@@ -193,9 +193,9 @@ class Property:
         if not self.__data and self.__deferRead:
             self.__deferredRead()
         self.__data = value
-        if size != None:
+        if size is not None:
             self.__size = size
-        if width != None:
+        if width is not None:
             self.__width = width
 
     def component(self):
@@ -797,9 +797,9 @@ class gtoContainer(gto.Reader):
         """
         self.__objects = []
         self.__filename = filename
-        self.__deferredRead = deferredRead and filename != None
+        self.__deferredRead = deferredRead and filename is not None
 
-        if filename == None:
+        if filename is None:
             return
 
         if self.__deferredRead:
@@ -1041,12 +1041,12 @@ class gtoContainer(gto.Reader):
         given filename.  If no filename is given, the filename given to
         the constructor is used.
         """
-        if filename == None:
+        if filename is None:
             filename = self.__filename
         else:
             self.__filename = filename
 
-        if filename == None:
+        if filename is None:
             raise ValueError("No filename specified")
 
         if self.__deferredRead:
@@ -1063,7 +1063,7 @@ class gtoContainer(gto.Reader):
             for o in self.objects():
                 try:
                     o[0][0][0]
-                except:
+                except Exception:
                     # Must have an object with no components or a
                     # component with no properties.
                     pass

--- a/src/plugins/python/network/network/__init__.py
+++ b/src/plugins/python/network/network/__init__.py
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-from .rvNetwork import RvCommunicator
+from .rvNetwork import RvCommunicator as RvCommunicator

--- a/src/plugins/python/network/network/muConsole.py
+++ b/src/plugins/python/network/network/muConsole.py
@@ -27,12 +27,12 @@ class MuConsole:
         while 1:
             time.sleep(0.1)
 
-            l = sys.stdin.readline()
-            if l[0] == "\n":
+            line = sys.stdin.readline()
+            if line[0] == "\n":
                 print("RETURN:", self.rvc.remoteEvalAndReturn(buf))
                 buf = ""
             else:
-                buf += l
+                buf += line
 
             self.rvc.processEvents()
 

--- a/src/plugins/python/network/network/rvNetwork.py
+++ b/src/plugins/python/network/network/rvNetwork.py
@@ -6,7 +6,6 @@
 #
 from __future__ import print_function
 
-import os
 import socket
 import sys
 import time
@@ -92,7 +91,7 @@ class RvCommunicator:
                 self._sendMessage("DISCONNECT")
             self.sock.shutdown(socket.SHUT_RDWR)
             self.sock.close()
-        except:
+        except Exception:
             pass
         self.connected = False
 
@@ -166,8 +165,7 @@ class RvCommunicator:
                 sanitized_msg = (msg.errno, msg.strerror)
             if (
                 sanitized_msg[1] != "Resource temporarily unavailable"
-                and sanitized_msg[1]
-                != "A non-blocking socket operation could not be completed immediately"
+                and sanitized_msg[1] != "A non-blocking socket operation could not be completed immediately"
                 and sanitized_msg[0] != 10035
             ):
                 print("ERROR: peek for messages failed: %s\n" % msg, file=sys.stderr)
@@ -185,7 +183,6 @@ class RvCommunicator:
         return field
 
     def _receiveSingleMessage(self):
-
         messType = 0
         messContents = 0
 
@@ -271,7 +268,6 @@ class RvCommunicator:
         self._processEvents()
 
     def _processEvents(self, processReturnOnly=False):
-
         while 1:
             noMessage = True
             while noMessage:
@@ -300,10 +296,7 @@ class RvCommunicator:
                             file=sys.stderr,
                         )
                         return six.ensure_binary("")
-                elif (
-                    len(self.eventQueue) == 0
-                    or (event, contents) != self.eventQueue[-1:]
-                ):
+                elif len(self.eventQueue) == 0 or (event, contents) != self.eventQueue[-1:]:
                     self.eventQueue.append((event, contents))
 
             elif messType == six.ensure_binary("PING"):

--- a/src/plugins/python/rvSession/rvSession.py
+++ b/src/plugins/python/rvSession/rvSession.py
@@ -37,7 +37,7 @@ CAVEATS:
 
 * This is write-only, no session file reading yet.
 
-* Only version 4 session files (RV v4.0.7 and above) are supported 
+* Only version 4 session files (RV v4.0.7 and above) are supported
 
 RELEASE NOTES:
 
@@ -106,15 +106,11 @@ class _Node:
         """
         nodeType = six.ensure_binary(nodeType)
         try:
-            pipeProp = self.getProperty(
-                pipelineType, pipelineSuffix, "pipeline", "nodes"
-            )
+            pipeProp = self.getProperty(pipelineType, pipelineSuffix, "pipeline", "nodes")
             pipenodes = pipeProp[1] + [nodeType]
         except KeyError:
             pipenodes = [nodeType]
-        self.setProperty(
-            pipelineType, pipelineSuffix, "pipeline", "nodes", gto.STRING, pipenodes
-        )
+        self.setProperty(pipelineType, pipelineSuffix, "pipeline", "nodes", gto.STRING, pipenodes)
 
         return "%s_%d" % (pipelineSuffix, len(pipenodes) - 1)
 
@@ -124,9 +120,7 @@ class _Node:
         return None if it cannot be located.
         """
         try:
-            pipeProp = self.getProperty(
-                pipelineType, pipelineSuffix, "pipeline", "nodes"
-            )
+            pipeProp = self.getProperty(pipelineType, pipelineSuffix, "pipeline", "nodes")
         except KeyError:
             return None
 
@@ -174,10 +168,7 @@ class _Node:
         others may only allow a certain number of inputs.
         """
         if self.maxInputs != -1 and len(self.inputs) + 1 > self.maxInputs:
-            raise Exception(
-                "ERROR: node '%s' (%s) only allowed %d inputs"
-                % (self.name, self.typeName, self.maxInputs)
-            )
+            raise Exception("ERROR: node '%s' (%s) only allowed %d inputs" % (self.name, self.typeName, self.maxInputs))
         else:
             self.inputs.append(node.name)
 
@@ -230,9 +221,7 @@ class Source(_GroupNode):
         """
         Offset must be in _seconds_.
         """
-        self.setProperty(
-            "RVFileSource", "source", "group", "audioOffset", gto.FLOAT, offset
-        )
+        self.setProperty("RVFileSource", "source", "group", "audioOffset", gto.FLOAT, offset)
 
     def setRangeOffset(self, offset):
         """
@@ -240,9 +229,7 @@ class Source(_GroupNode):
         to have the first frame of foo.mov set to 101, set range
         offset to 100.
         """
-        self.setProperty(
-            "RVFileSource", "source", "group", "rangeOffset", gto.INT, offset
-        )
+        self.setProperty("RVFileSource", "source", "group", "rangeOffset", gto.INT, offset)
 
     def setCutIn(self, frame):
         """
@@ -271,10 +258,7 @@ class Source(_GroupNode):
         As a helper, a dictionary can be supplied that will print metadata sorted by the keys
         """
         if isinstance(metadata, dict):
-            metadata = [
-                "{0}={1}".format(k, v)
-                for k, v in sorted(metadata.items(), reverse=True)
-            ]
+            metadata = ["{0}={1}".format(k, v) for k, v in sorted(metadata.items(), reverse=True)]
 
         self.setProperty(
             "RVFileSource",
@@ -292,7 +276,7 @@ class Source(_GroupNode):
         """
         args = ["RVLinearize", "RVLinearizePipelineGroup", "tolinPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
         self.setProperty(
             "RVLinearize",
@@ -311,11 +295,9 @@ class Source(_GroupNode):
         """
         args = ["RVLensWarp", "RVLinearizePipelineGroup", "tolinPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
-        self.setProperty(
-            "RVLensWarp", pipeNode, "warp", "pixelAspectRatio", gto.FLOAT, pa
-        )
+        self.setProperty("RVLensWarp", pipeNode, "warp", "pixelAspectRatio", gto.FLOAT, pa)
         self.setProperty("RVLensWarp", pipeNode, "node", "active", gto.INT, 1)
 
     ## Color
@@ -328,13 +310,11 @@ class Source(_GroupNode):
         """
         args = ["RVColor", "RVColorPipelineGroup", "colorPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
         self.setProperty("RVColor", pipeNode, "color", "exposure", gto.FLOAT, exp)
         self.setProperty("RVColor", pipeNode, "color", "active", gto.INT, 1)
-        self.setProperty(
-            "RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1
-        )
+        self.setProperty("RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1)
         self.setProperty("RVFormat", "format", "color", "maxBitDepth", gto.INT, 0)
 
     def setColorScale(self, scale):
@@ -345,13 +325,11 @@ class Source(_GroupNode):
         """
         args = ["RVColor", "RVColorPipelineGroup", "colorPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
         self.setProperty("RVColor", pipeNode, "color", "scale", gto.FLOAT, scale)
         self.setProperty("RVColor", pipeNode, "color", "active", gto.INT, 1)
-        self.setProperty(
-            "RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1
-        )
+        self.setProperty("RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1)
         self.setProperty("RVFormat", "format", "color", "maxBitDepth", gto.INT, 0)
 
     ## Channels and Layers
@@ -363,19 +341,13 @@ class Source(_GroupNode):
         """
         args = ["RVColor", "RVColorPipelineGroup", "colorPipeline"]
         pipeNode = self.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.addPipelineNode(*args)
-        self.setProperty(
-            "RVColor", pipeNode, "color", "channelOrder", gto.STRING, channelOrder
-        )
+        self.setProperty("RVColor", pipeNode, "color", "channelOrder", gto.STRING, channelOrder)
         self.setProperty("RVColor", pipeNode, "color", "active", gto.INT, 1)
-        self.setProperty(
-            "RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1
-        )
+        self.setProperty("RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1)
         self.setProperty("RVFormat", "format", "color", "maxBitDepth", gto.INT, 0)
-        self.setProperty(
-            "RVFileSource", "source", "request", "readAllChannels", gto.INT, 1
-        )
+        self.setProperty("RVFileSource", "source", "request", "readAllChannels", gto.INT, 1)
 
     def setImageLayerSelection(self, layer):
         """
@@ -395,16 +367,10 @@ class Source(_GroupNode):
         channelMap can be a single channel which represents RGB, or a tuple ("Z","A"). Mapping
         happens in software
         """
-        self.setProperty(
-            "RVChannelMap", "channelMap", "format", "channels", gto.STRING, channelMap
-        )
-        self.setProperty(
-            "RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1
-        )
+        self.setProperty("RVChannelMap", "channelMap", "format", "channels", gto.STRING, channelMap)
+        self.setProperty("RVFormat", "format", "color", "allowFloatingPoint", gto.INT, 1)
         self.setProperty("RVFormat", "format", "color", "maxBitDepth", gto.INT, 0)
-        self.setProperty(
-            "RVFileSource", "source", "request", "readAllChannels", gto.INT, 1
-        )
+        self.setProperty("RVFileSource", "source", "request", "readAllChannels", gto.INT, 1)
 
     ## Text
     def setTextPosition(self, x, y):
@@ -415,17 +381,13 @@ class Source(_GroupNode):
         lower right == 1,1
         upper right == 1,0
         """
-        self.setProperty(
-            "RVPaint", "paint", self.txt.name, "position", gto.FLOAT, (x, y)
-        )
+        self.setProperty("RVPaint", "paint", self.txt.name, "position", gto.FLOAT, (x, y))
 
     def setTextColor(self, r=1, g=1, b=1, a=1):
         """
         modify color to text # note: this should probably use a tuple like other "set" functions
         """
-        self.setProperty(
-            "RVPaint", "paint", self.txt.name, "color", gto.FLOAT, (r, g, b, a)
-        )
+        self.setProperty("RVPaint", "paint", self.txt.name, "color", gto.FLOAT, (r, g, b, a))
 
     def setTextSize(self, size):
         """
@@ -445,9 +407,7 @@ class Source(_GroupNode):
             if k not in ["order", "sourceCount", "name"]:
                 if isinstance(v, str):
                     valueType = gto.STRING
-                self.setProperty(
-                    "RVPaint", "paint", self.txt.name, "{0}".format(k), valueType, v
-                )
+                self.setProperty("RVPaint", "paint", self.txt.name, "{0}".format(k), valueType, v)
         # For layout, but not source
         # self.txt.order.append(self.txt.name)
         return self.txt.name
@@ -620,17 +580,13 @@ class Layout(_GroupNode):
         """
         modify position of text. Positions are x, y values from lower left == 0, upper right == 1
         """
-        self.setProperty(
-            "RVPaint", "paint", self.txt.name, "position", gto.FLOAT, (x, y)
-        )
+        self.setProperty("RVPaint", "paint", self.txt.name, "position", gto.FLOAT, (x, y))
 
     def setTextColor(self, r=1, g=1, b=1, a=1):
         """
         modify color to text
         """
-        self.setProperty(
-            "RVPaint", "paint", self.txt.name, "color", gto.FLOAT, (r, g, b, a)
-        )
+        self.setProperty("RVPaint", "paint", self.txt.name, "color", gto.FLOAT, (r, g, b, a))
 
     def setTextSize(self, size):
         """
@@ -650,9 +606,7 @@ class Layout(_GroupNode):
             if k not in ["order", "sourceCount", "name"]:
                 if isinstance(v, str):
                     valueType = gto.STRING
-                self.setProperty(
-                    "RVPaint", "paint", self.txt.name, "{0}".format(k), valueType, v
-                )
+                self.setProperty("RVPaint", "paint", self.txt.name, "{0}".format(k), valueType, v)
         self.txt.order.append(self.txt.name)
 
     def setFrameNumberForText(self, frame):
@@ -691,7 +645,6 @@ class Layout(_GroupNode):
         scale = 1.0 / nside
 
         pos = []
-        total = 0
         for row in reversed(range(0, nside)):
             y = scale * row - (0.5 * scale)
             for column in range(0, nside):
@@ -770,7 +723,6 @@ class Session:
 
     @staticmethod
     def lookupNodeType(key):
-
         if key in Session.nodeTypes.keys():
             return Session.nodeTypes[key]
 
@@ -808,9 +760,7 @@ class Session:
         LUTs, or stereo modes.
         """
 
-        self.outputGroup.setProperty(
-            objType, objName, contName, propName, valueType, value
-        )
+        self.outputGroup.setProperty(objType, objName, contName, propName, valueType, value)
 
     def newNode(self, nodeType, uiName=None):
         """
@@ -828,10 +778,8 @@ class Session:
         try:
             (objType, cons) = Session.lookupNodeType(nodeType)
             node = cons()
-        except:
-            raise Exception(
-                "Can't construct node of type '%s':" % nodeType, sys.exc_info()[0]
-            )
+        except Exception:
+            raise Exception("Can't construct node of type '%s':" % nodeType, sys.exc_info()[0])
 
         if nodeType == "Source":
             node.name = "sourceGroup%06d" % self.sourceCount
@@ -875,13 +823,12 @@ class Session:
         """
 
         subObjects = {}
-        if obj != None:
+        if obj is not None:
             subObjects[""] = (obj, {})
 
         containers = {}
 
-        for (path, info) in sorted(properties.items()):
-
+        for path, info in sorted(properties.items()):
             (subObjType, subObject, container, prop) = path
             (typeName, value) = info
 
@@ -910,28 +857,22 @@ class Session:
 
             w = 1
             element = value
-            if type(element) == type([]):
+            if type(element) is type([]):
                 element = element[0]
             else:
                 value = [value]
 
-            if type(element) == type((0,)):
+            if type(element) is type((0,)):
                 w = len(element)
 
-            gtoContainer.append(
-                gc.Property(prop, typeName, size=len(value), width=w, data=value)
-            )
+            gtoContainer.append(gc.Property(prop, typeName, size=len(value), width=w, data=value))
 
     def _writeSessionObject(self, top):
-
         top.rv = self._getVersionedObj("rv", "RVSession")
         self._writeProperties(top, top.rv, "rv", self.properties)
 
     def _writeDefaultOutput(self, top):
-
-        top.defaultOutputGroup = self._getVersionedObj(
-            "defaultOutputGroup", "RVOutputGroup"
-        )
+        top.defaultOutputGroup = self._getVersionedObj("defaultOutputGroup", "RVOutputGroup")
         self._writeProperties(
             top,
             top.defaultOutputGroup,
@@ -940,7 +881,6 @@ class Session:
         )
 
     def _writeConnections(self, top):
-
         #
         #   Input order is significant for stack/sequence/layout
         #   nodes, so preserve it here.
@@ -957,9 +897,7 @@ class Session:
         top.connections = self._getVersionedObj("connections", "connection")
 
         top.connections.evaluation = gc.Component("evaluation", "compinterp")
-        top.connections.evaluation.append(
-            gc.Property("connections", gto.STRING, size=len(cons), width=2, data=cons)
-        )
+        top.connections.evaluation.append(gc.Property("connections", gto.STRING, size=len(cons), width=2, data=cons))
 
     def _writeNodes(self, top):
         """
@@ -1014,9 +952,7 @@ class Session:
         "pair"     Left eye on left, Right eye on right
         "mirror"   Like "pair" but with right eye mirrored
         """
-        self.setOutputProperty(
-            "RVOutputDisplayStereo", "stereo", "stereo", "type", gto.STRING, mode
-        )
+        self.setOutputProperty("RVOutputDisplayStereo", "stereo", "stereo", "type", gto.STRING, mode)
 
     def setOutputGamma(self, gamma):
         """
@@ -1024,14 +960,10 @@ class Session:
         """
         args = ["RVDisplayColor", "RVDisplayPipelineGroup", "colorPipeline"]
         pipeNode = self.outputGroup.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.outputGroup.addPipelineNode(*args)
-        self.setOutputProperty(
-            "RVDisplayColor", pipeNode, "color", "gamma", gto.FLOAT, gamma
-        )
-        self.setOutputProperty(
-            "RVDisplayColor", pipeNode, "color", "active", gto.INT, 1
-        )
+        self.setOutputProperty("RVDisplayColor", pipeNode, "color", "gamma", gto.FLOAT, gamma)
+        self.setOutputProperty("RVDisplayColor", pipeNode, "color", "active", gto.INT, 1)
 
         return pipeNode
 
@@ -1041,11 +973,9 @@ class Session:
         """
         args = ["RVDisplayColor", "RVDisplayPipelineGroup", "colorPipeline"]
         pipeNode = self.outputGroup.getPipelineNode(*args)
-        if pipeNode == None:
+        if pipeNode is None:
             pipeNode = self.outputGroup.addPipelineNode(*args)
-        self.setOutputProperty(
-            "RVDisplayColor", pipeNode, "lut", "file", gto.STRING, name
-        )
+        self.setOutputProperty("RVDisplayColor", pipeNode, "lut", "file", gto.STRING, name)
         self.setOutputProperty("RVDIsplayColor", pipeNode, "lut", "active", gto.INT, 1)
 
         return pipeNode

--- a/src/plugins/rv-packages/annot_tools/annot_tools.py
+++ b/src/plugins/rv-packages/annot_tools/annot_tools.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # *****************************************************************************
-import os
 
 import rv.commands as rvc
 import rv.extra_commands as rvec
@@ -58,9 +57,7 @@ class RVAnnotTools(rv.rvtypes.MinorMode):
 
         for frame in range(source_data["startFrame"], source_data["endFrame"] + 1):
             paint_prop = "{}.paint".format(paint_node)
-            text_name = "text:{}:{}:annotation".format(
-                rvc.getIntProperty("{}.nextId".format(paint_prop))[0], frame
-            )
+            text_name = "text:{}:{}:annotation".format(rvc.getIntProperty("{}.nextId".format(paint_prop))[0], frame)
             text_prop = "{}.{}".format(paint_node, text_name)
 
             rvc.setIntProperty("{}.{}".format(paint_prop, "show"), [1])
@@ -68,25 +65,17 @@ class RVAnnotTools(rv.rvtypes.MinorMode):
             rvc.newProperty("{}.{}".format(text_prop, "position"), rvc.FloatType, 2)
             rvc.newProperty("{}.{}".format(text_prop, "color"), rvc.FloatType, 4)
             rvc.newProperty("{}.{}".format(text_prop, "size"), rvc.FloatType, 1)
-            rvc.newProperty(
-                "{}.frame:{}.order".format(paint_node, frame), rvc.StringType, 1
-            )
+            rvc.newProperty("{}.frame:{}.order".format(paint_node, frame), rvc.StringType, 1)
 
             rvc.setStringProperty(
                 "{}.{}".format(text_prop, "text"),
                 ["This is frame {}".format(frame)],
                 True,
             )
-            rvc.setFloatProperty(
-                "{}.{}".format(text_prop, "position"), [-0.6, 0.24], True
-            )
-            rvc.setFloatProperty(
-                "{}.{}".format(text_prop, "color"), [1.0, 1.0, 1.0, 1.0], True
-            )
+            rvc.setFloatProperty("{}.{}".format(text_prop, "position"), [-0.6, 0.24], True)
+            rvc.setFloatProperty("{}.{}".format(text_prop, "color"), [1.0, 1.0, 1.0, 1.0], True)
             rvc.setFloatProperty("{}.{}".format(text_prop, "size"), [0.01], True)
-            rvc.setStringProperty(
-                "{}.frame:{}.order".format(paint_node, frame), [text_name], True
-            )
+            rvc.setStringProperty("{}.frame:{}.order".format(paint_node, frame), [text_name], True)
 
 
 g_the_mode = None

--- a/src/plugins/rv-packages/channel_select/channel_select.py
+++ b/src/plugins/rv-packages/channel_select/channel_select.py
@@ -1,29 +1,23 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands as rvc
 from rv import extra_commands as rve
 from rv import rvtypes as rvt
 
-import os
-import sys
-import re
-
 
 def getColorSelectNodes():
-
     try:
         return rvc.nodesOfType("ChannelSelect")
-    except:
+    except Exception:
         pass
 
     return None
 
 
 def channelIs(node, num):
-
     active = rvc.getIntProperty(node + ".node.active")[0]
     chan = rvc.getIntProperty(node + ".parameters.channel")[0]
 
@@ -32,19 +26,12 @@ def channelIs(node, num):
 
 class ColorSelectMode(rvt.MinorMode):
     def readPrefs(self):
-
-        self._postDisplaySelect = bool(
-            rvc.readSettings("channel_select", "postDisplaySelect", False)
-        )
+        self._postDisplaySelect = bool(rvc.readSettings("channel_select", "postDisplaySelect", False))
 
     def writePrefs(self):
-
-        rvc.writeSettings(
-            "channel_select", "postDisplaySelect", self._postDisplaySelect
-        )
+        rvc.writeSettings("channel_select", "postDisplaySelect", self._postDisplaySelect)
 
     def addChannelSelect(self):
-
         if self._postDisplaySelect:
             groups = []
             for dg in rvc.nodesOfType("RVDisplayGroup"):
@@ -57,7 +44,7 @@ class ColorSelectMode(rvt.MinorMode):
         for g in groups:
             nodes = rvc.getStringProperty(g + ".pipeline.nodes")
 
-            if not ("ChannelSelect" in nodes):
+            if "ChannelSelect" not in nodes:
                 nodes += ["ChannelSelect"]
                 rvc.setStringProperty(g + ".pipeline.nodes", nodes, True)
 
@@ -70,7 +57,6 @@ class ColorSelectMode(rvt.MinorMode):
 
     def toggleChannel(self, num):
         def foo(event):
-
             self.addChannelSelect()
 
             nodes = getColorSelectNodes()
@@ -93,18 +79,15 @@ class ColorSelectMode(rvt.MinorMode):
         return foo
 
     def togglePostDisplaySelect(self, event):
-
         self._postDisplaySelect = not self._postDisplaySelect
         self.writePrefs()
 
     def postDisplaySelectState(self):
-
         if self._postDisplaySelect:
             return rvc.CheckedMenuState
         return rvc.UncheckedMenuState
 
     def __init__(self):
-
         rvt.MinorMode.__init__(self)
 
         self.readPrefs()
@@ -137,5 +120,4 @@ class ColorSelectMode(rvt.MinorMode):
 
 
 def createMode():
-
     return ColorSelectMode()

--- a/src/plugins/rv-packages/collapse_missing_frames/collapse_missing_frames.py
+++ b/src/plugins/rv-packages/collapse_missing_frames/collapse_missing_frames.py
@@ -1,9 +1,9 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
-from rv import rvtypes, commands, extra_commands
+# SPDX-License-Identifier: Apache-2.0
+#
+from rv import rvtypes, commands
 
 
 def groupMemberOfType(node, memberType):
@@ -38,9 +38,7 @@ class CollapseMissingFrames(rvtypes.MinorMode):
             self.collapse(source, True)
 
     def collapse(self, source, force=False):
-        linPG = groupMemberOfType(
-            commands.nodeGroup(source), "RVLinearizePipelineGroup"
-        )
+        linPG = groupMemberOfType(commands.nodeGroup(source), "RVLinearizePipelineGroup")
         retime = groupMemberOfType(linPG, "RVRetime")
         if not force and retime is not None and isCollapsed(retime):
             commands.setIntProperty(retime + ".explicit.active", [0])
@@ -63,17 +61,13 @@ class CollapseMissingFrames(rvtypes.MinorMode):
                         [int(rangeInfo["start"])],
                         True,
                     )
-                    commands.setIntProperty(
-                        retime + ".explicit.inputFrames", partial, True
-                    )
+                    commands.setIntProperty(retime + ".explicit.inputFrames", partial, True)
                     commands.setIntProperty(retime + ".explicit.active", [1])
 
     def collapsed(self):
         sources = commands.sourcesAtFrame(commands.frame())
         for source in sources:
-            linPG = groupMemberOfType(
-                commands.nodeGroup(source), "RVLinearizePipelineGroup"
-            )
+            linPG = groupMemberOfType(commands.nodeGroup(source), "RVLinearizePipelineGroup")
             retime = groupMemberOfType(linPG, "RVRetime")
             if retime is None or not isCollapsed(retime):
                 return commands.UncheckedMenuState
@@ -90,7 +84,6 @@ class CollapseMissingFrames(rvtypes.MinorMode):
         return self._collapseAll
 
     def __init__(self):
-
         rvtypes.MinorMode.__init__(self)
 
         self.init(
@@ -119,9 +112,7 @@ class CollapseMissingFrames(rvtypes.MinorMode):
             ],
         )
 
-        self._collapseAll = commands.readSettings(
-            "COLLAPSE_MISSING", "collapseAll", False
-        )
+        self._collapseAll = commands.readSettings("COLLAPSE_MISSING", "collapseAll", False)
 
 
 def createMode():

--- a/src/plugins/rv-packages/custom_lut_menu_mode/custom_lut_menu_mode.py
+++ b/src/plugins/rv-packages/custom_lut_menu_mode/custom_lut_menu_mode.py
@@ -208,7 +208,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                     searchType = self.lutNodes[lut][1:]
                     xfrmNodes = commands.closestNodesOfType(searchType, source, 0)
                     xfrmNode = xfrmNodes[0]
-                except:
+                except Exception:
                     continue
 
                 try:
@@ -222,13 +222,13 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                         and power == [1, 1, 1]
                         and sat == 1
                     )
-                except:
+                except Exception:
                     defCDL = True
 
                 try:
                     lut = commands.getStringProperty(xfrmNode + ".lut.file")[0]
                     defLUT = lut == ""
-                except:
+                except Exception:
                     defLUT = True
 
                 if not defLUT or not defCDL:
@@ -236,7 +236,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                         commands.setIntProperty(
                             xfrmNode + ".CDL.active", [int(not self._activeCXfrm)], True
                         )
-                    except:
+                    except Exception:
                         pass
                     if self._activeCXfrm:
                         self.restoreDefaultProps(xfrmNode)
@@ -260,7 +260,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
             try:
                 xfrmFile = self._autoLUT[lut]
                 xfrmExt = xfrmFile.split(".")[-1]
-            except:
+            except Exception:
                 print(("ERROR: Unable to determine extension from '%s'" % xfrmFile))
         else:
             dirUp = 0
@@ -272,7 +272,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                     xfrmFile = containing + os.sep + entry
                     break
 
-        if xfrmFile == None:
+        if xfrmFile is None:
             extra_commands.displayFeedback(
                 "Unable to find accompanying color"
                 + " transform with extension '%s'" % self._autoFormat[lut],
@@ -289,7 +289,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
         try:
             searchType = self.lutNodes[lut][1:]
             xfrmNode = extra_commands.associatedNode(searchType, srcNode)
-        except:
+        except Exception:
             print(("ERROR: Unable to find transform node from '%s'" % searchType))
             return
 
@@ -366,17 +366,17 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                     return commands.CheckedMenuState
                 else:
                     return commands.UncheckedMenuState
-            except:
+            except Exception:
                 return commands.DisabledMenuState
 
         return loaded
 
     def setAutoFormat(self, lut, ext):
         def saveSetting(event):
-            if (ext != None and self._autoLevel[lut] < 0) or (ext == None):
+            if (ext is not None and self._autoLevel[lut] < 0) or (ext is None):
                 self.setAutoFormatLevel(lut, 0)(None)
             self._autoFormat[lut] = ext
-            self._autoLoadCXfrm[lut] = ext != None
+            self._autoLoadCXfrm[lut] = ext is not None
             commands.writeSettings(
                 "CUSTOM_LUTS", lut + "loadColorTransform", self._autoLoadCXfrm[lut]
             )
@@ -394,7 +394,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
 
     def isAutoFormat(self, lut, ext):
         def checkFormat():
-            if (ext == None and not self._autoLoadCXfrm[lut]) or (
+            if (ext is None and not self._autoLoadCXfrm[lut]) or (
                 self._autoLoadCXfrm[lut] and self._autoFormat[lut] == ext
             ):
                 return commands.CheckedMenuState
@@ -414,7 +414,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                         "CUSTOM_LUTS", lut + "AutoLut", self._autoLUT[lut]
                     )
                     self.setAutoFormat(lut, "")(None)
-                except:
+                except Exception:
                     return
             self._autoLevel[lut] = level
             commands.writeSettings(
@@ -529,7 +529,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                 commands.writeSettings(
                     "CUSTOM_LUTS", "custom%sDir" % typeStr, self._dirs[typeStr]
                 )
-            except:
+            except Exception:
                 pass
 
         return changeSpecificLUTDir

--- a/src/plugins/rv-packages/data_display_indicators/data_display_indicator_mode.py
+++ b/src/plugins/rv-packages/data_display_indicators/data_display_indicator_mode.py
@@ -3,7 +3,8 @@
 # 
 # SPDX-License-Identifier: Apache-2.0 
 #
-import re, math
+import re
+import math
 
 import rv.rvtypes as rvt
 import rv.commands as rvc

--- a/src/plugins/rv-packages/lat_long_viewer/lat_long_viewer.py
+++ b/src/plugins/rv-packages/lat_long_viewer/lat_long_viewer.py
@@ -11,9 +11,7 @@ from rv import rvtypes as rvt
 
 import rv.runtime
 
-import os
 import sys
-import re
 
 
 def deb(s):

--- a/src/plugins/rv-packages/media_library_demo/media_library_event_plugin.py
+++ b/src/plugins/rv-packages/media_library_demo/media_library_event_plugin.py
@@ -1,22 +1,21 @@
 # Note that this event based Media Library's implementation is not available
 # from rvio because rvio does not support modes.
-plugin_enabled = True
-try:
-    from rv.commands import sendInternalEvent
-except:
-    plugin_enabled = False
 
 from ast import literal_eval
 from typing import Dict, Iterable
+
+plugin_enabled = True
+try:
+    from rv.commands import sendInternalEvent
+except Exception:
+    plugin_enabled = False
 
 
 def is_plugin_enabled() -> bool:
     """
     Returns True if the media library plugin is enabled.
     """
-    return plugin_enabled and bool(
-        literal_eval(sendInternalEvent("media-library-events-are-enabled") or "True")
-    )
+    return plugin_enabled and bool(literal_eval(sendInternalEvent("media-library-events-are-enabled") or "True"))
 
 
 def is_library_media_url(url: str) -> bool:
@@ -31,9 +30,7 @@ def is_streaming(url: str) -> bool:
     Returns True if the given url is a streaming url and should receive cookies and headers.
     """
 
-    return bool(
-        literal_eval(sendInternalEvent("media-library-is-streaming", url) or "True")
-    )
+    return bool(literal_eval(sendInternalEvent("media-library-is-streaming", url) or "True"))
 
 
 def is_redirecting(url: str) -> bool:
@@ -41,9 +38,7 @@ def is_redirecting(url: str) -> bool:
     Returns True if the given url will get redirected by the media library.
     """
 
-    return bool(
-        literal_eval(sendInternalEvent("media-library-is-streaming", url) or "False")
-    )
+    return bool(literal_eval(sendInternalEvent("media-library-is-streaming", url) or "False"))
 
 
 def get_http_cookies(url: str) -> Iterable[Dict]:

--- a/src/plugins/rv-packages/os_dependent_path_conversion/os_dependent_path_conversion_mode.py
+++ b/src/plugins/rv-packages/os_dependent_path_conversion/os_dependent_path_conversion_mode.py
@@ -1,15 +1,15 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
-from rv import rvtypes, commands, rvui
-import platform, re
+# SPDX-License-Identifier: Apache-2.0
+#
+from rv import rvtypes
+import platform
+import re
 
 
 class OSDependentPathConversionModeMinorMode(rvtypes.MinorMode):
     def fixpath(self, event):
-
         #
         #  The contents of the "incoming-source-path" looks like
         #  "filename;;tag".
@@ -21,7 +21,7 @@ class OSDependentPathConversionModeMinorMode(rvtypes.MinorMode):
             try:
                 remainder = m1.group(2) if m1 and m1.group(1) != "" else m2.group(2)
                 final = prefix + remainder
-            except:
+            except Exception:
                 final = path
             return final
 
@@ -45,17 +45,11 @@ class OSDependentPathConversionModeMinorMode(rvtypes.MinorMode):
 
         if len(parts) > 1 and parts[1] == "session":
             if os == "Darwin":
-                outpath = choosePath(
-                    self._macPrefix, self._windowsRE, self._linuxRE, inpath
-                )
+                outpath = choosePath(self._macPrefix, self._windowsRE, self._linuxRE, inpath)
             elif os == "Linux":
-                outpath = choosePath(
-                    self._linuxPrefix, self._windowsRE, self._macRE, inpath
-                )
+                outpath = choosePath(self._linuxPrefix, self._windowsRE, self._macRE, inpath)
             elif os == "Windows":
-                outpath = choosePath(
-                    self._windowsPrefix, self._linuxRE, self._macRE, inpath
-                )
+                outpath = choosePath(self._windowsPrefix, self._linuxRE, self._macRE, inpath)
 
         event.setReturnContent(outpath)
 
@@ -83,20 +77,14 @@ class OSDependentPathConversionModeMinorMode(rvtypes.MinorMode):
         self._windowsRE = re.compile("(%s)(.*)" % self._windowsPrefix)
         self._macRE = re.compile("(%s)(.*)" % self._macPrefix)
 
-        initBindings = [
-            ("incoming-source-path", self.fixpath, "Change path for this platform")
-        ]
+        initBindings = [("incoming-source-path", self.fixpath, "Change path for this platform")]
 
         #
         #  NOTE: All prefix values must be set for any translation
         #  to occur.
         #
 
-        if (
-            self._linuxPrefix == None
-            or self._windowsPrefix == None
-            or self._macPrefix == None
-        ):
+        if self._linuxPrefix is None or self._windowsPrefix is None or self._macPrefix is None:
             initBindings = None
 
         self.init("os-dependent-path-conversion", initBindings, None, None)

--- a/src/plugins/rv-packages/otio_reader/cdlHook.py
+++ b/src/plugins/rv-packages/otio_reader/cdlHook.py
@@ -1,10 +1,10 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
-from rv import extra_commands
-from effectHook import *
+# SPDX-License-Identifier: Apache-2.0
+#
+from rv import extra_commands, commands
+from effectHook import set_rv_effect_props, add_otio_metadata
 
 
 def modify_source(source, otio_cdl):

--- a/src/plugins/rv-packages/otio_reader/clipHook.py
+++ b/src/plugins/rv-packages/otio_reader/clipHook.py
@@ -1,10 +1,10 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
-from rv import commands
-from effectHook import *
+# SPDX-License-Identifier: Apache-2.0
+#
+from effectHook import *  # noqa: F403
+
 
 # this is an example for clip that can be removed or augmented as required
 def hook_function(in_timeline, argument_map=None):

--- a/src/plugins/rv-packages/otio_reader/effectHook.py
+++ b/src/plugins/rv-packages/otio_reader/effectHook.py
@@ -23,8 +23,8 @@ ADD_NODE_TYPE_MAP = {
 }
 
 if sys.version_info < (3,):
-    SET_NODE_TYPE_MAP[unicode] = commands.StringType
-    ADD_NODE_TYPE_MAP[unicode] = commands.StringType
+    SET_NODE_TYPE_MAP[unicode] = commands.StringType  # noqa: F821
+    ADD_NODE_TYPE_MAP[unicode] = commands.StringType  # noqa: F821
 
 
 class NoMappingForRvNode(Exception):
@@ -63,9 +63,7 @@ def add_rv_effect_props(node_component, prop_map):
             prop_name = "{}.{}".format(node_component, prop)
             rv_value = _get_rv_value(value)
 
-            commands.newProperty(
-                prop_name, ADD_NODE_TYPE_MAP[type(rv_value[0])], len(rv_value)
-            )
+            commands.newProperty(prop_name, ADD_NODE_TYPE_MAP[type(rv_value[0])], len(rv_value))
             _set_rv_prop(prop_name, rv_value)
 
 
@@ -84,11 +82,7 @@ def add_otio_metadata(node_component, otio_node):
     if otio_node.metadata:
         add_rv_effect_props(
             node_component,
-            {
-                "otio_metadata": otio.core.serialize_json_to_string(
-                    otio_node.metadata, indent=-1
-                )
-            },
+            {"otio_metadata": otio.core.serialize_json_to_string(otio_node.metadata, indent=-1)},
         )
 
 
@@ -110,7 +104,7 @@ def get_otio_metadata(node_component):
 
 
 def _get_rv_value(value):
-    if type(value) == bool:
+    if type(value) is bool:
         return [1] if value is True else [0]
 
     # OTIO returns AnyVector, so ensure anything iterable is a list

--- a/src/plugins/rv-packages/otio_reader/otio_reader_plugin.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader_plugin.py
@@ -148,18 +148,14 @@ class ExampleOTIOReaderPlugin(rvtypes.MinorMode):
         Adds OTIO to Open File dialog filters
         """
         event.reject()
-        event.setReturnContent(
-            "{}:{}".format(event.returnContents(), "otio;OpenTimelineIO")
-        )
+        event.setReturnContent("{}:{}".format(event.returnContents(), "otio;OpenTimelineIO"))
 
     def otio_export(self, event):
         """
         Exports the currently viewed node to the OTIO file from the event
         """
         event.reject()
-        otio_timeline = otio_writer.write_otio_file(
-            commands.viewNode(), event.contents()
-        )
+        otio_writer.write_otio_file(commands.viewNode(), event.contents())
 
     def expand_sources(self):
         """
@@ -179,11 +175,7 @@ class ExampleOTIOReaderPlugin(rvtypes.MinorMode):
                     continue
 
                 # get the source file name
-                paths = [
-                    info["file"]
-                    for info in commands.sourceMediaInfoList(src)
-                    if "file" in info
-                ]
+                paths = [info["file"] for info in commands.sourceMediaInfoList(src) if "file" in info]
                 for info_path in paths:
                     # Looking for: 'blank,otioFile=/foo.otio.movieproc'
                     parts = info_path.split("=", 1)
@@ -223,16 +215,12 @@ def _remove_source_from_views(source_group):
 
 
 def createMode():
-    support_files_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "..", "SupportFiles", "otio_reader"
-    )
+    support_files_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "SupportFiles", "otio_reader")
 
     manifest_path = os.environ.get("OTIO_PLUGIN_MANIFEST_PATH", "")
     if manifest_path:
         manifest_path += os.pathsep
-    os.environ["OTIO_PLUGIN_MANIFEST_PATH"] = manifest_path + os.path.join(
-        support_files_path, "manifest.json"
-    )
+    os.environ["OTIO_PLUGIN_MANIFEST_PATH"] = manifest_path + os.path.join(support_files_path, "manifest.json")
     sys.path.append(support_files_path)
 
     return ExampleOTIOReaderPlugin()

--- a/src/plugins/rv-packages/otio_reader/sourcePostExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/sourcePostExportHook.py
@@ -1,10 +1,10 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, extra_commands
-from effectHook import *
+from effectHook import get_otio_metadata
 import opentimelineio as otio
 
 
@@ -24,9 +24,7 @@ def hook_function(in_timeline, argument_map):
             slope=commands.getFloatProperty("{}.CDL.slope".format(linearize)),
             power=commands.getFloatProperty("{}.CDL.power".format(linearize)),
             offset=commands.getFloatProperty("{}.CDL.offset".format(linearize)),
-            saturation=commands.getFloatProperty("{}.CDL.saturation".format(linearize))[
-                0
-            ],
+            saturation=commands.getFloatProperty("{}.CDL.saturation".format(linearize))[0],
             visible=True,
         )
 
@@ -40,18 +38,12 @@ def hook_function(in_timeline, argument_map):
             global_translate_vec = otio.schema.V2d(0.0, 0.0)
             global_scale_vec = otio.schema.V2d(1.0, 1.0)
 
-            if commands.propertyExists(
-                "{}.otio.global_translate".format(transform)
-            ) and commands.propertyExists("{}.otio.global_scale".format(transform)):
-                global_translate = commands.getFloatProperty(
-                    "{}.otio.global_translate".format(transform)
-                )
-                global_scale = commands.getFloatProperty(
-                    "{}.otio.global_scale".format(transform)
-                )
-                global_translate_vec = otio.schema.V2d(
-                    global_translate[0], global_translate[1]
-                )
+            if commands.propertyExists("{}.otio.global_translate".format(transform)) and commands.propertyExists(
+                "{}.otio.global_scale".format(transform)
+            ):
+                global_translate = commands.getFloatProperty("{}.otio.global_translate".format(transform))
+                global_scale = commands.getFloatProperty("{}.otio.global_scale".format(transform))
+                global_translate_vec = otio.schema.V2d(global_translate[0], global_translate[1])
                 global_scale_vec = otio.schema.V2d(global_scale[0], global_scale[1])
 
             translate = commands.getFloatProperty(

--- a/src/plugins/rv-packages/otio_reader/timeWarpHook.py
+++ b/src/plugins/rv-packages/otio_reader/timeWarpHook.py
@@ -1,12 +1,12 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import sys
 
 from rv import commands
-from effectHook import *
+from effectHook import set_rv_effect_props
 
 
 def hook_function(in_timeline, argument_map=None):

--- a/src/plugins/rv-packages/pymystuff/pymystuff.py
+++ b/src/plugins/rv-packages/pymystuff/pymystuff.py
@@ -3,19 +3,19 @@
 # 
 # SPDX-License-Identifier: Apache-2.0 
 #
-from rv.rvtypes import *
-from rv.commands import *
-from rv.extra_commands import *
+from rv.rvtypes import MinorMode
+import rv.commands as commands
+import rv.extra_commands as extra_commands
 
 
 class PyMyStuffMode(MinorMode):
     def faster(self, event):
-        setFPS(fps() * 1.5)
-        displayFeedback("%g fps" % fps(), 2.0)
+        commands.setFPS(commands.fps() * 1.5)
+        extra_commands.displayFeedback("%g fps" % commands.fps(), 2.0)
 
     def slower(self, event):
-        setFPS(fps() * 1.0 / 1.5)
-        displayFeedback("%g fps" % fps(), 2.0)
+        commands.setFPS(commands.fps() * 1.0 / 1.5)
+        extra_commands.displayFeedback("%g fps" % commands.fps(), 2.0)
 
     def __init__(self):
         MinorMode.__init__(self)

--- a/src/plugins/rv-packages/pyside_example/pyside_example.py
+++ b/src/plugins/rv-packages/pyside_example/pyside_example.py
@@ -24,8 +24,6 @@ except ImportError:
 from OpenGL.GL import *
 from OpenGL.GLUT import *
 from OpenGL.GLU import *
-import types
-import math
 import rv
 import rv.qtutils
 
@@ -106,7 +104,7 @@ class PySideDockTest(rv.rvtypes.MinorMode):
                     if self.rvSessionQObject is not None:
                         self.rvSessionQObject.setWindowOpacity(0.5)
                     rv.commands.setIntProperty(prop, [0], True)
-            except:
+            except Exception:
                 pass
 
         return F
@@ -129,7 +127,7 @@ class PySideDockTest(rv.rvtypes.MinorMode):
                     p[0] = spins[index].minimum()
                 spins[index].setValue(p[0])
                 rv.commands.setFloatProperty(prop, p, True)
-            except:
+            except Exception:
                 pass
 
         return F
@@ -138,14 +136,14 @@ class PySideDockTest(rv.rvtypes.MinorMode):
         def F(value):
             try:
                 rv.commands.setFloatProperty(prop, [p], True)
-            except:
+            except Exception:
                 pass
 
         def F():
             try:
                 p = spins[index].value()
                 rv.commands.setFloatProperty(prop, [p], True)
-            except:
+            except Exception:
                 pass
 
         return F
@@ -154,7 +152,7 @@ class PySideDockTest(rv.rvtypes.MinorMode):
         array = []
         for n in names:
             array.append(self.dialog.findChild(typeObj, n))
-            if array[-1] == None:
+            if array[-1] is None:
                 print("Can't find", n)
         return array
 

--- a/src/plugins/rv-packages/rvnuke/menu.py
+++ b/src/plugins/rv-packages/rvnuke/menu.py
@@ -1,4 +1,5 @@
 import rvNuke
+import nuke
 
 menubar = nuke.menu("Nuke")
 

--- a/src/plugins/rv-packages/rvnuke/rvNetwork.py
+++ b/src/plugins/rv-packages/rvnuke/rvNetwork.py
@@ -12,7 +12,7 @@ import time
 import os
 
 doDebug = False
-if os.getenv("RV_NUKE_DEBUG") != None:
+if os.getenv("RV_NUKE_DEBUG") is not None:
     doDebug = True
 
 
@@ -74,9 +74,7 @@ class RvCommunicator:
 
         try:
             greeting = "%s rvController" % self.name
-            self.sock.sendall(
-                b"NEWGREETING %d %s" % (len(greeting), greeting.encode("utf-8"))
-            )
+            self.sock.sendall(b"NEWGREETING %d %s" % (len(greeting), greeting.encode("utf-8")))
             if self.noPingPong:
                 self.sock.sendall(b"PINGPONGCONTROL 1 0")
         except socket.error as msg:
@@ -151,8 +149,7 @@ class RvCommunicator:
         except socket.error as msg:
             if (
                 msg.strerror != "Resource temporarily unavailable"
-                and msg.strerror
-                != "A non-blocking socket operation could not be completed immediately"
+                and msg.strerror != "A non-blocking socket operation could not be completed immediately"
                 and msg.errno != 10035
             ):
                 print("ERROR: peek for messages failed: %s\n" % msg, file=sys.stderr)
@@ -174,7 +171,6 @@ class RvCommunicator:
         return field
 
     def _receiveSingleMessage(self):
-
         messType = 0
         messContents = 0
 
@@ -260,7 +256,6 @@ class RvCommunicator:
         self._processEvents()
 
     def _processEvents(self, processReturnOnly=False):
-
         while 1:
             noMessage = True
             while noMessage:
@@ -283,7 +278,7 @@ class RvCommunicator:
                     try:
                         self.sock.shutdown(socket.SHUT_RDWR)
                         self.sock.close()
-                    except:
+                    except Exception:
                         pass
                     self.connected = False
                     return ""
@@ -299,20 +294,13 @@ class RvCommunicator:
                             file=sys.stderr,
                         )
                         return ""
-                elif (
-                    len(self.eventQueue) == 0
-                    or (event, contents) != self.eventQueue[-1:]
-                ):
+                elif len(self.eventQueue) == 0 or (event, contents) != self.eventQueue[-1:]:
                     self.eventQueue.append((event, contents))
 
             elif messType == "PING":
                 self.sock.sendall(b"PONG 1 p")
 
-            elif (
-                messType == "GREETING"
-                or messType == "NEWGREETING"
-                or messType == "PONG"
-            ):
+            elif messType == "GREETING" or messType == "NEWGREETING" or messType == "PONG":
                 #   ignore
                 pass
             else:

--- a/src/plugins/rv-packages/rvnuke/rvNuke.py
+++ b/src/plugins/rv-packages/rvnuke/rvNuke.py
@@ -16,7 +16,6 @@ import time
 import sys
 import select
 import threading
-import string
 
 protocolVersion = 115
 
@@ -25,7 +24,7 @@ rvmon = None
 rvmonProc = None
 
 doDebug = False
-if os.getenv("RV_NUKE_DEBUG") != None:
+if os.getenv("RV_NUKE_DEBUG") is not None:
     doDebug = True
 
 
@@ -59,7 +58,7 @@ def pythonHandler(eventContents):
         log("pythonHandler exec '%s'" % eventContents)
         exec(eventContents, globals(), locals())
         # nuke.executeInMainThread (nuke.selectPattern)
-    except:
+    except Exception:
         log("Remote python exec error: %s\n" % sys.exc_info()[1])
 
 
@@ -273,7 +272,7 @@ class RvMonitor:
                     log("type '%s'" % type(nuke.thisNode()).__name__)
                     log("class '%s'" % nuke.thisNode().Class())
                     nname = nuke.thisNode().name()
-                except:
+                except Exception:
                     pass
             if nuke.thisKnob():
                 kname = nuke.thisKnob().name()
@@ -420,11 +419,11 @@ class RvMonitor:
                         break
                     log("running queued command '%s'" % cmd)
                     self.eval(cmd)
-            except:
+            except Exception:
                 log("can't send messages to RV, shutting down.")
                 try:
                     self.rvc.disconnect()
-                except:
+                except Exception:
                     pass
                 self.running = False
                 self.crashFlag.set()
@@ -439,7 +438,7 @@ class RvMonitor:
                 # log ("selecting")
                 select.select([self.rvc.sock], [], [], 0.1)
                 # log ("selecting done")
-            except:
+            except Exception:
                 log("rvc select/wait error: %s" % sys.exc_info()[1])
 
             #
@@ -448,11 +447,11 @@ class RvMonitor:
             try:
                 # log ("process rv events")
                 self.rvc.processEvents()
-            except:
+            except Exception:
                 log("can't process messages from the RV side, shutting down.")
                 try:
                     self.rvc.disconnect()
-                except:
+                except Exception:
                     pass
                 self.running = False
                 self.crashFlag.set()
@@ -481,7 +480,7 @@ class RvMonitor:
                 # self.rvProc.kill()
                 # self.rvProc.wait()
                 # log ("returncode %s" % self.rvProc.returncode))
-        except:
+        except Exception:
             log("error terminating RV: %s\n" % sys.exc_info()[1])
 
         self.initialized = False
@@ -517,7 +516,7 @@ class RvMonitor:
             try:
                 src = os.environ["SRC_ROOT"]
                 usingBuild = True
-            except:
+            except Exception:
                 pass
 
             cmd = [src + "/build/run", "--p", src + "/bin/nsapps/RV64"]
@@ -536,7 +535,7 @@ class RvMonitor:
         log("starting cmd %s" % str(fullcmd))
         try:
             os.remove(self.portFile)
-        except:
+        except Exception:
             pass
 
         try:
@@ -553,7 +552,7 @@ class RvMonitor:
                     file=sys.stderr,
                 )
                 return
-        except:
+        except Exception:
             log("ERROR: failed to start RV '%s'" % cmd[0])
             print("ERROR: failed to start RV '%s'\n" % cmd[0], file=sys.stderr)
             return
@@ -576,7 +575,7 @@ class RvMonitor:
 
         try:
             os.remove(self.portFile)
-        except:
+        except Exception:
             pass
 
         if self.port != 0:
@@ -717,7 +716,7 @@ class RvMonitor:
             log("making directory '%s'" % sessionDir)
             try:
                 os.makedirs(sessionDir)
-            except:
+            except Exception:
                 pass
 
         self.queueCommand("self.setSessionDir()")
@@ -964,7 +963,7 @@ class RvSettings:
         for k in knobList:
             try:
                 r.removeKnob(r.knob(k))
-            except:
+            except Exception:
                 pass
 
         #
@@ -1034,7 +1033,7 @@ class RvSettings:
         for k in self.settings.keys():
             try:
                 self.settings[k] = r.knob("rvSettings_" + k).value()
-            except:
+            except Exception:
                 log("value failed for '%s'" % k)
                 somethingMissing = True
 
@@ -1049,11 +1048,11 @@ class RvPreferences:
         """
         self.prefs = {}
 
-        plat = platform.system()
+        _plat = platform.system()
         rvPath = ""
         try:
             rvPath = os.environ["RV_PATH"]
-        except:
+        except Exception:
             pass
 
         if rvPath == "":
@@ -1067,7 +1066,7 @@ class RvPreferences:
                 else:
                     rvPath = rvHome + "/bin/rv.exe"
 
-            except:
+            except Exception:
                 if nuke.env["MACOS"]:
                     rvPath = "/Applications/RV64.app/Contents/MacOS/RV64"
                 elif nuke.env["LINUX"]:
@@ -1214,8 +1213,8 @@ def showSettingsPanel():
     """
     log("showSettings")
     try:
-        s = str(nuke.root())
-    except:
+        _s = str(nuke.root())
+    except Exception:
         return
 
     if not nuke.root():
@@ -1223,7 +1222,7 @@ def showSettingsPanel():
 
     rvPrefs = RvPreferences()
 
-    settings = RvSettings(rvPrefs.prefs["sessionDirBase"])
+    _settings = RvSettings(rvPrefs.prefs["sessionDirBase"])
 
     nuke.showSettings()
 
@@ -1319,7 +1318,7 @@ def createCheckpoint():
     viewedInput = None
     viewer = None
     log ("activeViewer %s input %s" % (nuke.activeViewer(), nuke.activeViewer().activeInput()))
-    if (nuke.activeViewer() and nuke.activeViewer().activeInput() != None) :
+    if (nuke.activeViewer() and nuke.activeViewer().activeInput() is not None) :
         log("viewer and activeInput")
         n = nuke.activeViewer().node().input(nuke.activeViewer().activeInput())
         log ("n %s node %s" % (n.name(), node.name()))
@@ -1330,7 +1329,7 @@ def createCheckpoint():
             viewer.setInput(viewedInput, None)
             time.sleep(1)
 
-    if (viewedInput != None) :
+    if (viewedInput is not None) :
         log("restoring viewer")
         viewer.setInput(viewedInput, node)
     """
@@ -1391,7 +1390,7 @@ class RvRenderPanel(nukescripts.PythonPanel):
 
     def updateFromSelection(self):
         log("updateFromSelection")
-        if self.useSelected.value() == True:
+        if self.useSelected.value():
             log("    useSelected True")
             nodes = nuke.selectedNodes()
             log("    %d selected nodes" % len(nodes))
@@ -1410,7 +1409,7 @@ class RvRenderPanel(nukescripts.PythonPanel):
         # log ("reading knobs from Root '%s'" % s)
         try:
             self.readKnobs(s)
-        except:
+        except Exception:
             pass
 
     def saveToRoot(self):
@@ -1577,7 +1576,7 @@ def restoreCheckpoint(nukeScript, nodeName, date):
 
         try:
             v = nuke.activeViewer().node().name()
-        except:
+        except Exception:
             v = None
 
         if rvmon:

--- a/src/plugins/rv-packages/source_setup/source_setup.py
+++ b/src/plugins/rv-packages/source_setup/source_setup.py
@@ -7,7 +7,9 @@ from rv import rvtypes
 from rv import commands
 from rv import extra_commands
 
-import os, re, platform
+import os
+import re
+import platform
 from six.moves.urllib.parse import urlparse
 
 
@@ -57,16 +59,16 @@ class SourceSetupMode(rvtypes.MinorMode):
         group = args[0]
         fileSource = groupMemberOfType(group, "RVFileSource")
         imageSource = groupMemberOfType(group, "RVImageSource")
-        source = fileSource if imageSource == None else imageSource
+        source = fileSource if imageSource is None else imageSource
         linPipeNode = groupMemberOfType(group, "RVLinearizePipelineGroup")
         linNode = groupMemberOfType(linPipeNode, "RVLinearize")
         ICCNode = groupMemberOfType(linPipeNode, "ICCLinearizeTransform")
         lensNode = groupMemberOfType(linPipeNode, "RVLensWarp")
-        fmtNode = groupMemberOfType(group, "RVFormat")
+        _fmtNode = groupMemberOfType(group, "RVFormat")
         tformNode = groupMemberOfType(group, "RVTransform2D")
         lookPipeNode = groupMemberOfType(group, "RVLookPipelineGroup")
-        lookNode = groupMemberOfType(lookPipeNode, "RVLookLUT")
-        typeName = commands.nodeType(source)
+        _lookNode = groupMemberOfType(lookPipeNode, "RVLookLUT")
+        _typeName = commands.nodeType(source)
         fileNames = commands.getStringProperty("%s.media.movie" % source, 0, 1000)
         fileName = fileNames[0]
         ext = fileName.split(".")[-1].upper()
@@ -105,10 +107,10 @@ class SourceSetupMode(rvtypes.MinorMode):
         try:
             srcAttrs = commands.sourceAttributes(source, fileName)
             srcData = commands.sourceDataAttributes(source, fileName)
-        except:
+        except Exception:
             return
 
-        if srcAttrs == None:
+        if srcAttrs is None:
             print(
                 (
                     "ERROR: SourceSetup: source %s/%s has no attributes"
@@ -398,9 +400,9 @@ class SourceSetupMode(rvtypes.MinorMode):
                 commands.setIntProperty(dICCNode + ".node.active", [0], True)
 
             if (
-                dgroup != None
+                dgroup is not None
                 and commands.nodeType(dgroup) == "RVDisplayGroup"
-                and not dgroup in dnodesWithProfile
+                and dgroup not in dnodesWithProfile
             ):
 
                 dICC = commands.getStringProperty(dgroup + ".device.systemProfileURL")
@@ -536,11 +538,11 @@ class SourceSetupMode(rvtypes.MinorMode):
 
         val = commands.commandLineFlag(varSpecific, None)
 
-        if val == None:
+        if val is None:
             val = commands.commandLineFlag(varGeneral, None)
-        if val == None:
+        if val is None:
             val = os.getenv(varSpecific, None)
-        if val == None:
+        if val is None:
             val = os.getenv(varGeneral, transfer)
 
         return val

--- a/src/plugins/rv-packages/stereo_autoload/stereo_autoload.py
+++ b/src/plugins/rv-packages/stereo_autoload/stereo_autoload.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from __future__ import print_function
 
@@ -27,17 +27,10 @@ class StereoAutoloadMode(rvtypes.MinorMode):
             )
         )
 
-        self._autoLoadStereo = bool(
-            commands.readSettings("stereo_autoload", "autoStereo", False)
-        )
-        self._autoLoadAlways = bool(
-            commands.readSettings("stereo_autoload", "autoAlways", False)
-        )
+        self._autoLoadStereo = bool(commands.readSettings("stereo_autoload", "autoStereo", False))
+        self._autoLoadAlways = bool(commands.readSettings("stereo_autoload", "autoAlways", False))
 
-        deb(
-            "    after read: %s %s\n"
-            % (str(self._autoLoadStereo), str(self._autoLoadAlways))
-        )
+        deb("    after read: %s %s\n" % (str(self._autoLoadStereo), str(self._autoLoadAlways)))
 
     def writePrefs(self):
         deb("writing settings %s %s\n" % (self._autoLoadStereo, self._autoLoadAlways))
@@ -76,8 +69,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
             elems = val.split(":")
             if len(elems) % 2 != 0:
                 print(
-                    "ERROR: eyes env var '%s' does not have even number of elements.\n"
-                    % varName,
+                    "ERROR: eyes env var '%s' does not have even number of elements.\n" % varName,
                     file=sys.stderr,
                 )
                 return
@@ -127,7 +119,6 @@ class StereoAutoloadMode(rvtypes.MinorMode):
         return (nviews, leftMedia)
 
     def swapLeftForRight(self, leftMedia):
-
         rightMedia = leftMedia
         for pair in self._pairs:
             rightMedia = re.sub(
@@ -152,7 +143,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
                 rightMedia,
             )
 
-        if not rightMedia in ret:
+        if rightMedia not in ret:
             ret.append(rightMedia)
 
         #
@@ -166,7 +157,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
                 rightMedia,
             )
 
-        if not rightMedia in ret:
+        if rightMedia not in ret:
             ret.append(rightMedia)
 
         return ret
@@ -206,9 +197,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
 
         if not rightMedia:
             for m in rightMediaList:
-                print(
-                    "INFO: Right eye media '%s' does not exist\n" % m, file=sys.stderr
-                )
+                print("INFO: Right eye media '%s' does not exist\n" % m, file=sys.stderr)
             return
 
         #
@@ -228,9 +217,7 @@ class StereoAutoloadMode(rvtypes.MinorMode):
             self.updateSource(s, "force")
 
     def viewStereoOn(self):
-        return (
-            "off" != commands.getStringProperty("#RVDisplayStereo.stereo.type", 0, 1)[0]
-        )
+        return "off" != commands.getStringProperty("#RVDisplayStereo.stereo.type", 0, 1)[0]
 
     def presentationStereoOn(self):
         s = commands.videoState()
@@ -313,7 +300,6 @@ class StereoAutoloadMode(rvtypes.MinorMode):
             self.updateAllSources()
 
     def __init__(self):
-
         rvtypes.MinorMode.__init__(self)
 
         self.initStereoPairs()

--- a/src/plugins/rv-packages/stereo_disassembly/stereo_disassembly.py
+++ b/src/plugins/rv-packages/stereo_disassembly/stereo_disassembly.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from __future__ import print_function
 
@@ -9,11 +9,8 @@ from rv import commands as rvc
 from rv import extra_commands as rve
 from rv import rvtypes as rvt
 
-import rv.runtime
 
-import os
 import sys
-import re
 
 
 def deb(s):
@@ -46,23 +43,17 @@ class StereoDisMode(rvt.MinorMode):
         return nodeType
 
     def readPrefs(self):
-
-        self._expectTopBot = rvc.readSettings(
-            "stereo_disassembly", "expectTopBot", True
-        )
+        self._expectTopBot = rvc.readSettings("stereo_disassembly", "expectTopBot", True)
         self._swapEyes = rvc.readSettings("stereo_disassembly", "swapEyes", True)
         self._squeezed = rvc.readSettings("stereo_disassembly", "squeezed", True)
 
     def writePrefs(self):
-
         rvc.writeSettings("stereo_disassembly", "expectTopBot", self._expectTopBot)
         rvc.writeSettings("stereo_disassembly", "swapEyes", self._swapEyes)
         rvc.writeSettings("stereo_disassembly", "squeezed", self._squeezed)
 
     def addDisNode(self, event):
-
         for pg in linPipeGroups():
-
             deb("addDisNode: checking g %s hasSD %s" % (pg, str(groupHasStereoDis(pg))))
 
             if not groupHasStereoDis(pg):
@@ -102,13 +93,8 @@ class StereoDisMode(rvt.MinorMode):
                     rvc.setIntProperty(sd + ".output.size", size, True)
 
     def removeDisNode(self, event):
-
         for pg in linPipeGroups():
-
-            deb(
-                "removeDisNode: checking g %s hasSD %s"
-                % (pg, str(groupHasStereoDis(pg)))
-            )
+            deb("removeDisNode: checking g %s hasSD %s" % (pg, str(groupHasStereoDis(pg))))
 
             if groupHasStereoDis(pg):
                 sd = stereoDisOfGroup(pg)
@@ -120,28 +106,22 @@ class StereoDisMode(rvt.MinorMode):
                 rvc.setStringProperty(pg + ".pipeline.nodes", newNodes, True)
 
     def toggleTopBotPref(self, event):
-
         self._expectTopBot = not self._expectTopBot
         self.writePrefs()
 
     def toggleSwapEyesPref(self, event):
-
         self._swapEyes = not self._swapEyes
         self.writePrefs()
 
     def toggleSqueezed(self, event):
-
         self._squeezed = not self._squeezed
         self.writePrefs()
 
     def disabledMenuState(self):
-
         return rvc.DisabledMenuState
 
     def noDisNodesState(self):
-
         for pg in linPipeGroups():
-
             deb("checking g %s hasSD %s" % (pg, str(groupHasStereoDis(pg))))
 
             if not groupHasStereoDis(pg):
@@ -150,7 +130,6 @@ class StereoDisMode(rvt.MinorMode):
         return rvc.DisabledMenuState
 
     def haveDisNodesState(self):
-
         for pg in linPipeGroups():
             if groupHasStereoDis(pg):
                 return rvc.UncheckedMenuState
@@ -158,28 +137,24 @@ class StereoDisMode(rvt.MinorMode):
         return rvc.DisabledMenuState
 
     def expectTopBotState(self):
-
         if self._expectTopBot:
             return rvc.CheckedMenuState
 
         return rvc.UncheckedMenuState
 
     def swapEyesState(self):
-
         if self._swapEyes:
             return rvc.CheckedMenuState
 
         return rvc.UncheckedMenuState
 
     def squeezedState(self):
-
         if not self._squeezed:
             return rvc.CheckedMenuState
 
         return rvc.UncheckedMenuState
 
     def __init__(self):
-
         deb("__init__")
         rvt.MinorMode.__init__(self)
 
@@ -243,5 +218,4 @@ class StereoDisMode(rvt.MinorMode):
 
 
 def createMode():
-
     return StereoDisMode()

--- a/src/plugins/rv-packages/webview2/webview2.py
+++ b/src/plugins/rv-packages/webview2/webview2.py
@@ -4,6 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0 
 #
 
+import sys
+import os
+
+
+from rv import rvtypes
+from rv import qtutils
+
 try:
     from PySide2 import QtCore
     from PySide2 import QtWidgets
@@ -31,14 +38,6 @@ except ImportError:
     pass
 
 print(QtWebEngineWidgets.__file__)
-
-import sys, os
-
-import rv.commands
-from shiboken2 import getCppPointer
-
-from rv import rvtypes
-from rv import qtutils
 
 
 class WebView2(rvtypes.MinorMode):


### PR DESCRIPTION
### Lint Python code with Ruff

### Summarize your change.

Run `ruff check --fix` on all Python files with the default linting rules.

Note that multiple files had too many issues that would need to manually be reviewed to follow best practices and pass Ruff linting rules. The idea here was not to fix everything but rather to add tools to make working on this project easier. For that reason, some rules were ignore in specific files in `ruff.toml` that is added in another PR. Since some of these files were added recently, we should to take the time to fix them properly and make sure the code is following Python's conventions.

### Describe the reason for the change.

The project had a formatter but no linter. Ruff is a tool that can do exactly what Black was doing as a formatter while also being able to lint and fix the code following PEP8 at the same time. 