### PR TITLE
Format Python code with Ruff

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,19 +3,19 @@
 # -- Project information
 import re
 
-project = 'Open RV'
-author = 'Open RV contributors'
+project = "Open RV"
+author = "Open RV contributors"
 
-version = '0.0'
-release = '0.0.0'
+version = "0.0"
+release = "0.0.0"
 
 # https://regex101.com/r/Sr8aQX/2
-# This pattern assumes that the SET command follows the typical syntax of a CMake SET command, 
-# with a variable name, a string value enclosed in quotes, and the CACHE STRING clause. 
+# This pattern assumes that the SET command follows the typical syntax of a CMake SET command,
+# with a variable name, a string value enclosed in quotes, and the CACHE STRING clause.
 # It captures the numeric part of the value assigned to these variables.
 pattern = r'SET\(\s*(?:RV_MAJOR_VERSION|RV_MINOR_VERSION|RV_REVISION_NUMBER|RV_VERSION_YEAR)\s*"(\d+)"\s*CACHE\s*STRING\s*"[^"]+"\s*\)'
 # Open the file and read its contents
-with open('../CMakeLists.txt', 'r') as file:
+with open("../CMakeLists.txt", "r") as file:
     text = file.read()
 
 # Find all matches of the pattern in the text
@@ -25,11 +25,11 @@ matches = re.findall(pattern, text)
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 #
 # version
-# The major project version, used as the replacement for |version|. 
+# The major project version, used as the replacement for |version|.
 # For example, for the Python documentation, this may be something like 2.6.
 #
 # release
-# The full project version, used as the replacement for |release| and e.g. in the HTML templates. 
+# The full project version, used as the replacement for |release| and e.g. in the HTML templates.
 # For example, for the Python documentation, this may be something like 2.6.0rc1.
 #
 # If you don’t need the separation provided between version and release, just set them both to the same value.
@@ -41,29 +41,29 @@ copyright = matches[3]
 # -- General configuration
 
 extensions = [
-    'myst_parser',
-    'sphinx_carousel.carousel',
-    'sphinx_copybutton',
-    'sphinx.ext.duration',
-    'sphinx.ext.doctest',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
-    'sphinx_tabs.tabs',
-    'sphinx_rtd_theme'
+    "myst_parser",
+    "sphinx_carousel.carousel",
+    "sphinx_copybutton",
+    "sphinx.ext.duration",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx_tabs.tabs",
+    "sphinx_rtd_theme",
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
-intersphinx_disabled_domains = ['std']
+intersphinx_disabled_domains = ["std"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # -- Options for HTML output
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # -- Options for EPUB output
-epub_show_urls = 'footnote'
+epub_show_urls = "footnote"

--- a/src/bin/mu/mu-interp/test/ack.py
+++ b/src/bin/mu/mu-interp/test/ack.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-# 
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
-# 
+#
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 import sys
 
 sys.setrecursionlimit(10000)

--- a/src/bin/mu/mu-interp/test/tak.py
+++ b/src/bin/mu/mu-interp/test/tak.py
@@ -1,8 +1,8 @@
 #! /depot/python/arch/bin/python
-# 
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+#
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 # takeuchi benchmark in Python
 # see <url:http://www.lib.uchicago.edu/keith/crisis/benchmarks/tak/>

--- a/src/bin/python/py-interp/tests/__init__.py
+++ b/src/bin/python/py-interp/tests/__init__.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import os
 import unittest
@@ -10,7 +10,5 @@ import unittest
 class TestBaseSetup(unittest.TestCase):
     def test_qt_env_var(self):
         qt_platform = os.environ.get("QT_QPA_PLATFORM")
-        self.assertIsNotNone(
-            qt_platform, "Was expecting the QT_QPA_PLATFORM environment variable"
-        )
+        self.assertIsNotNone(qt_platform, "Was expecting the QT_QPA_PLATFORM environment variable")
         self.assertEqual("minimal", qt_platform)

--- a/src/build/install_all_rvpkg.py
+++ b/src/build/install_all_rvpkg.py
@@ -12,10 +12,7 @@ def get_packages_from_dir(packages_source_folder: pathlib.Path) -> [pathlib.Path
 
 
 def install_rvpkg_packages(
-    *,
-    rvpkg_path: pathlib.Path,
-    packages_source_folder: pathlib.Path,
-    packages_destination_folder: pathlib.Path
+    *, rvpkg_path: pathlib.Path, packages_source_folder: pathlib.Path, packages_destination_folder: pathlib.Path
 ) -> None:
     command = [
         rvpkg_path,
@@ -33,9 +30,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--rvpkg", dest="rvpkg_path", type=pathlib.Path, required=True)
-    parser.add_argument(
-        "--source", dest="packages_source_folder", type=pathlib.Path, required=True
-    )
+    parser.add_argument("--source", dest="packages_source_folder", type=pathlib.Path, required=True)
     parser.add_argument(
         "--destination",
         dest="packages_destination_folder",

--- a/src/build/make_openssl.py
+++ b/src/build/make_openssl.py
@@ -34,9 +34,7 @@ def get_openssl_args(root) -> List[str]:
 
     :return: Path to the openssl binary
     """
-    openssl_bins = glob.glob(
-        os.path.join(root, "**", "bin", "openssl*"), recursive=True
-    )
+    openssl_bins = glob.glob(os.path.join(root, "**", "bin", "openssl*"), recursive=True)
 
     print(openssl_bins)
 
@@ -136,9 +134,7 @@ def test_openssl_distribution() -> None:
         openssl_bin = get_openssl_args(tmp_openssl_dir)
 
         subprocess_env = os.environ.copy()
-        subprocess_env.update(
-            {"LD_LIBRARY_PATH": os.path.join(tmp_openssl_dir, LIB_DIR)}
-        )
+        subprocess_env.update({"LD_LIBRARY_PATH": os.path.join(tmp_openssl_dir, LIB_DIR)})
 
         print(f"Executing {openssl_bin}")
         subprocess.run(
@@ -242,9 +238,7 @@ if __name__ == "__main__":
     parser.add_argument("--output-dir", dest="output", type=pathlib.Path, required=True)
 
     parser.add_argument("--arch", dest="arch", type=str, required=False, default="")
-    parser.add_argument(
-        "--perlroot", dest="perlroot", type=str, required=False, default=""
-    )
+    parser.add_argument("--perlroot", dest="perlroot", type=str, required=False, default="")
 
     parser.add_argument("--vfx_platform", dest="vfx_platform", type=int, required=True)
 

--- a/src/build/patch_PySide2/windows_desktop.py
+++ b/src/build/patch_PySide2/windows_desktop.py
@@ -20,9 +20,7 @@ def prepare_packages_win32(self, vars):
     # For now, debug symbols will not be shipped into the package.
     copy_pdbs = False
     pdbs = []
-    if (
-        self.debug or OPTION["DEBUG"] or self.build_type == "RelWithDebInfo"
-    ) and copy_pdbs:
+    if (self.debug or OPTION["DEBUG"] or self.build_type == "RelWithDebInfo") and copy_pdbs:
         pdbs = ["*.pdb"]
 
     # <install>/lib/site-packages/{st_package_name}/* ->
@@ -115,10 +113,7 @@ def prepare_packages_win32(self, vars):
             vars=vars,
         )
 
-    if (
-        config.is_internal_shiboken_generator_build()
-        or config.is_internal_pyside_build()
-    ):
+    if config.is_internal_shiboken_generator_build() or config.is_internal_pyside_build():
         # <install>/include/* -> <setup>/{st_package_name}/include
         copydir(
             "{install_dir}/include/{cmake_package_name}",
@@ -224,14 +219,10 @@ def prepare_packages_win32(self, vars):
             # Re-generate examples Qt resource files for Python 3
             # compatibility
             if sys.version_info[0] == 3:
-                examples_path = "{st_build_dir}/{st_package_name}/examples".format(
-                    **vars
-                )
+                examples_path = "{st_build_dir}/{st_package_name}/examples".format(**vars)
                 pyside_rcc_path = "{install_dir}/bin/rcc.exe".format(**vars)
                 pyside_rcc_options = ["-g", "python"]
-                regenerate_qt_resources(
-                    examples_path, pyside_rcc_path, pyside_rcc_options
-                )
+                regenerate_qt_resources(examples_path, pyside_rcc_path, pyside_rcc_options)
 
         if vars["ssl_libs_dir"]:
             # <ssl_libs>/* -> <setup>/{st_package_name}/openssl
@@ -248,10 +239,7 @@ def prepare_packages_win32(self, vars):
         # shiboken module, because libshiboken uses C++ code.
         copy_msvc_redist_files(vars, "{build_dir}/msvc_redist".format(**vars))
 
-    if (
-        config.is_internal_pyside_build()
-        or config.is_internal_shiboken_generator_build()
-    ):
+    if config.is_internal_pyside_build() or config.is_internal_shiboken_generator_build():
         copy_qt_artifacts(self, copy_pdbs, vars)
         copy_msvc_redist_files(vars, "{build_dir}/msvc_redist".format(**vars))
 
@@ -418,9 +406,7 @@ def copy_qt_artifacts(self, copy_pdbs, vars):
                 return os.path.exists(path)
 
         # e.g. "/home/work/qt/qtbase/bin/Qt5Coredd.dll"
-        other_config_path = os.path.join(
-            file_path_dir_name, maybe_debug_name + file_ext
-        )
+        other_config_path = os.path.join(file_path_dir_name, maybe_debug_name + file_ext)
 
         if filter_match(file_name, filter) and predicate(other_config_path):
             return True
@@ -441,9 +427,7 @@ def copy_qt_artifacts(self, copy_pdbs, vars):
         pdb_pattern = "*{}.pdb"
         if copy_pdbs:
             plugin_dll_patterns += [pdb_pattern]
-        plugin_dll_filter = functools.partial(
-            qt_build_config_filter, plugin_dll_patterns
-        )
+        plugin_dll_filter = functools.partial(qt_build_config_filter, plugin_dll_patterns)
         copydir(
             "{qt_plugins_dir}",
             "{st_build_dir}/{st_package_name}/plugins",
@@ -500,9 +484,7 @@ def copy_qt_artifacts(self, copy_pdbs, vars):
             vars=vars,
         )
 
-        filter = "QtWebEngineProcess{}.exe".format(
-            "d" if (self.debug or OPTION["DEBUG"]) else ""
-        )
+        filter = "QtWebEngineProcess{}.exe".format("d" if (self.debug or OPTION["DEBUG"]) else "")
         copydir(
             "{qt_bin_dir}",
             "{st_build_dir}/{st_package_name}",

--- a/src/lib/app/py_rvui/rv/extra_commands.py
+++ b/src/lib/app/py_rvui/rv/extra_commands.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 def __dummy__():
     pass

--- a/src/lib/app/py_rvui/rv/qtutils.py
+++ b/src/lib/app/py_rvui/rv/qtutils.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import rv.commands
 
@@ -12,14 +12,14 @@ try:
     from shiboken2 import wrapInstance
     from shiboken2 import getCppPointer
 except ImportError:
-  try:
-    from PySide6 import QtGui, QtWidgets
-    from PySide6.QtGui import *
-    from PySide6.QtWidgets import *
-    from shiboken6 import wrapInstance
-    from shiboken6 import getCppPointer
-  except ImportError:
-    pass
+    try:
+        from PySide6 import QtGui, QtWidgets
+        from PySide6.QtGui import *
+        from PySide6.QtWidgets import *
+        from shiboken6 import wrapInstance
+        from shiboken6 import getCppPointer
+    except ImportError:
+        pass
 
 
 def sessionWindow():

--- a/src/lib/app/py_rvui/rv/runtime.py
+++ b/src/lib/app/py_rvui/rv/runtime.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import os
 
@@ -12,18 +12,16 @@ def __dummy__():
 
 def setup_webview_default_profile():
     default_profile = QWebEngineProfile.defaultProfile()
-    user_agent = (
-        default_profile.httpUserAgent() + " RV/" + os.environ["TWK_APP_VERSION"]
-    )
+    user_agent = default_profile.httpUserAgent() + " RV/" + os.environ["TWK_APP_VERSION"]
     default_profile.setHttpUserAgent(user_agent)
 
 
 try:
     from PySide2.QtWebEngineWidgets import QWebEngineProfile
 except ImportError:
-  try:
-    from PySide6.QtWebEngineCore import QWebEngineProfile
-  except ImportError:
-    pass
+    try:
+        from PySide6.QtWebEngineCore import QWebEngineProfile
+    except ImportError:
+        pass
 
 setup_webview_default_profile()

--- a/src/lib/mu/MuQt5/qt512_to_mu.py
+++ b/src/lib/mu/MuQt5/qt512_to_mu.py
@@ -1124,12 +1124,8 @@ exclusionMap = {
     ],
     # QFile has funky semantics which screw things up in QFileInfo
     # so these have to be done manually
-    "QFileInfo::QFileInfo": [
-        ("QFileInfo", "", [("file", "const QFile &", None)], "", False)
-    ],
-    "QFileInfo::setFile": [
-        ("setFile", "", [("file", "const QFile &", None)], "void", False)
-    ],
+    "QFileInfo::QFileInfo": [("QFileInfo", "", [("file", "const QFile &", None)], "", False)],
+    "QFileInfo::setFile": [("setFile", "", [("file", "const QFile &", None)], "void", False)],
     "QFileInfo::operator!=": [
         (
             "operator!=",
@@ -1177,9 +1173,7 @@ exclusionMap = {
     "QEvent::LeaveEditFocus": None,  # ????
     "QAbstractSpinBox::fixup": None,  # return val is arg
     "QTouchEvent::QTouchEvent": None,
-    "QStyle::polish": [
-        ("polish", "", [("palette", "QPalette &", None)], "virtual void", False)
-    ],
+    "QStyle::polish": [("polish", "", [("palette", "QPalette &", None)], "virtual void", False)],
     "QTextDocument::undo": None,  # Takes a TextCursor* needs manual imp
     "QTextDocument::redo": None,  # same
     "QSlider::sliderChange": None,  # protected
@@ -1566,9 +1560,7 @@ def parseParameter(param, n):
         return ("", param, None)
     if "=" in parts:
         index = indexInList("=", parts)
-        default = sstrip(
-            reduce(lambda x, y: str(x) + " " + str(y), parts[index + 1 :], "")
-        )
+        default = sstrip(reduce(lambda x, y: str(x) + " " + str(y), parts[index + 1 :], ""))
         name = parts[index - 1]
         del parts[index - 1 :]
     elif "*" in parts or "&" in parts:
@@ -1768,12 +1760,7 @@ class NamespaceInfo:
         global api
         for i in self.enums:
             fullname = "%s::%s" % (self.name, name)
-            if (
-                i.name == name
-                or i.name == fullname
-                or i.flags == name
-                or i.flags == fullname
-            ):
+            if i.name == name or i.name == fullname or i.flags == name or i.flags == fullname:
                 return True
             for p in self.inherits:
                 if api.classes.has_key(p):
@@ -1786,12 +1773,7 @@ class NamespaceInfo:
         global api
         for i in self.enums:
             fullname = "%s::%s" % (self.name, name)
-            if (
-                i.name == name
-                or i.name == fullname
-                or i.flags == name
-                or i.flags == fullname
-            ):
+            if i.name == name or i.name == fullname or i.flags == name or i.flags == fullname:
                 return i.name
             for p in self.inherits:
                 if p not in api.classes.keys():
@@ -2000,9 +1982,7 @@ class MuFunction:
             self.rtype = '"%s"' % rtype
             # message("%s failed because rtype == %s" % (name, rtype))
 
-        self.compiled = mangleName(
-            "qt_%s_%s_%s" % (muclass.name, name, conditionType(self.rtype))
-        )
+        self.compiled = mangleName("qt_%s_%s_%s" % (muclass.name, name, conditionType(self.rtype)))
 
         #
         #   Test for functions that were already successfully translated
@@ -2083,9 +2063,7 @@ class MuFunction:
                 # this for some value types. Generally Qt rarely used
                 # default parameter values before Qt 5
                 # right now only ints, flags, and enums are supported
-                if aval is not None and doesFunctionAllowDefaultValues(
-                    self.muclass, self.name
-                ):
+                if aval is not None and doesFunctionAllowDefaultValues(self.muclass, self.name):
                     if atype == "int":
                         out += ", Value((int)%s)" % self.muclass.qualifyValue(aval)
                 out += "), "
@@ -2214,10 +2192,7 @@ class MuFunction:
                 expr = "%s(" % self.name
             else:
                 if inheritable:
-                    expr = (
-                        "new MuQt_%s(param_this, NODE_THREAD.process()->callEnv()"
-                        % self.name
-                    )
+                    expr = "new MuQt_%s(param_this, NODE_THREAD.process()->callEnv()" % self.name
                     if len(self.args) > 1:
                         expr += ", "
                 else:
@@ -2401,9 +2376,7 @@ class MuFunction:
                         body += "    return %s;\n" % convertTo(expr, qtrtype)
         elif muclass.pointertype:
             if self.isconstructor:
-                body += "    %s;\n    return param_this;\n" % setExpr(
-                    "param_this", expr, muclass.name
-                )
+                body += "    %s;\n    return param_this;\n" % setExpr("param_this", expr, muclass.name)
             elif self.rtype == "void":
                 body += "    %s;\n" % expr
                 if self.ismember:
@@ -2466,11 +2439,7 @@ class MuClass:
         self.globalfuncs = []
         self.castoperators = []
         self.enums = []
-        self.F_trans = (
-            lambda f: not f.failed
-            and not f.isprop
-            and (self.inheritable or not f.isprotected)
-        )
+        self.F_trans = lambda f: not f.failed and not f.isprop and (self.inheritable or not f.isprotected)
         self.funcCount = {}
         self.inherits = []
         self.inheritedby = []
@@ -2499,9 +2468,7 @@ class MuClass:
                     mufunc = MuFunction(api, self, newqtfunc, True, False, True)
                     self.castoperators.append(mufunc)
             elif not fname.startswith("~") and not exclude:
-                mufunc = MuFunction(
-                    api, self, f, True, f in qtnamespace.protectedfuncs, False
-                )
+                mufunc = MuFunction(api, self, f, True, f in qtnamespace.protectedfuncs, False)
                 if mufunc.virtual and not mufunc.failed:
                     mufunc.virtualSlot = len(self.virtuals)
                     self.virtuals.append(mufunc)
@@ -2520,9 +2487,7 @@ class MuClass:
             for ft in self.inheritedVirtuals:
                 (f, protected, origin) = ft
                 fhere = self.name + "::" + f[0]
-                if not self.hasFunction(f[0]) and not isFunctionExcluded(
-                    qtnamespace, f
-                ):
+                if not self.hasFunction(f[0]) and not isFunctionExcluded(qtnamespace, f):
                     mufunc = MuFunction(api, self, f, True, protected, False)
                     if mufunc.virtual and not mufunc.failed:
                         mufunc.virtualSlot = len(self.virtuals)
@@ -2536,11 +2501,7 @@ class MuClass:
             cppname = qtnamespace.name + "::" + fname
             exclude = isFunctionExcluded(qtnamespace, f)
             if not exclude:
-                self.statics.append(
-                    MuFunction(
-                        api, self, f, False, f in qtnamespace.protectedfuncs, False
-                    )
-                )
+                self.statics.append(MuFunction(api, self, f, False, f in qtnamespace.protectedfuncs, False))
 
         for e in qtnamespace.enums:
             cppname = qtnamespace.name + "::" + e.name.split(":")[-1]
@@ -2562,9 +2523,7 @@ class MuClass:
                     if not self.hasFunction(f[0]) and "~" not in f[0]:
                         # if self.name == "QLayout":
                         #    print " -> ",str(f)
-                        self.inheritedVirtuals.append(
-                            (f, f in qtnamespace.protectedfuncs, qtnamespace)
-                        )
+                        self.inheritedVirtuals.append((f, f in qtnamespace.protectedfuncs, qtnamespace))
             for p in qtnamespace.parents:
                 self.collectVirtuals(p)
 
@@ -2636,18 +2595,14 @@ class MuClass:
 
     def outputCompiledNodes(self):
         out = ""
-        for f in filter(
-            self.F_trans, self.functions + self.statics + self.castoperators
-        ):
+        for f in filter(self.F_trans, self.functions + self.statics + self.castoperators):
             out += f.compiledFunction()
             out += "\n"
         return out
 
     def outputNodeImplementations(self):
         out = ""
-        for f in filter(
-            self.F_trans, self.functions + self.statics + self.castoperators
-        ):
+        for f in filter(self.F_trans, self.functions + self.statics + self.castoperators):
             out += f.nodeImplementation()
             out += "\n"
         return out
@@ -2792,9 +2747,7 @@ class MuClass:
     def qualifyValue(self, value):
         if "(" in value or "|" in value:
             newvalue = value
-            parts = (
-                value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
-            )
+            parts = value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
             for p in parts:
                 if p != "" and p is not None:
                     if self.needsLocalQualification(p):
@@ -2849,13 +2802,7 @@ class MuClass:
                     # rtype_clean = rtype
                     # output the function rtype name and args
                     if f.isconstructor:
-                        out += (
-                            "MuQt_"
-                            + name
-                            + "::MuQt_"
-                            + name
-                            + "(Pointer muobj, const CallEnvironment* ce"
-                        )
+                        out += "MuQt_" + name + "::MuQt_" + name + "(Pointer muobj, const CallEnvironment* ce"
                     else:
                         out += rtype_clean + " MuQt_" + self.name + "::" + name + "("
 
@@ -2893,9 +2840,7 @@ class MuClass:
                         out += "    _env = ce;\n"
                         out += "    _obj = reinterpret_cast<ClassInstance*>(muobj);\n"
                         out += "    _obj->retainExternal();\n"
-                        out += (
-                            "    MuLangContext* c = (MuLangContext*)_env->context();\n"
-                        )
+                        out += "    MuLangContext* c = (MuLangContext*)_env->context();\n"
                         out += (
                             '    _baseType = c->findSymbolOfTypeByQualifiedName<%sType>(c->internName("qt.%s"));\n'
                             % (self.name, self.name)
@@ -2923,18 +2868,11 @@ class MuClass:
                             if rtype_clean == "void":
                                 out += " return; }"
                             out += "\n"
-                        out += (
-                            "    MuLangContext* c = (MuLangContext*)_env->context();\n"
-                        )
-                        out += (
-                            "    const MemberFunction* F0 = _baseType->_func[%d];\n"
-                            % f.virtualSlot
-                        )
+                        out += "    MuLangContext* c = (MuLangContext*)_env->context();\n"
+                        out += "    const MemberFunction* F0 = _baseType->_func[%d];\n" % f.virtualSlot
                         out += "    const MemberFunction* F = _obj->classType()->dynamicLookup(F0);\n"
                         out += "    if (F != F0) \n    {\n"
-                        out += "        Function::ArgumentVector args(%d);\n" % (
-                            len(params) + 1
-                        )
+                        out += "        Function::ArgumentVector args(%d);\n" % (len(params) + 1)
                         # if f.name == "splitPath":
                         #   print str(parms)
                         out += "        args[0] = Value(Pointer(_obj));\n"
@@ -2947,10 +2885,7 @@ class MuClass:
                             )
                         out += "        Value rval = _env->call(F, args);\n"
                         if f.rtype != "void":
-                            out += (
-                                "        return %s;\n"
-                                % f.derefExp(f.unpackReturnValue("rval"), f.rtype)[0]
-                            )
+                            out += "        return %s;\n" % f.derefExp(f.unpackReturnValue("rval"), f.rtype)[0]
                         out += "    }\n"
                         out += "    else\n"
                         out += "    {\n        "
@@ -3001,12 +2936,7 @@ class MuClass:
                         protected = False
                         out += "  public:\n"
                     if f.isconstructor:
-                        out += (
-                            "    "
-                            + "MuQt_"
-                            + name
-                            + "(Pointer muobj, const CallEnvironment*"
-                        )
+                        out += "    " + "MuQt_" + name + "(Pointer muobj, const CallEnvironment*"
                     else:
                         out += "    " + rtype + " " + name + "("
                     for i in range(0, len(params)):
@@ -3029,9 +2959,7 @@ class MuClass:
                             nameSuffix = ""
                             if parent:
                                 nameSuffix = "_parent"
-                            out += (
-                                "    " + nvrtype + " " + name + "_pub%s(" % nameSuffix
-                            )
+                            out += "    " + nvrtype + " " + name + "_pub%s(" % nameSuffix
                             for i in range(0, len(params)):
                                 p = params[i]
                                 (pname, ptype, pval) = p
@@ -3071,7 +2999,6 @@ class MuClass:
         return out
 
     def outputSourceFiles(self):
-
         name = self.name
         if name == "":
             name = "Global"
@@ -3155,9 +3082,7 @@ class MuClass:
                     cpplines.append("    const char** propExclusions = 0;")
             elif line.find("{%%nativeObject%%}") != -1:
                 if self.name == "QObject":
-                    cpplines.append(
-                        '   new MemberVariable(c, "native", "qt.NativeObject"),'
-                    )
+                    cpplines.append('   new MemberVariable(c, "native", "qt.NativeObject"),')
             elif line.find("{%%addHandRolledSymbols%%}") != -1:
                 if hsyms:
                     cpplines.extend(hsyms)
@@ -3202,17 +3127,11 @@ class MuClass:
                     hlines.append("\n")
                 elif line.find("{%%isInheritableFunc%%}") != -1:
                     if self.inheritable:
-                        hlines.append(
-                            "    static bool isInheritable() { return true; }\n"
-                        )
+                        hlines.append("    static bool isInheritable() { return true; }\n")
                     else:
-                        hlines.append(
-                            "    static bool isInheritable() { return false; }\n"
-                        )
+                        hlines.append("    static bool isInheritable() { return false; }\n")
                 elif line.find("{%%virtualArray%%}") != -1:
-                    hlines.append(
-                        "    MemberFunction* _func[%d];\n" % len(self.virtuals)
-                    )
+                    hlines.append("    MemberFunction* _func[%d];\n" % len(self.virtuals))
                 elif line.find("{%%cachedInstanceFunc%%}") != -1:
                     if self.inheritable:
                         hlines.append(
@@ -3609,16 +3528,10 @@ class QtDocParser(SGMLParser):
                     self.inherits.append(data)
             elif self.h2:
                 self.intypes = False
-                if (
-                    data == "Public Functions"
-                    or data == "Reimplemented Public Functions"
-                ):
+                if data == "Public Functions" or data == "Reimplemented Public Functions":
                     self.bucket = self.public
                     self.functable = True
-                elif (
-                    data == "Protected Functions"
-                    or data == "Reimplemented Protected Functions"
-                ):
+                elif data == "Protected Functions" or data == "Reimplemented Protected Functions":
                     self.bucket = self.protected
                     self.functable = True
                 elif data == "Static Public Members":
@@ -3659,9 +3572,7 @@ class QtDocParser(SGMLParser):
         self.qtnamespace.staticfuncs = filter(F, map(P, self.staticPublic))
         self.qtnamespace.signals = filter(F, map(P, self.signals))
         self.qtnamespace.protectedfuncs = filter(F, map(P, self.protected))
-        self.qtnamespace.functions = (
-            self.qtnamespace.publicfuncs + self.qtnamespace.protectedfuncs
-        )
+        self.qtnamespace.functions = self.qtnamespace.publicfuncs + self.qtnamespace.protectedfuncs
 
         rootnamespace.staticfuncs += filter(F, map(P, self.globaldefs))
 

--- a/src/lib/mu/MuQt5/qt515_to_mu.py
+++ b/src/lib/mu/MuQt5/qt515_to_mu.py
@@ -1292,9 +1292,7 @@ exclusionMap = {
     "QEvent::LeaveEditFocus": None,  # ????
     "QAbstractSpinBox::fixup": None,  # return val is arg
     "QTouchEvent::QTouchEvent": None,
-    "QStyle::polish": [
-        ("polish", "", [("palette", "QPalette &", None)], "virtual void", False)
-    ],
+    "QStyle::polish": [("polish", "", [("palette", "QPalette &", None)], "virtual void", False)],
     "QTextDocument::undo": None,  # Takes a TextCursor* needs manual imp
     "QTextDocument::redo": None,  # same
     "QSlider::sliderChange": None,  # protected
@@ -1812,9 +1810,7 @@ def parseParameter(param, n):
         return ("", param, None)
     if "=" in parts:
         index = indexInList("=", parts)
-        default = sstrip(
-            reduce(lambda x, y: str(x) + " " + str(y), parts[index + 1 :], "")
-        )
+        default = sstrip(reduce(lambda x, y: str(x) + " " + str(y), parts[index + 1 :], ""))
         name = parts[index - 1]
         del parts[index - 1 :]
     elif "*" in parts or "&" in parts:
@@ -2091,12 +2087,7 @@ class NamespaceInfo:
         global api
         for i in self.enums:
             fullname = "%s::%s" % (self.name, name)
-            if (
-                i.name == name
-                or i.name == fullname
-                or i.flags == name
-                or i.flags == fullname
-            ):
+            if i.name == name or i.name == fullname or i.flags == name or i.flags == fullname:
                 return True
             for p in self.inherits:
                 if api.classes.has_key(p):
@@ -2109,12 +2100,7 @@ class NamespaceInfo:
         global api
         for i in self.enums:
             fullname = "%s::%s" % (self.name, name)
-            if (
-                i.name == name
-                or i.name == fullname
-                or i.flags == name
-                or i.flags == fullname
-            ):
+            if i.name == name or i.name == fullname or i.flags == name or i.flags == fullname:
                 return i.name
             for p in self.inherits:
                 if p not in api.classes.keys():
@@ -2317,10 +2303,7 @@ class MuFunction:
             mutype = api.translate(atype, c)
             if mutype is None:
                 self.failed = True
-                message(
-                    "%s failed because api.translate(%s,%s) return None"
-                    % (name, atype, c)
-                )
+                message("%s failed because api.translate(%s,%s) return None" % (name, atype, c))
                 mutype = '"%s"' % atype
             self.args.append((aname, mutype, aval))
 
@@ -2344,9 +2327,7 @@ class MuFunction:
             self.rtype = '"%s"' % rtype
             message("%s failed because rtype == %s" % (name, rtype))
 
-        self.compiled = mangleName(
-            "qt_%s_%s_%s" % (muclass.name, name, conditionType(self.rtype))
-        )
+        self.compiled = mangleName("qt_%s_%s_%s" % (muclass.name, name, conditionType(self.rtype)))
 
         #
         #   Test for functions that were already successfully translated
@@ -2429,9 +2410,7 @@ class MuFunction:
                 # this for some value types. Generally Qt rarely used
                 # default parameter values before Qt 5
                 # right now only ints, flags, and enums are supported
-                if aval is not None and doesFunctionAllowDefaultValues(
-                    self.muclass, self.name
-                ):
+                if aval is not None and doesFunctionAllowDefaultValues(self.muclass, self.name):
                     if atype == "int":
                         out += ", Value((int)%s)" % self.muclass.qualifyValue(aval)
                 out += "), "
@@ -2569,10 +2548,7 @@ class MuFunction:
                 expr = "%s(" % self.name
             else:
                 if inheritable:
-                    expr = (
-                        "new MuQt_%s(param_this, NODE_THREAD.process()->callEnv()"
-                        % self.name
-                    )
+                    expr = "new MuQt_%s(param_this, NODE_THREAD.process()->callEnv()" % self.name
                     if len(self.args) > 1:
                         expr += ", "
                 else:
@@ -2759,9 +2735,7 @@ class MuFunction:
                         body += "    return %s;\n" % convertTo(expr, qtrtype)
         elif muclass.pointertype:
             if self.isconstructor:
-                body += "    %s;\n    return param_this;\n" % setExpr(
-                    "param_this", expr, muclass.name
-                )
+                body += "    %s;\n    return param_this;\n" % setExpr("param_this", expr, muclass.name)
             elif self.rtype == "void":
                 body += "    %s;\n" % expr
                 if self.ismember:
@@ -2824,11 +2798,7 @@ class MuClass:
         self.globalfuncs = []
         self.castoperators = []
         self.enums = []
-        self.F_trans = (
-            lambda f: not f.failed
-            and not f.isprop
-            and (self.inheritable or not f.isprotected)
-        )
+        self.F_trans = lambda f: not f.failed and not f.isprop and (self.inheritable or not f.isprotected)
         self.funcCount = {}
         self.inherits = []
         self.inheritedby = []
@@ -2844,10 +2814,7 @@ class MuClass:
             fname = f[0]
             rtype = f[3]
             cppname = qtnamespace.name + "::" + fname
-            message(
-                "functions fname = %s, rtype = %s, cppname = %s"
-                % (fname, rtype, cppname)
-            )
+            message("functions fname = %s, rtype = %s, cppname = %s" % (fname, rtype, cppname))
             exclude = isFunctionExcluded(qtnamespace, f)
             if exclude and verbose:
                 print("EXCLUDED:", str(f))
@@ -2861,9 +2828,7 @@ class MuClass:
                     mufunc = MuFunction(api, self, newqtfunc, True, False, True)
                     self.castoperators.append(mufunc)
             elif not fname.startswith("~") and not exclude:
-                mufunc = MuFunction(
-                    api, self, f, True, f in qtnamespace.protectedfuncs, False
-                )
+                mufunc = MuFunction(api, self, f, True, f in qtnamespace.protectedfuncs, False)
                 if mufunc.virtual and not mufunc.failed:
                     mufunc.virtualSlot = len(self.virtuals)
                     self.virtuals.append(mufunc)
@@ -2882,9 +2847,7 @@ class MuClass:
             for ft in self.inheritedVirtuals:
                 (f, protected, origin) = ft
                 fhere = self.name + "::" + f[0]
-                if not self.hasFunction(f[0]) and not isFunctionExcluded(
-                    qtnamespace, f
-                ):
+                if not self.hasFunction(f[0]) and not isFunctionExcluded(qtnamespace, f):
                     mufunc = MuFunction(api, self, f, True, protected, False)
                     if mufunc.virtual and not mufunc.failed:
                         mufunc.virtualSlot = len(self.virtuals)
@@ -2898,16 +2861,9 @@ class MuClass:
             cppname = qtnamespace.name + "::" + fname
             exclude = isFunctionExcluded(qtnamespace, f)
             print(qtnamespace)
-            message(
-                "staticfuncs fname = %s, cppname = %s, exclude = %s"
-                % (fname, cppname, str(exclude))
-            )
+            message("staticfuncs fname = %s, cppname = %s, exclude = %s" % (fname, cppname, str(exclude)))
             if not exclude:
-                self.statics.append(
-                    MuFunction(
-                        api, self, f, False, f in qtnamespace.protectedfuncs, False
-                    )
-                )
+                self.statics.append(MuFunction(api, self, f, False, f in qtnamespace.protectedfuncs, False))
 
         for e in qtnamespace.enums:
             cppname = qtnamespace.name + "::" + e.name.split(":")[-1]
@@ -2929,9 +2885,7 @@ class MuClass:
                     if not self.hasFunction(f[0]) and "~" not in f[0]:
                         # if self.name == "QLayout":
                         #    print " -> ",str(f)
-                        self.inheritedVirtuals.append(
-                            (f, f in qtnamespace.protectedfuncs, qtnamespace)
-                        )
+                        self.inheritedVirtuals.append((f, f in qtnamespace.protectedfuncs, qtnamespace))
             for p in qtnamespace.parents:
                 self.collectVirtuals(p)
 
@@ -3003,9 +2957,7 @@ class MuClass:
 
     def outputCompiledNodes(self):
         out = ""
-        for f in filter(
-            self.F_trans, self.functions + self.statics + self.castoperators
-        ):
+        for f in filter(self.F_trans, self.functions + self.statics + self.castoperators):
             out += f.compiledFunction()
             out += "\n"
         return out
@@ -3014,9 +2966,7 @@ class MuClass:
         out = ""
         print("self.statics for {0}".format(self.name))
 
-        for f in filter(
-            self.F_trans, self.functions + self.statics + self.castoperators
-        ):
+        for f in filter(self.F_trans, self.functions + self.statics + self.castoperators):
             out += f.nodeImplementation()
             out += "\n"
         return out
@@ -3161,9 +3111,7 @@ class MuClass:
     def qualifyValue(self, value):
         if "(" in value or "|" in value:
             newvalue = value
-            parts = (
-                value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
-            )
+            parts = value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
             for p in parts:
                 if p != "" and p is not None:
                     if self.needsLocalQualification(p):
@@ -3218,13 +3166,7 @@ class MuClass:
                     # rtype_clean = rtype
                     # output the function rtype name and args
                     if f.isconstructor:
-                        out += (
-                            "MuQt_"
-                            + name
-                            + "::MuQt_"
-                            + name
-                            + "(Pointer muobj, const CallEnvironment* ce"
-                        )
+                        out += "MuQt_" + name + "::MuQt_" + name + "(Pointer muobj, const CallEnvironment* ce"
                     else:
                         out += rtype_clean + " MuQt_" + self.name + "::" + name + "("
 
@@ -3262,9 +3204,7 @@ class MuClass:
                         out += "    _env = ce;\n"
                         out += "    _obj = reinterpret_cast<ClassInstance*>(muobj);\n"
                         out += "    _obj->retainExternal();\n"
-                        out += (
-                            "    MuLangContext* c = (MuLangContext*)_env->context();\n"
-                        )
+                        out += "    MuLangContext* c = (MuLangContext*)_env->context();\n"
                         out += (
                             '    _baseType = c->findSymbolOfTypeByQualifiedName<%sType>(c->internName("qt.%s"));\n'
                             % (self.name, self.name)
@@ -3292,18 +3232,11 @@ class MuClass:
                             if rtype_clean == "void":
                                 out += " return; }"
                             out += "\n"
-                        out += (
-                            "    MuLangContext* c = (MuLangContext*)_env->context();\n"
-                        )
-                        out += (
-                            "    const MemberFunction* F0 = _baseType->_func[%d];\n"
-                            % f.virtualSlot
-                        )
+                        out += "    MuLangContext* c = (MuLangContext*)_env->context();\n"
+                        out += "    const MemberFunction* F0 = _baseType->_func[%d];\n" % f.virtualSlot
                         out += "    const MemberFunction* F = _obj->classType()->dynamicLookup(F0);\n"
                         out += "    if (F != F0) \n    {\n"
-                        out += "        Function::ArgumentVector args(%d);\n" % (
-                            len(params) + 1
-                        )
+                        out += "        Function::ArgumentVector args(%d);\n" % (len(params) + 1)
                         # if f.name == "splitPath":
                         #   print str(parms)
                         out += "        args[0] = Value(Pointer(_obj));\n"
@@ -3316,10 +3249,7 @@ class MuClass:
                             )
                         out += "        Value rval = _env->call(F, args);\n"
                         if f.rtype != "void":
-                            out += (
-                                "        return %s;\n"
-                                % f.derefExp(f.unpackReturnValue("rval"), f.rtype)[0]
-                            )
+                            out += "        return %s;\n" % f.derefExp(f.unpackReturnValue("rval"), f.rtype)[0]
                         out += "    }\n"
                         out += "    else\n"
                         out += "    {\n        "
@@ -3372,12 +3302,7 @@ class MuClass:
                         protected = False
                         out += "  public:\n"
                     if f.isconstructor:
-                        out += (
-                            "    "
-                            + "MuQt_"
-                            + name
-                            + "(Pointer muobj, const CallEnvironment*"
-                        )
+                        out += "    " + "MuQt_" + name + "(Pointer muobj, const CallEnvironment*"
                     else:
                         out += "    " + rtype + " " + name + "("
                     for i in range(0, len(params)):
@@ -3400,9 +3325,7 @@ class MuClass:
                             nameSuffix = ""
                             if parent:
                                 nameSuffix = "_parent"
-                            out += (
-                                "    " + nvrtype + " " + name + "_pub%s(" % nameSuffix
-                            )
+                            out += "    " + nvrtype + " " + name + "_pub%s(" % nameSuffix
                             for i in range(0, len(params)):
                                 p = params[i]
                                 (pname, ptype, pval) = p
@@ -3442,7 +3365,6 @@ class MuClass:
         return out
 
     def outputSourceFiles(self):
-
         name = self.name
         if name == "":
             name = "Global"
@@ -3529,9 +3451,7 @@ class MuClass:
                     cpplines.append("    const char** propExclusions = 0;")
             elif line.find("{%%nativeObject%%}") != -1:
                 if self.name == "QObject":
-                    cpplines.append(
-                        '   new MemberVariable(c, "native", "qt.NativeObject"),'
-                    )
+                    cpplines.append('   new MemberVariable(c, "native", "qt.NativeObject"),')
             elif line.find("{%%addHandRolledSymbols%%}") != -1:
                 if hsyms:
                     cpplines.extend(hsyms)
@@ -3576,17 +3496,11 @@ class MuClass:
                     hlines.append("\n")
                 elif line.find("{%%isInheritableFunc%%}") != -1:
                     if self.inheritable:
-                        hlines.append(
-                            "    static bool isInheritable() { return true; }\n"
-                        )
+                        hlines.append("    static bool isInheritable() { return true; }\n")
                     else:
-                        hlines.append(
-                            "    static bool isInheritable() { return false; }\n"
-                        )
+                        hlines.append("    static bool isInheritable() { return false; }\n")
                 elif line.find("{%%virtualArray%%}") != -1:
-                    hlines.append(
-                        "    MemberFunction* _func[%d];\n" % len(self.virtuals)
-                    )
+                    hlines.append("    MemberFunction* _func[%d];\n" % len(self.virtuals))
                 elif line.find("{%%cachedInstanceFunc%%}") != -1:
                     if self.inheritable:
                         hlines.append(
@@ -3989,16 +3903,10 @@ class QtDocParser(SGMLParser):
                     self.inherits.append(data)
             elif self.h2:
                 self.intypes = False
-                if (
-                    data == "Public Functions"
-                    or data == "Reimplemented Public Functions"
-                ):
+                if data == "Public Functions" or data == "Reimplemented Public Functions":
                     self.bucket = self.public
                     self.functable = True
-                elif (
-                    data == "Protected Functions"
-                    or data == "Reimplemented Protected Functions"
-                ):
+                elif data == "Protected Functions" or data == "Reimplemented Protected Functions":
                     self.bucket = self.protected
                     self.functable = True
                 elif data == "Static Public Members":
@@ -4039,9 +3947,7 @@ class QtDocParser(SGMLParser):
         self.qtnamespace.staticfuncs = filter(F, map(P, self.staticPublic))
         self.qtnamespace.signals = filter(F, map(P, self.signals))
         self.qtnamespace.protectedfuncs = filter(F, map(P, self.protected))
-        self.qtnamespace.functions = (
-            self.qtnamespace.publicfuncs + self.qtnamespace.protectedfuncs
-        )
+        self.qtnamespace.functions = self.qtnamespace.publicfuncs + self.qtnamespace.protectedfuncs
 
         rootnamespace.staticfuncs += filter(F, map(P, self.globaldefs))
 

--- a/src/lib/mu/MuQt6/qt6_to_mu.py
+++ b/src/lib/mu/MuQt6/qt6_to_mu.py
@@ -1292,9 +1292,7 @@ exclusionMap = {
     "QEvent::LeaveEditFocus": None,  # ????
     "QAbstractSpinBox::fixup": None,  # return val is arg
     "QTouchEvent::QTouchEvent": None,
-    "QStyle::polish": [
-        ("polish", "", [("palette", "QPalette &", None)], "virtual void", False)
-    ],
+    "QStyle::polish": [("polish", "", [("palette", "QPalette &", None)], "virtual void", False)],
     "QTextDocument::undo": None,  # Takes a TextCursor* needs manual imp
     "QTextDocument::redo": None,  # same
     "QSlider::sliderChange": None,  # protected
@@ -1812,9 +1810,7 @@ def parseParameter(param, n):
         return ("", param, None)
     if "=" in parts:
         index = indexInList("=", parts)
-        default = sstrip(
-            reduce(lambda x, y: str(x) + " " + str(y), parts[index + 1 :], "")
-        )
+        default = sstrip(reduce(lambda x, y: str(x) + " " + str(y), parts[index + 1 :], ""))
         name = parts[index - 1]
         del parts[index - 1 :]
     elif "*" in parts or "&" in parts:
@@ -2091,12 +2087,7 @@ class NamespaceInfo:
         global api
         for i in self.enums:
             fullname = "%s::%s" % (self.name, name)
-            if (
-                i.name == name
-                or i.name == fullname
-                or i.flags == name
-                or i.flags == fullname
-            ):
+            if i.name == name or i.name == fullname or i.flags == name or i.flags == fullname:
                 return True
             for p in self.inherits:
                 if api.classes.has_key(p):
@@ -2109,12 +2100,7 @@ class NamespaceInfo:
         global api
         for i in self.enums:
             fullname = "%s::%s" % (self.name, name)
-            if (
-                i.name == name
-                or i.name == fullname
-                or i.flags == name
-                or i.flags == fullname
-            ):
+            if i.name == name or i.name == fullname or i.flags == name or i.flags == fullname:
                 return i.name
             for p in self.inherits:
                 if p not in api.classes.keys():
@@ -2317,10 +2303,7 @@ class MuFunction:
             mutype = api.translate(atype, c)
             if mutype is None:
                 self.failed = True
-                message(
-                    "%s failed because api.translate(%s,%s) return None"
-                    % (name, atype, c)
-                )
+                message("%s failed because api.translate(%s,%s) return None" % (name, atype, c))
                 mutype = '"%s"' % atype
             self.args.append((aname, mutype, aval))
 
@@ -2344,9 +2327,7 @@ class MuFunction:
             self.rtype = '"%s"' % rtype
             message("%s failed because rtype == %s" % (name, rtype))
 
-        self.compiled = mangleName(
-            "qt_%s_%s_%s" % (muclass.name, name, conditionType(self.rtype))
-        )
+        self.compiled = mangleName("qt_%s_%s_%s" % (muclass.name, name, conditionType(self.rtype)))
 
         #
         #   Test for functions that were already successfully translated
@@ -2429,9 +2410,7 @@ class MuFunction:
                 # this for some value types. Generally Qt rarely used
                 # default parameter values before Qt 5
                 # right now only ints, flags, and enums are supported
-                if aval is not None and doesFunctionAllowDefaultValues(
-                    self.muclass, self.name
-                ):
+                if aval is not None and doesFunctionAllowDefaultValues(self.muclass, self.name):
                     if atype == "int":
                         out += ", Value((int)%s)" % self.muclass.qualifyValue(aval)
                 out += "), "
@@ -2569,10 +2548,7 @@ class MuFunction:
                 expr = "%s(" % self.name
             else:
                 if inheritable:
-                    expr = (
-                        "new MuQt_%s(param_this, NODE_THREAD.process()->callEnv()"
-                        % self.name
-                    )
+                    expr = "new MuQt_%s(param_this, NODE_THREAD.process()->callEnv()" % self.name
                     if len(self.args) > 1:
                         expr += ", "
                 else:
@@ -2759,9 +2735,7 @@ class MuFunction:
                         body += "    return %s;\n" % convertTo(expr, qtrtype)
         elif muclass.pointertype:
             if self.isconstructor:
-                body += "    %s;\n    return param_this;\n" % setExpr(
-                    "param_this", expr, muclass.name
-                )
+                body += "    %s;\n    return param_this;\n" % setExpr("param_this", expr, muclass.name)
             elif self.rtype == "void":
                 body += "    %s;\n" % expr
                 if self.ismember:
@@ -2824,11 +2798,7 @@ class MuClass:
         self.globalfuncs = []
         self.castoperators = []
         self.enums = []
-        self.F_trans = (
-            lambda f: not f.failed
-            and not f.isprop
-            and (self.inheritable or not f.isprotected)
-        )
+        self.F_trans = lambda f: not f.failed and not f.isprop and (self.inheritable or not f.isprotected)
         self.funcCount = {}
         self.inherits = []
         self.inheritedby = []
@@ -2844,10 +2814,7 @@ class MuClass:
             fname = f[0]
             rtype = f[3]
             cppname = qtnamespace.name + "::" + fname
-            message(
-                "functions fname = %s, rtype = %s, cppname = %s"
-                % (fname, rtype, cppname)
-            )
+            message("functions fname = %s, rtype = %s, cppname = %s" % (fname, rtype, cppname))
             exclude = isFunctionExcluded(qtnamespace, f)
             if exclude and verbose:
                 print("EXCLUDED:", str(f))
@@ -2861,9 +2828,7 @@ class MuClass:
                     mufunc = MuFunction(api, self, newqtfunc, True, False, True)
                     self.castoperators.append(mufunc)
             elif not fname.startswith("~") and not exclude:
-                mufunc = MuFunction(
-                    api, self, f, True, f in qtnamespace.protectedfuncs, False
-                )
+                mufunc = MuFunction(api, self, f, True, f in qtnamespace.protectedfuncs, False)
                 if mufunc.virtual and not mufunc.failed:
                     mufunc.virtualSlot = len(self.virtuals)
                     self.virtuals.append(mufunc)
@@ -2882,9 +2847,7 @@ class MuClass:
             for ft in self.inheritedVirtuals:
                 (f, protected, origin) = ft
                 fhere = self.name + "::" + f[0]
-                if not self.hasFunction(f[0]) and not isFunctionExcluded(
-                    qtnamespace, f
-                ):
+                if not self.hasFunction(f[0]) and not isFunctionExcluded(qtnamespace, f):
                     mufunc = MuFunction(api, self, f, True, protected, False)
                     if mufunc.virtual and not mufunc.failed:
                         mufunc.virtualSlot = len(self.virtuals)
@@ -2898,16 +2861,9 @@ class MuClass:
             cppname = qtnamespace.name + "::" + fname
             exclude = isFunctionExcluded(qtnamespace, f)
             print(qtnamespace)
-            message(
-                "staticfuncs fname = %s, cppname = %s, exclude = %s"
-                % (fname, cppname, str(exclude))
-            )
+            message("staticfuncs fname = %s, cppname = %s, exclude = %s" % (fname, cppname, str(exclude)))
             if not exclude:
-                self.statics.append(
-                    MuFunction(
-                        api, self, f, False, f in qtnamespace.protectedfuncs, False
-                    )
-                )
+                self.statics.append(MuFunction(api, self, f, False, f in qtnamespace.protectedfuncs, False))
 
         for e in qtnamespace.enums:
             cppname = qtnamespace.name + "::" + e.name.split(":")[-1]
@@ -2929,9 +2885,7 @@ class MuClass:
                     if not self.hasFunction(f[0]) and "~" not in f[0]:
                         # if self.name == "QLayout":
                         #    print " -> ",str(f)
-                        self.inheritedVirtuals.append(
-                            (f, f in qtnamespace.protectedfuncs, qtnamespace)
-                        )
+                        self.inheritedVirtuals.append((f, f in qtnamespace.protectedfuncs, qtnamespace))
             for p in qtnamespace.parents:
                 self.collectVirtuals(p)
 
@@ -3003,9 +2957,7 @@ class MuClass:
 
     def outputCompiledNodes(self):
         out = ""
-        for f in filter(
-            self.F_trans, self.functions + self.statics + self.castoperators
-        ):
+        for f in filter(self.F_trans, self.functions + self.statics + self.castoperators):
             out += f.compiledFunction()
             out += "\n"
         return out
@@ -3014,9 +2966,7 @@ class MuClass:
         out = ""
         print("self.statics for {0}".format(self.name))
 
-        for f in filter(
-            self.F_trans, self.functions + self.statics + self.castoperators
-        ):
+        for f in filter(self.F_trans, self.functions + self.statics + self.castoperators):
             out += f.nodeImplementation()
             out += "\n"
         return out
@@ -3161,9 +3111,7 @@ class MuClass:
     def qualifyValue(self, value):
         if "(" in value or "|" in value:
             newvalue = value
-            parts = (
-                value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
-            )
+            parts = value.replace("(", " ").replace(")", " ").replace("|", " ").split(" ")
             for p in parts:
                 if p != "" and p is not None:
                     if self.needsLocalQualification(p):
@@ -3218,13 +3166,7 @@ class MuClass:
                     # rtype_clean = rtype
                     # output the function rtype name and args
                     if f.isconstructor:
-                        out += (
-                            "MuQt_"
-                            + name
-                            + "::MuQt_"
-                            + name
-                            + "(Pointer muobj, const CallEnvironment* ce"
-                        )
+                        out += "MuQt_" + name + "::MuQt_" + name + "(Pointer muobj, const CallEnvironment* ce"
                     else:
                         out += rtype_clean + " MuQt_" + self.name + "::" + name + "("
 
@@ -3262,9 +3204,7 @@ class MuClass:
                         out += "    _env = ce;\n"
                         out += "    _obj = reinterpret_cast<ClassInstance*>(muobj);\n"
                         out += "    _obj->retainExternal();\n"
-                        out += (
-                            "    MuLangContext* c = (MuLangContext*)_env->context();\n"
-                        )
+                        out += "    MuLangContext* c = (MuLangContext*)_env->context();\n"
                         out += (
                             '    _baseType = c->findSymbolOfTypeByQualifiedName<%sType>(c->internName("qt.%s"));\n'
                             % (self.name, self.name)
@@ -3292,18 +3232,11 @@ class MuClass:
                             if rtype_clean == "void":
                                 out += " return; }"
                             out += "\n"
-                        out += (
-                            "    MuLangContext* c = (MuLangContext*)_env->context();\n"
-                        )
-                        out += (
-                            "    const MemberFunction* F0 = _baseType->_func[%d];\n"
-                            % f.virtualSlot
-                        )
+                        out += "    MuLangContext* c = (MuLangContext*)_env->context();\n"
+                        out += "    const MemberFunction* F0 = _baseType->_func[%d];\n" % f.virtualSlot
                         out += "    const MemberFunction* F = _obj->classType()->dynamicLookup(F0);\n"
                         out += "    if (F != F0) \n    {\n"
-                        out += "        Function::ArgumentVector args(%d);\n" % (
-                            len(params) + 1
-                        )
+                        out += "        Function::ArgumentVector args(%d);\n" % (len(params) + 1)
                         # if f.name == "splitPath":
                         #   print str(parms)
                         out += "        args[0] = Value(Pointer(_obj));\n"
@@ -3316,10 +3249,7 @@ class MuClass:
                             )
                         out += "        Value rval = _env->call(F, args);\n"
                         if f.rtype != "void":
-                            out += (
-                                "        return %s;\n"
-                                % f.derefExp(f.unpackReturnValue("rval"), f.rtype)[0]
-                            )
+                            out += "        return %s;\n" % f.derefExp(f.unpackReturnValue("rval"), f.rtype)[0]
                         out += "    }\n"
                         out += "    else\n"
                         out += "    {\n        "
@@ -3372,12 +3302,7 @@ class MuClass:
                         protected = False
                         out += "  public:\n"
                     if f.isconstructor:
-                        out += (
-                            "    "
-                            + "MuQt_"
-                            + name
-                            + "(Pointer muobj, const CallEnvironment*"
-                        )
+                        out += "    " + "MuQt_" + name + "(Pointer muobj, const CallEnvironment*"
                     else:
                         out += "    " + rtype + " " + name + "("
                     for i in range(0, len(params)):
@@ -3400,9 +3325,7 @@ class MuClass:
                             nameSuffix = ""
                             if parent:
                                 nameSuffix = "_parent"
-                            out += (
-                                "    " + nvrtype + " " + name + "_pub%s(" % nameSuffix
-                            )
+                            out += "    " + nvrtype + " " + name + "_pub%s(" % nameSuffix
                             for i in range(0, len(params)):
                                 p = params[i]
                                 (pname, ptype, pval) = p
@@ -3442,7 +3365,6 @@ class MuClass:
         return out
 
     def outputSourceFiles(self):
-
         name = self.name
         if name == "":
             name = "Global"
@@ -3529,9 +3451,7 @@ class MuClass:
                     cpplines.append("    const char** propExclusions = 0;")
             elif line.find("{%%nativeObject%%}") != -1:
                 if self.name == "QObject":
-                    cpplines.append(
-                        '   new MemberVariable(c, "native", "qt.NativeObject"),'
-                    )
+                    cpplines.append('   new MemberVariable(c, "native", "qt.NativeObject"),')
             elif line.find("{%%addHandRolledSymbols%%}") != -1:
                 if hsyms:
                     cpplines.extend(hsyms)
@@ -3576,17 +3496,11 @@ class MuClass:
                     hlines.append("\n")
                 elif line.find("{%%isInheritableFunc%%}") != -1:
                     if self.inheritable:
-                        hlines.append(
-                            "    static bool isInheritable() { return true; }\n"
-                        )
+                        hlines.append("    static bool isInheritable() { return true; }\n")
                     else:
-                        hlines.append(
-                            "    static bool isInheritable() { return false; }\n"
-                        )
+                        hlines.append("    static bool isInheritable() { return false; }\n")
                 elif line.find("{%%virtualArray%%}") != -1:
-                    hlines.append(
-                        "    MemberFunction* _func[%d];\n" % len(self.virtuals)
-                    )
+                    hlines.append("    MemberFunction* _func[%d];\n" % len(self.virtuals))
                 elif line.find("{%%cachedInstanceFunc%%}") != -1:
                     if self.inheritable:
                         hlines.append(
@@ -3989,16 +3903,10 @@ class QtDocParser(SGMLParser):
                     self.inherits.append(data)
             elif self.h2:
                 self.intypes = False
-                if (
-                    data == "Public Functions"
-                    or data == "Reimplemented Public Functions"
-                ):
+                if data == "Public Functions" or data == "Reimplemented Public Functions":
                     self.bucket = self.public
                     self.functable = True
-                elif (
-                    data == "Protected Functions"
-                    or data == "Reimplemented Protected Functions"
-                ):
+                elif data == "Protected Functions" or data == "Reimplemented Protected Functions":
                     self.bucket = self.protected
                     self.functable = True
                 elif data == "Static Public Members":
@@ -4039,9 +3947,7 @@ class QtDocParser(SGMLParser):
         self.qtnamespace.staticfuncs = filter(F, map(P, self.staticPublic))
         self.qtnamespace.signals = filter(F, map(P, self.signals))
         self.qtnamespace.protectedfuncs = filter(F, map(P, self.protected))
-        self.qtnamespace.functions = (
-            self.qtnamespace.publicfuncs + self.qtnamespace.protectedfuncs
-        )
+        self.qtnamespace.functions = self.qtnamespace.publicfuncs + self.qtnamespace.protectedfuncs
 
         rootnamespace.staticfuncs += filter(F, map(P, self.globaldefs))
 

--- a/src/plugins/python/gtoContainer/gtoContainer.py
+++ b/src/plugins/python/gtoContainer/gtoContainer.py
@@ -8,7 +8,7 @@
 # agreement to the ShotGrid Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by ShotGrid Software Inc.
 
-""" 
+"""
 This module defines a generic gtoContainer class.  This class can be used to
 work with GTO data at an extremely high level, without the need to derive a new
 reader class or change your workflow to accomodate the somewhat restrictive GTO
@@ -53,11 +53,11 @@ until runtime?  No problem:
     print myGtoFile[someObject][someComponent][someProperty].name()
 
 
-or mix and match:    
+or mix and match:
 
-    
+
     myGtoFile[someObject].surface.texture.setData( "foo.tex" )
-    
+
 
 Let's say we want to start fresh and make a really simple gto file.  Here we
 illustrate three different ways to create and add Objects, Components, and
@@ -65,14 +65,14 @@ Properties to a gtoContainer:
 
 
     #!/usr/bin/env python
-    
+
     import gto
     from gtoContainer import *
 
     myGtoFile = gtoContainer()
     myGtoFile.myobj = Object( "myobj", "objprotocol", 1 )
     myGtoFile.myobj.append( Component( "mycomponent", "compinterp" ) )
-    
+
     prop = Property( "myprop", gto.STRING, size = 2, width = 1,
                      data = ["Hello","world"] )
     myGtoFile.myobj.mycomponent.append( prop )
@@ -111,6 +111,7 @@ import gto
 import operator
 from functools import reduce
 import six
+
 
 #############################################
 class Property:
@@ -827,9 +828,7 @@ class gtoContainer(gto.Reader):
                 # Create the Property itself.
                 objName = pi.component.object.name
                 compName = pi.component.name
-                newProp = Property(
-                    pi.name, pi.type, pi.size, pi.width, interp=pi.interpretation
-                )
+                newProp = Property(pi.name, pi.type, pi.size, pi.width, interp=pi.interpretation)
                 newProp._Property__deferRead = (self, pi)
                 self[objName][compName].append(newProp)
 
@@ -895,7 +894,7 @@ class gtoContainer(gto.Reader):
         for obj in self.__objects:
             if obj.name() == name:
                 return obj
-        raise AttributeError("gtoContainer instance has no " "attribute '%s'" % name)
+        raise AttributeError("gtoContainer instance has no attribute '%s'" % name)
 
     def __setattr__(self, name, value):
         if isinstance(value, Object):
@@ -1017,9 +1016,7 @@ class gtoContainer(gto.Reader):
         if not self.__deferredRead:
             objName = six.ensure_str(pinfo.component.object.name)
             compName = six.ensure_str(pinfo.component.name)
-            newProp = Property(
-                propName, pinfo.type, pinfo.size, pinfo.width, interp=interp
-            )
+            newProp = Property(propName, pinfo.type, pinfo.size, pinfo.width, interp=interp)
             self[objName][compName].append(newProp)
         return True
 
@@ -1094,9 +1091,7 @@ class gtoContainer(gto.Reader):
                     if propType == gto.STRING:
                         writer.intern(prop())
                     if propInterp:
-                        writer.property(
-                            propName, propType, propSize, propWidth, propInterp
-                        )
+                        writer.property(propName, propType, propSize, propWidth, propInterp)
                     else:
                         writer.property(propName, propType, propSize, propWidth)
                 writer.endComponent()

--- a/src/plugins/python/network/network/playControl.py
+++ b/src/plugins/python/network/network/playControl.py
@@ -27,7 +27,6 @@ class PlayControl:
         self.frameChanged = True
 
     def run(self):
-
         sys.stdout.write("Type: p=play, s=stop, r=reverse play, q=quit\r\n")
 
         while 1:

--- a/src/plugins/rv-packages/custom_lut_menu_mode/custom_lut_menu_mode.py
+++ b/src/plugins/rv-packages/custom_lut_menu_mode/custom_lut_menu_mode.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import rvtypes, commands, extra_commands
 import os
@@ -56,9 +56,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
 
     def toggleDefaultDisplayLUT(self, event):
         self._autoLoadDLUT = not self._autoLoadDLUT
-        commands.writeSettings(
-            "CUSTOM_LUTS", "loadDefaultDisplayLut", int(self._autoLoadDLUT)
-        )
+        commands.writeSettings("CUSTOM_LUTS", "loadDefaultDisplayLut", int(self._autoLoadDLUT))
         if self._autoLoadDLUT:
             deflut = commands.getStringProperty(self.lutNodes["DLUT"] + ".lut.file")[0]
             extra_commands.displayFeedback("Default Display LUT: %s" % (deflut), 5.0)
@@ -125,9 +123,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
             fltProps = linFltProps
         if linNode in self._setups.keys():
             for prop in intProps:
-                commands.setIntProperty(
-                    linNode + ".color." + prop, [int(self._setups[linNode][prop])], True
-                )
+                commands.setIntProperty(linNode + ".color." + prop, [int(self._setups[linNode][prop])], True)
             for prop in fltProps:
                 commands.setFloatProperty(
                     linNode + ".color." + prop,
@@ -148,18 +144,10 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
             else:
                 self.restoreDefaultProps(lutNode, display)
         except Exception as inst:
-            extra_commands.displayFeedback(
-                "LUT File Failed to Read: Check File %s" % path, 5.0
-            )
-            print(
-                (
-                    "ERROR: Failed to set LUT '%s' for %s: %s"
-                    % (path, lutNode, str(inst))
-                )
-            )
+            extra_commands.displayFeedback("LUT File Failed to Read: Check File %s" % path, 5.0)
+            print(("ERROR: Failed to set LUT '%s' for %s: %s" % (path, lutNode, str(inst))))
 
     def sourceColorSetup(self, event):
-
         # IF No Linearization is set, turn off all To->Linear Conversions
         if self._noLinConv:
             source = event.contents().split(";")[0]
@@ -171,12 +159,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
         for lut in self.lutNodes.keys():
             if self.lutNodes[lut].startswith("#") and self._autoLoadCXfrm[lut]:
                 if self._autoFormat[lut] != "":
-                    print(
-                        (
-                            "INFO: Searching for accompanying '%s'"
-                            % self._autoFormat[lut]
-                        )
-                    )
+                    print(("INFO: Searching for accompanying '%s'" % self._autoFormat[lut]))
                 self.loadColorXfrm(lut, event)
 
         event.reject()
@@ -187,7 +170,6 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
             dnodes = commands.nodesOfType("RVDisplayColor")
 
         for dnode in dnodes:
-
             # IF No Display is set, turn off all Linear->To Display settings
             if self._noDispCor:
                 self.saveDefaultProps(dnode, True)
@@ -216,12 +198,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                     offset = commands.getFloatProperty(xfrmNode + ".CDL.offset")
                     power = commands.getFloatProperty(xfrmNode + ".CDL.power")
                     sat = commands.getFloatProperty(xfrmNode + ".CDL.saturation")[0]
-                    defCDL = (
-                        slope == [1, 1, 1]
-                        and offset == [0, 0, 0]
-                        and power == [1, 1, 1]
-                        and sat == 1
-                    )
+                    defCDL = slope == [1, 1, 1] and offset == [0, 0, 0] and power == [1, 1, 1] and sat == 1
                 except Exception:
                     defCDL = True
 
@@ -233,9 +210,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
 
                 if not defLUT or not defCDL:
                     try:
-                        commands.setIntProperty(
-                            xfrmNode + ".CDL.active", [int(not self._activeCXfrm)], True
-                        )
+                        commands.setIntProperty(xfrmNode + ".CDL.active", [int(not self._activeCXfrm)], True)
                     except Exception:
                         pass
                     if self._activeCXfrm:
@@ -274,16 +249,10 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
 
         if xfrmFile is None:
             extra_commands.displayFeedback(
-                "Unable to find accompanying color"
-                + " transform with extension '%s'" % self._autoFormat[lut],
+                "Unable to find accompanying color" + " transform with extension '%s'" % self._autoFormat[lut],
                 5.0,
             )
-            print(
-                (
-                    "WARNING: No '%s' file found in '%s' for '%s'"
-                    % (self._autoFormat[lut], containing, movie)
-                )
-            )
+            print(("WARNING: No '%s' file found in '%s' for '%s'" % (self._autoFormat[lut], containing, movie)))
             return
 
         try:
@@ -297,15 +266,8 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
             try:
                 commands.readCDL(xfrmFile, xfrmNode, True)
             except Exception as inst:
-                extra_commands.displayFeedback(
-                    "CDL File Failed to Read: Check File %s" % xfrmFile, 5.0
-                )
-                print(
-                    (
-                        "ERROR: Failed to set CDL '%s' for %s: %s"
-                        % (xfrmFile, xfrmNode, str(inst))
-                    )
-                )
+                extra_commands.displayFeedback("CDL File Failed to Read: Check File %s" % xfrmFile, 5.0)
+                print(("ERROR: Failed to set CDL '%s' for %s: %s" % (xfrmFile, xfrmNode, str(inst))))
 
         elif xfrmExt in LUTS:
             self.setLUT(xfrmFile, xfrmNode)
@@ -377,16 +339,10 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
                 self.setAutoFormatLevel(lut, 0)(None)
             self._autoFormat[lut] = ext
             self._autoLoadCXfrm[lut] = ext is not None
-            commands.writeSettings(
-                "CUSTOM_LUTS", lut + "loadColorTransform", self._autoLoadCXfrm[lut]
-            )
+            commands.writeSettings("CUSTOM_LUTS", lut + "loadColorTransform", self._autoLoadCXfrm[lut])
             if self._autoLoadCXfrm[lut]:
-                extra_commands.displayFeedback(
-                    "Autoload shot CDL/Look LUT: %s" % (ext), 5.0
-                )
-                commands.writeSettings(
-                    "CUSTOM_LUTS", lut + "autoColorTransform", self._autoFormat[lut]
-                )
+                extra_commands.displayFeedback("Autoload shot CDL/Look LUT: %s" % (ext), 5.0)
+                commands.writeSettings("CUSTOM_LUTS", lut + "autoColorTransform", self._autoFormat[lut])
             else:
                 extra_commands.displayFeedback("Disabled Autoload CDL/Look LUT", 5.0)
 
@@ -407,19 +363,13 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
         def saveAutoDirLevel(event):
             if level < 0:
                 try:
-                    self._autoLUT[lut] = commands.openFileDialog(
-                        True, False, False, None, self._dirs[lut]
-                    )[0]
-                    commands.writeSettings(
-                        "CUSTOM_LUTS", lut + "AutoLut", self._autoLUT[lut]
-                    )
+                    self._autoLUT[lut] = commands.openFileDialog(True, False, False, None, self._dirs[lut])[0]
+                    commands.writeSettings("CUSTOM_LUTS", lut + "AutoLut", self._autoLUT[lut])
                     self.setAutoFormat(lut, "")(None)
                 except Exception:
                     return
             self._autoLevel[lut] = level
-            commands.writeSettings(
-                "CUSTOM_LUTS", lut + "autoFormatDirLevel", self._autoLevel[lut]
-            )
+            commands.writeSettings("CUSTOM_LUTS", lut + "autoFormatDirLevel", self._autoLevel[lut])
 
         return saveAutoDirLevel
 
@@ -465,9 +415,7 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
         fmtOpts.append(("LUT", None, "", lambda: commands.DisabledMenuState))
         for ext in LUTS:
             title = "  " + ext.upper()
-            fmtOpts.append(
-                (title, self.setAutoFormat(lut, ext), "", self.isAutoFormat(lut, ext))
-            )
+            fmtOpts.append((title, self.setAutoFormat(lut, ext), "", self.isAutoFormat(lut, ext)))
 
         fmtOpts += [
             ("_", None),
@@ -522,13 +470,9 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
     def changeLUTDir(self, typeStr):
         def changeSpecificLUTDir(event):
             try:
-                self._dirs[typeStr] = commands.openFileDialog(
-                    True, False, True, None, None
-                )[0]
+                self._dirs[typeStr] = commands.openFileDialog(True, False, True, None, None)[0]
                 commands.defineModeMenu("custom-luts-mode", self.createMenu(), True)
-                commands.writeSettings(
-                    "CUSTOM_LUTS", "custom%sDir" % typeStr, self._dirs[typeStr]
-                )
+                commands.writeSettings("CUSTOM_LUTS", "custom%sDir" % typeStr, self._dirs[typeStr])
             except Exception:
                 pass
 
@@ -607,40 +551,20 @@ class CustomLUTMenuMode(rvtypes.MinorMode):
     def __init__(self):
         rvtypes.MinorMode.__init__(self)
 
-        self._autoLoadDLUT = commands.readSettings(
-            "CUSTOM_LUTS", "loadDefaultDisplayLut", self._autoLoadDLUT
-        )
+        self._autoLoadDLUT = commands.readSettings("CUSTOM_LUTS", "loadDefaultDisplayLut", self._autoLoadDLUT)
         for lut in self.lutNodes.keys():
-            self._autoLoadCXfrm[lut] = commands.readSettings(
-                "CUSTOM_LUTS", lut + "loadColorTransform", False
-            )
-            self._autoFormat[lut] = commands.readSettings(
-                "CUSTOM_LUTS", lut + "autoColorTransform", ""
-            )
-            self._autoLevel[lut] = commands.readSettings(
-                "CUSTOM_LUTS", lut + "autoFormatDirLevel", 0
-            )
-            self._autoLUT[lut] = commands.readSettings(
-                "CUSTOM_LUTS", lut + "AutoLut", "NONE"
-            )
-        self._noLinConv = commands.readSettings(
-            "CUSTOM_LUTS", "linearNoConversion", self._noLinConv
-        )
-        self._noDispCor = commands.readSettings(
-            "CUSTOM_LUTS", "displayNoCorrection", self._noDispCor
-        )
-        self._preferEnv = commands.readSettings(
-            "CUSTOM_LUTS", "preferEnvironment", self._preferEnv
-        )
-        self._onAllDisplays = commands.readSettings(
-            "CUSTOM_LUTS", "onAllDisplays", self._onAllDisplays
-        )
+            self._autoLoadCXfrm[lut] = commands.readSettings("CUSTOM_LUTS", lut + "loadColorTransform", False)
+            self._autoFormat[lut] = commands.readSettings("CUSTOM_LUTS", lut + "autoColorTransform", "")
+            self._autoLevel[lut] = commands.readSettings("CUSTOM_LUTS", lut + "autoFormatDirLevel", 0)
+            self._autoLUT[lut] = commands.readSettings("CUSTOM_LUTS", lut + "AutoLut", "NONE")
+        self._noLinConv = commands.readSettings("CUSTOM_LUTS", "linearNoConversion", self._noLinConv)
+        self._noDispCor = commands.readSettings("CUSTOM_LUTS", "displayNoCorrection", self._noDispCor)
+        self._preferEnv = commands.readSettings("CUSTOM_LUTS", "preferEnvironment", self._preferEnv)
+        self._onAllDisplays = commands.readSettings("CUSTOM_LUTS", "onAllDisplays", self._onAllDisplays)
 
         for typeStr in self._dirs.keys():
             customEnvDir = os.environ.get("RV_CUSTOM_%s_DIR" % typeStr, "")
-            customSettingDir = commands.readSettings(
-                "CUSTOM_LUTS", "custom%sDir" % typeStr, customEnvDir
-            )
+            customSettingDir = commands.readSettings("CUSTOM_LUTS", "custom%sDir" % typeStr, customEnvDir)
             self._dirs[typeStr] = customSettingDir
             if self._preferEnv and customEnvDir != "":
                 self._dirs[typeStr] = customEnvDir

--- a/src/plugins/rv-packages/custom_mattes/custom_mattes.py
+++ b/src/plugins/rv-packages/custom_mattes/custom_mattes.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, rvtypes, extra_commands
 import os
@@ -22,9 +22,7 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         try:
             definition = os.environ["RV_CUSTOM_MATTE_DEFINITIONS"]
         except KeyError:
-            definition = str(
-                commands.readSettings("CUSTOM_MATTES", "customMattesDefinition", "")
-            )
+            definition = str(commands.readSettings("CUSTOM_MATTES", "customMattesDefinition", ""))
         try:
             if os.path.exists(definition):
                 self.updateMattesFromFile(definition)
@@ -46,7 +44,6 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         return matteState
 
     def selectMatte(self, matte):
-
         # Create a method that is specific to each matte for setting the
         # relavent session node properties to display the matte
         def select(event):
@@ -56,12 +53,8 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
                 extra_commands.displayFeedback("Disabling mattes", 2.0)
             else:
                 m = self._mattes[matte]
-                commands.setFloatProperty(
-                    "#Session.matte.aspect", [float(m["ratio"])], True
-                )
-                commands.setFloatProperty(
-                    "#Session.matte.heightVisible", [float(m["heightVisible"])], True
-                )
+                commands.setFloatProperty("#Session.matte.aspect", [float(m["ratio"])], True)
+                commands.setFloatProperty("#Session.matte.heightVisible", [float(m["heightVisible"])], True)
                 commands.setFloatProperty(
                     "#Session.matte.centerPoint",
                     [float(m["centerX"]), float(m["centerY"])],
@@ -82,7 +75,6 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         self.setMenuAndBindings()
 
     def setMenuAndBindings(self):
-
         # Walk through all of the mattes adding a menu entry as well as a
         # hotkey binding for alt + index number
         # NOTE: The bindings will only matter for the first 9 mattes since you
@@ -90,9 +82,7 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         matteItems = []
         bindings = []
         if len(self._order) > 0:
-            matteItems.append(
-                ("No Matte", self.selectMatte(""), "alt `", self.currentMatteState(""))
-            )
+            matteItems.append(("No Matte", self.selectMatte(""), "alt `", self.currentMatteState("")))
             bindings.append(("key-down--alt--`", ""))
 
             for i, m in enumerate(self._order):
@@ -126,24 +116,16 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         # Create hotkeys for each matte
         for b in bindings:
             (event, matte) = b
-            commands.bind(
-                "custom-mattes-mode", "global", event, self.selectMatte(matte), ""
-            )
+            commands.bind("custom-mattes-mode", "global", event, self.selectMatte(matte), "")
 
     def updateMattesFromFile(self, filename):
-
         # Make sure the definition file exists
         if not os.path.exists(filename):
-            raise KnownError(
-                "ERROR: Custom Mattes Mode: Non-existent mattes"
-                + " definition file: '%s'" % filename
-            )
+            raise KnownError("ERROR: Custom Mattes Mode: Non-existent mattes" + " definition file: '%s'" % filename)
 
         # Clear existing key bindings
         for i in range(len(self._order)):
-            commands.unbind(
-                "custom-mattes-mode", "global", "key-down--alt--%d" % (i + 1)
-            )
+            commands.unbind("custom-mattes-mode", "global", "key-down--alt--%d" % (i + 1))
 
         # Walk through the lines of the definition file collecting matte
         # parameters
@@ -166,10 +148,7 @@ class CustomMatteMinorMode(rvtypes.MinorMode):
         if len(order) == 0:
             self._order = []
             self._mattes = {}
-            raise KnownError(
-                "ERROR: Custom Mattes Mode: Empty mattes"
-                + " definition file: '%s'" % filename
-            )
+            raise KnownError("ERROR: Custom Mattes Mode: Empty mattes" + " definition file: '%s'" % filename)
 
         # Save the definition path and assign the mattes
         commands.writeSettings("CUSTOM_MATTES", "customMattesDefinition", filename)

--- a/src/plugins/rv-packages/data_display_indicators/data_display_indicator_mode.py
+++ b/src/plugins/rv-packages/data_display_indicators/data_display_indicator_mode.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import re
 import math
@@ -59,7 +59,6 @@ class EXRWindowIndicatorMode(rvt.MinorMode):
         dataH = 0.0
         pa = 1.0
         for a in attrs:
-
             if a[0] == "EXR/dataWindow":
                 clean = re.sub("[\(\)]", " ", a[1])
                 parts = clean.split(" ")
@@ -120,7 +119,6 @@ class EXRWindowIndicatorMode(rvt.MinorMode):
         #
 
         if dataW != dispW or dataH != dispH:
-
             #
             #   Find the angle/radians of rotation
             #
@@ -204,7 +202,6 @@ class EXRWindowIndicatorMode(rvt.MinorMode):
         return array3
 
     def render(self, event):
-
         sources = rvc.sourcesAtFrame(rvc.frame())
 
         if len(sources) == 0:
@@ -219,7 +216,6 @@ class EXRWindowIndicatorMode(rvt.MinorMode):
             box.render()
 
     def __init__(self):
-
         rvt.MinorMode.__init__(self)
 
         self.init(

--- a/src/plugins/rv-packages/lat_long_viewer/lat_long_viewer.py
+++ b/src/plugins/rv-packages/lat_long_viewer/lat_long_viewer.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from __future__ import print_function
 
@@ -63,19 +63,13 @@ class LatLongViewerMode(rvt.MinorMode):
             rv.runtime.eval(code, ["sync", "rvtypes", "commands"])
 
     def readPrefs(self):
-
-        self.adjustAllowed = bool(
-            rvc.readSettings("lat_long_viewer", "adjustAllowed", True)
-        )
+        self.adjustAllowed = bool(rvc.readSettings("lat_long_viewer", "adjustAllowed", True))
 
     def writePrefs(self):
-
         rvc.writeSettings("lat_long_viewer", "adjustAllowed", self.adjustAllowed)
 
     def addViewer(self, event):
-
         for pg in colorPipeGroups():
-
             deb("addViewer: checking g %s hasViewer %s" % (pg, str(groupHasViewer(pg))))
 
             if not groupHasViewer(pg):
@@ -97,13 +91,8 @@ class LatLongViewerMode(rvt.MinorMode):
             """
 
     def removeDisNode(self, event):
-
         for pg in linPipeGroups():
-
-            deb(
-                "removeDisNode: checking g %s hasSD %s"
-                % (pg, str(groupHasStereoDis(pg)))
-            )
+            deb("removeDisNode: checking g %s hasSD %s" % (pg, str(groupHasStereoDis(pg))))
 
             if groupHasStereoDis(pg):
                 nodes = rvc.getStringProperty(pg + ".pipeline.nodes")
@@ -114,25 +103,20 @@ class LatLongViewerMode(rvt.MinorMode):
                 rvc.setStringProperty(pg + ".pipeline.nodes", newNodes, True)
 
     def toggleTopBotPref(self, event):
-
         self._expectTopBot = not self._expectTopBot
         self.writePrefs()
 
     def toggleSwapEyesPref(self, event):
-
         self._swapEyes = not self._swapEyes
         self.writePrefs()
 
     def disabledMenuState(self):
-
         return rvc.DisabledMenuState
 
     def uncheckedMenuState(self):
-
         return rvc.UncheckedMenuState
 
     def haveDisNodesState(self):
-
         for pg in linPipeGroups():
             if groupHasStereoDis(pg):
                 return rvc.UncheckedMenuState
@@ -140,14 +124,12 @@ class LatLongViewerMode(rvt.MinorMode):
         return rvc.DisabledMenuState
 
     def expectTopBotState(self):
-
         if self._expectTopBot:
             return rvc.CheckedMenuState
 
         return rvc.UncheckedMenuState
 
     def swapEyesState(self):
-
         if self._swapEyes:
             return rvc.CheckedMenuState
 
@@ -180,7 +162,6 @@ class LatLongViewerMode(rvt.MinorMode):
         pass
 
     def toggleAdjust(self, event):
-
         self.adjustAllowed = not self.adjustAllowed
         self.writePrefs()
 
@@ -226,17 +207,11 @@ class LatLongViewerMode(rvt.MinorMode):
         dy = dy / domain[1]
         deb("dx %s dy %s" % (str(dx), str(dy)))
 
-        rvc.setFloatProperty(
-            "#LatLongViewer.parameters.rotateX", [self.downRotateX + -dy * 180.0], True
-        )
-        rvc.setFloatProperty(
-            "#LatLongViewer.parameters.rotateY", [self.downRotateY + dx * 360.0], True
-        )
+        rvc.setFloatProperty("#LatLongViewer.parameters.rotateX", [self.downRotateX + -dy * 180.0], True)
+        rvc.setFloatProperty("#LatLongViewer.parameters.rotateY", [self.downRotateY + dx * 360.0], True)
 
     def missingState(self):
-
         for pg in colorPipeGroups():
-
             deb("checking g %s hasViewer %s" % (pg, str(groupHasViewer(pg))))
 
             if not groupHasViewer(pg):
@@ -277,7 +252,6 @@ class LatLongViewerMode(rvt.MinorMode):
         return rvc.UncheckedMenuState
 
     def __init__(self):
-
         deb("__init__")
         rvt.MinorMode.__init__(self)
 
@@ -349,5 +323,4 @@ class LatLongViewerMode(rvt.MinorMode):
 
 
 def createMode():
-
     return LatLongViewerMode()

--- a/src/plugins/rv-packages/media_library_demo/media_library_environment_variable_reader_plugin.py
+++ b/src/plugins/rv-packages/media_library_demo/media_library_environment_variable_reader_plugin.py
@@ -23,26 +23,26 @@ from urllib.parse import urlparse
 # If you want to enable this package to play around it, you can set the following environment variable.
 #
 # !!!!! W A R N I N G !!!!!
-ENABLED_ENV = 'RV_MEDIA_LIBRARY_UNSECURE_DEMO_ENABLED'
+ENABLED_ENV = "RV_MEDIA_LIBRARY_UNSECURE_DEMO_ENABLED"
 
 # The environment variables is used to set the cookies for the media library.
 # The cookies are set as a string of the form:
 #   cookie1=value1; [Domain=domain1; Path=path1;] cookie2=value2; [Domain=domain1; Path=path2;]...
 # The cookies are set for all urls. However, the cookies can be set for specific urls
 # by using the url parameter in the get_http_cookies function and your own logic.
-COOKIES_ENV = 'RV_MEDIA_LIBRARY_UNSECURE_DEMO_COOKIES'
+COOKIES_ENV = "RV_MEDIA_LIBRARY_UNSECURE_DEMO_COOKIES"
 
 # The environment variables that is used to set the headers for the media library.
 # The headers are set as a string of the form:
 #   header1: value1; header2: value2; ...
 # The headers are set for all urls. However, the headers can be set for specific urls
 # by using the url parameter in the get_http_headers function and your own logic.
-HEADERS_ENV = 'RV_MEDIA_LIBRARY_UNSECURE_DEMO_HEADERS'
+HEADERS_ENV = "RV_MEDIA_LIBRARY_UNSECURE_DEMO_HEADERS"
 
 
 # The environment variables that is used to enable the redirection of the urls to disk.
 # The redirection is enabled if the environment variable is set.
-DOWNLOAD_ENV = 'RV_MEDIA_LIBRARY_UNSECURE_DEMO_FORCE_LOCAL_CACHE'
+DOWNLOAD_ENV = "RV_MEDIA_LIBRARY_UNSECURE_DEMO_FORCE_LOCAL_CACHE"
 
 
 def is_plugin_enabled() -> bool:
@@ -111,15 +111,9 @@ def get_http_cookies(url: str) -> Iterable[Dict]:
     for cookie in cookies.values():
         print(cookie)
 
-        yield {
-            "name": cookie.key,
-            "value": cookie.value,
-            "domain": cookie["domain"],
-            "path": cookie["path"]
-        }
+        yield {"name": cookie.key, "value": cookie.value, "domain": cookie["domain"], "path": cookie["path"]}
 
     yield from ()
-
 
 
 def get_http_headers(url: str) -> Iterable[Dict]:
@@ -144,12 +138,10 @@ def get_http_headers(url: str) -> Iterable[Dict]:
         print(header)
 
         name, value = header.split(":", 1)
-        yield {
-            "name": name.strip(),
-            "value": value.strip()
-        }
+        yield {"name": name.strip(), "value": value.strip()}
 
     yield from ()
+
 
 redirection_cache = {}
 

--- a/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep.py
+++ b/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep.py
@@ -42,16 +42,7 @@ class MediaRepresentationItem(QtWidgets.QWidgetAction):
         # and take care of the background color.
         widget = QtWidgets.QWidget()
         widget.setStyleSheet(
-            "QWidget"
-            "{"
-            "margin: 0px;"
-            "padding: 0px;"
-            "margin-top: 5px;"
-            "}"
-            "QWidget::hover"
-            "{"
-            "background-color: rgb(62, 62, 132);"
-            "}"
+            "QWidget{margin: 0px;padding: 0px;margin-top: 5px;}QWidget::hover{background-color: rgb(62, 62, 132);}"
         )
 
         # Using a layout to position the labels.
@@ -69,13 +60,7 @@ class MediaRepresentationItem(QtWidgets.QWidgetAction):
         policy = check_mark.sizePolicy()
         policy.setRetainSizeWhenHidden(True)
         check_mark.setSizePolicy(policy)
-        check_mark.setStyleSheet(
-            "background: none;"
-            "margin: 0px;"
-            "padding: 0px;"
-            "color: DarkGray;"
-            "font-size: 12px;"
-        )
+        check_mark.setStyleSheet("background: none;margin: 0px;padding: 0px;color: DarkGray;font-size: 12px;")
         check_mark.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
         layout.addWidget(check_mark)
         self._check_mark = check_mark
@@ -84,7 +69,7 @@ class MediaRepresentationItem(QtWidgets.QWidgetAction):
         # No background so that it uses the parent's one.
         # Does not listen for mouse events.
         label = QtWidgets.QLabel(widget)
-        label.setStyleSheet("background: none;" "margin: 0px;" "padding: 0px;")
+        label.setStyleSheet("background: none;margin: 0px;padding: 0px;")
         label.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
         layout.addWidget(label)
         self._label = label
@@ -96,9 +81,7 @@ class MediaRepresentationItem(QtWidgets.QWidgetAction):
         rep_txt = "<font color='DarkGray'>%s</font>" % rep
         res_txt = "<font color='DarkGray' size='0.6em'>%s</font>" % resolution
         ext_txt = "<font color='DarkGray' size='0.6em'>%s</font>" % extension
-        self._label.setText(
-            "%s<br>%s&nbsp;&nbsp;&nbsp;%s" % (rep_txt, res_txt, ext_txt)
-        )
+        self._label.setText("%s<br>%s&nbsp;&nbsp;&nbsp;%s" % (rep_txt, res_txt, ext_txt))
 
         self.setData({"rep": rep, "switch_nodes": switch_nodes})
 
@@ -172,7 +155,6 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
     # at higher resolution. If this representation is not available, then the
     # 'Movie' media representation will be selected, and so on.
     def sourceMediaUnavailable(self, event):
-
         package_logger.debug("%s in sourceMediaUnavailable" % event.name())
 
         #  event.reject() is done to allow other functions bound to
@@ -191,9 +173,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         expectedNumberOfArgs = 3
         if len(args) != expectedNumberOfArgs:
             package_logger.error(
-                "source-media-unavailable has {} parameters, expected={}".format(
-                    len(args), expectedNumberOfArgs
-                )
+                "source-media-unavailable has {} parameters, expected={}".format(len(args), expectedNumberOfArgs)
             )
             return
 
@@ -202,9 +182,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         mediaRepName = args[2]
 
         # Determine the media rep name to fall back to since this one is not available
-        fallbackMediaRepName = self._getFallbackMediaRepName(
-            sourceNodeName, mediaRepName
-        )
+        fallbackMediaRepName = self._getFallbackMediaRepName(sourceNodeName, mediaRepName)
 
         package_logger.debug(
             "sourceMediaUnavailable()-sourceNodeName={}, mediaRepName={}, fallbackMediaRepName={}".format(
@@ -327,21 +305,13 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
 
         # Media resolution.
         self._media_resolution_lbl = QtWidgets.QLabel("", self._bottomToolBar)
-        self._media_resolution_lbl.setStyleSheet(
-            "color: gray; background-color: transparent; margin-right: 5px"
-        )
-        self._bottomToolBar.insertWidget(
-            playback_style_action, self._media_resolution_lbl
-        )
+        self._media_resolution_lbl.setStyleSheet("color: gray; background-color: transparent; margin-right: 5px")
+        self._bottomToolBar.insertWidget(playback_style_action, self._media_resolution_lbl)
 
         # Media extension.
         self._media_extension_lbl = QtWidgets.QLabel("", self._bottomToolBar)
-        self._media_extension_lbl.setStyleSheet(
-            "color: gray; background-color: transparent"
-        )
-        self._bottomToolBar.insertWidget(
-            playback_style_action, self._media_extension_lbl
-        )
+        self._media_extension_lbl.setStyleSheet("color: gray; background-color: transparent")
+        self._bottomToolBar.insertWidget(playback_style_action, self._media_extension_lbl)
 
     def _populate_media_rep_menu(self, menu, switch_nodes):
         """
@@ -365,9 +335,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         # The menu items are composed of the media rep name, the extension and
         # the resolution.
         for rep in reps_and_source_nodes.keys():
-            source_media_infos = utils.get_common_source_media_infos(
-                reps_and_source_nodes[rep]
-            )
+            source_media_infos = utils.get_common_source_media_infos(reps_and_source_nodes[rep])
 
             action = MediaRepresentationItem(menu)
             action.set_values(
@@ -452,9 +420,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         Note: when there are multiple sources at the current frame then the
         resolution and extension is only shown when they are common to all
         """
-        common_source_media_infos = utils.get_common_source_media_infos(
-            self._current_sources
-        )
+        common_source_media_infos = utils.get_common_source_media_infos(self._current_sources)
 
         self._media_resolution_lbl.setText(common_source_media_infos.resolution)
         self._media_extension_lbl.setText(common_source_media_infos.extension)
@@ -520,9 +486,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
         # source group.
         if self._current_sources is None:
             return
-        if (source_deleted in self._current_sources) or (
-            source_deleted + "_source" in self._current_sources
-        ):
+        if (source_deleted in self._current_sources) or (source_deleted + "_source" in self._current_sources):
             self._current_sources = None
 
     def _on_force_update_media_info(self, event):
@@ -553,9 +517,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
           - media-relocated, source-media-rep-activated (media not ready)
           - source-group-complete (media ready)
         """
-        package_logger.debug(
-            "%s in _on_postpone_force_update_media_info" % event.name()
-        )
+        package_logger.debug("%s in _on_postpone_force_update_media_info" % event.name())
 
         event.reject()
         self._force_update_media_info = True

--- a/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep_utils.py
+++ b/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep_utils.py
@@ -120,13 +120,7 @@ def get_extension_from_info_file(info_file):
     """
     Returns the extension from the infos["file"] media info
     """
-    return (
-        ""
-        if not info_file
-        else "URL"
-        if is_url(info_file)
-        else info_file.split(".")[-1].upper()
-    )
+    return "" if not info_file else "URL" if is_url(info_file) else info_file.split(".")[-1].upper()
 
 
 def get_common_source_media_infos(sources):

--- a/src/plugins/rv-packages/node_graph_viz/node_graph_viz.py
+++ b/src/plugins/rv-packages/node_graph_viz/node_graph_viz.py
@@ -17,9 +17,7 @@ try:
     import matplotlib.pyplot as plt
 except:
     print("Exception occurred while importing and initializing matplotlib.")
-    print(
-        "'py-interp -m pip install matplotlib networkx' to install it into RV's environment."
-    )
+    print("'py-interp -m pip install matplotlib networkx' to install it into RV's environment.")
     raise
 
 import itertools
@@ -77,9 +75,7 @@ class RVNodeGraphViz(rv.rvtypes.MinorMode):
 
     def _show_graph(self):
         """Draw and display the graph."""
-        nx.draw_networkx(
-            self.dag, pos=nx.spring_layout(self.dag), with_labels=True, font_size=6
-        )
+        nx.draw_networkx(self.dag, pos=nx.spring_layout(self.dag), with_labels=True, font_size=6)
         plt.axis("off")
         plt.show()
 

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -12,30 +12,20 @@ import opentimelineio as otio
 from rv import commands, extra_commands
 
 
-def hook_function(
-    in_timeline: otio.schemadef.Annotation.Annotation, argument_map: dict | None = None
-) -> None:
+def hook_function(in_timeline: otio.schemadef.Annotation.Annotation, argument_map: dict | None = None) -> None:
     """A hook for the annotation schema"""
 
     try:
         if argument_map["effect_metadata"]:
             effect_metadata = argument_map["effect_metadata"]
-            commands.setIntProperty(
-                "#Session.paintEffects.hold", [effect_metadata.get("hold", 0)]
-            )
-            commands.setIntProperty(
-                "#Session.paintEffects.ghost", [effect_metadata.get("ghost", 0)]
-            )
+            commands.setIntProperty("#Session.paintEffects.hold", [effect_metadata.get("hold", 0)])
+            commands.setIntProperty("#Session.paintEffects.ghost", [effect_metadata.get("ghost", 0)])
         else:
             commands.setIntProperty("#Session.paintEffects.hold", [in_timeline.hold])
             commands.setIntProperty("#Session.paintEffects.ghost", [in_timeline.ghost])
 
-        commands.setIntProperty(
-            "#Session.paintEffects.ghostBefore", [in_timeline.ghost_before]
-        )
-        commands.setIntProperty(
-            "#Session.paintEffects.ghostAfter", [in_timeline.ghost_after]
-        )
+        commands.setIntProperty("#Session.paintEffects.ghostBefore", [in_timeline.ghost_before])
+        commands.setIntProperty("#Session.paintEffects.ghostAfter", [in_timeline.ghost_after])
     except Exception:
         logging.exception("Unable to set Hold and Ghost properties")
 
@@ -44,9 +34,7 @@ def hook_function(
             if isinstance(layer.layer_range, otio.opentime.TimeRange):
                 time_range = layer.layer_range
             else:
-                time_range = otio.opentime.TimeRange(
-                    layer.layer_range["start_time"], layer.layer_range["duration"]
-                )
+                time_range = otio.opentime.TimeRange(layer.layer_range["start_time"], layer.layer_range["duration"])
 
             relative_time = time_range.end_time_inclusive()
             frame = relative_time.to_frames()
@@ -85,28 +73,20 @@ def hook_function(
             if not commands.propertyExists(f"{frame_component}.order"):
                 commands.newProperty(f"{frame_component}.order", commands.StringType, 1)
 
-            commands.insertStringProperty(
-                f"{frame_component}.order", [f"pen:{stroke_id}:{frame}:annotation"]
-            )
+            commands.insertStringProperty(f"{frame_component}.order", [f"pen:{stroke_id}:{frame}:annotation"])
 
             global_scale = argument_map.get("global_scale")
             if global_scale is None:
-                logging.warning(
-                    "Unable to get the global scale, using the aspect ratio of the first media file"
-                )
+                logging.warning("Unable to get the global scale, using the aspect ratio of the first media file")
                 try:
                     media_switch = commands.nodeConnections("MediaTrack")[0][0]
                     media_source_group = commands.nodeConnections(media_switch)[0][0]
-                    first_source_node = extra_commands.nodesInGroupOfType(
-                        media_source_group, "RVFileSource"
-                    )[0]
+                    first_source_node = extra_commands.nodesInGroupOfType(media_source_group, "RVFileSource")[0]
                     media_info = commands.sourceMediaInfo(first_source_node)
                     height = media_info["height"]
                     aspect_ratio = media_info["width"] / height
                 except Exception:
-                    logging.exception(
-                        "Unable to determine aspect ratio, using default value of 16:9"
-                    )
+                    logging.exception("Unable to determine aspect ratio, using default value of 16:9")
                     aspect_ratio = 1920 / 1080
                 finally:
                     scale = aspect_ratio / 16
@@ -127,6 +107,4 @@ def hook_function(
                     points_property,
                     [point.x * global_scale.x, point.y * global_scale.y],
                 )
-                commands.insertFloatProperty(
-                    width_property, [point.width * global_width]
-                )
+                commands.insertFloatProperty(width_property, [point.width * global_width])

--- a/src/plugins/rv-packages/otio_reader/annotation_schema.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_schema.py
@@ -63,13 +63,9 @@ class Annotation(otio.schema.Effect):
     def layers(self, val: list):
         self._layers = val
 
-    hold = otio.core.serializable_field(
-        "hold", required_type=bool, doc=("hold: expects either true or false")
-    )
+    hold = otio.core.serializable_field("hold", required_type=bool, doc=("hold: expects either true or false"))
 
-    ghost = otio.core.serializable_field(
-        "ghost", required_type=bool, doc=("ghost: expects either true or false")
-    )
+    ghost = otio.core.serializable_field("ghost", required_type=bool, doc=("ghost: expects either true or false"))
 
     ghost_before = otio.core.serializable_field(
         "ghost_before", required_type=int, doc=("ghost_before: expects an integer")

--- a/src/plugins/rv-packages/otio_reader/cdlExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/cdlExportHook.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, extra_commands
 import opentimelineio as otio

--- a/src/plugins/rv-packages/otio_reader/cdlSchema.py
+++ b/src/plugins/rv-packages/otio_reader/cdlSchema.py
@@ -45,13 +45,9 @@ class CDL(otio.schema.Effect):
         self.power = power
         self.saturation = saturation
 
-    visible = otio.core.serializable_field(
-        "visible", required_type=bool, doc=("Visible: expects either true or false")
-    )
+    visible = otio.core.serializable_field("visible", required_type=bool, doc=("Visible: expects either true or false"))
 
-    _slope = otio.core.serializable_field(
-        "slope", required_type=list, doc=("Slope: expects a list of three floats")
-    )
+    _slope = otio.core.serializable_field("slope", required_type=list, doc=("Slope: expects a list of three floats"))
 
     @property
     def slope(self):
@@ -66,9 +62,7 @@ class CDL(otio.schema.Effect):
                 raise Exception("Invalid slope element type")
         self._slope = val
 
-    _offset = otio.core.serializable_field(
-        "offset", required_type=list, doc=("Offset: expects a list of three floats")
-    )
+    _offset = otio.core.serializable_field("offset", required_type=list, doc=("Offset: expects a list of three floats"))
 
     @property
     def offset(self):
@@ -83,9 +77,7 @@ class CDL(otio.schema.Effect):
                 raise Exception("Invalid offset element type")
         self._offset = val
 
-    _power = otio.core.serializable_field(
-        "power", required_type=list, doc=("Visible: expects a list of three floats")
-    )
+    _power = otio.core.serializable_field("power", required_type=list, doc=("Visible: expects a list of three floats"))
 
     @property
     def power(self):
@@ -100,9 +92,7 @@ class CDL(otio.schema.Effect):
                 raise Exception("Invalid power element type")
         self._power = val
 
-    saturation = otio.core.serializable_field(
-        "saturation", required_type=float, doc=("Saturation: expects a float")
-    )
+    saturation = otio.core.serializable_field("saturation", required_type=float, doc=("Saturation: expects a float"))
 
     def __str__(self):
         return 'CDL("{}", "{}", "{}", "{}", "{}", "{}", "{}")'.format(

--- a/src/plugins/rv-packages/otio_reader/compare_hook.py
+++ b/src/plugins/rv-packages/otio_reader/compare_hook.py
@@ -3,14 +3,12 @@ import opentimelineio as otio
 from rv import commands, extra_commands
 
 
-def hook_function(
-    in_timeline: otio.schemadef.Compare.Compare, argument_map: dict | None = None
-) -> None:
+def hook_function(in_timeline: otio.schemadef.Compare.Compare, argument_map: dict | None = None) -> None:
     """A hook for the compare schema"""
     compare_mode = in_timeline.mode
     is_swapped = in_timeline.is_swapped
 
-    match (compare_mode.lower()):
+    match compare_mode.lower():
         case "side_by_side":
             # Only the bounds need to be handled for this mode, and this is done in
             # the Live Review plugin, so nothing to do here
@@ -20,9 +18,7 @@ def hook_function(
             opacity = float(in_timeline.over_with_opacity["opacity"])
 
             sequence_group = argument_map["sequence"]
-            sequence_node = extra_commands.nodesInGroupOfType(
-                sequence_group, "RVSequence"
-            )[0]
+            sequence_node = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[0]
             composite_property = f"{sequence_node}.composite"
 
             effectHook.add_rv_effect_props(
@@ -35,13 +31,9 @@ def hook_function(
 
         case "difference":
             sequence_group = argument_map["sequence"]
-            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[
-                0
-            ]
+            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[0]
             composite_property = f"{sequence}.composite"
-            effectHook.set_rv_effect_props(
-                composite_property, {"inputBlendModes": ["difference"]}
-            )
+            effectHook.set_rv_effect_props(composite_property, {"inputBlendModes": ["difference"]})
 
         case "angular_mask":
             angle_in_radians = in_timeline.angular_mask["angle_in_radians"]
@@ -58,18 +50,12 @@ def hook_function(
                 global_translate_vec = otio.schema.V2d(0.0, 0.0)
                 global_scale_vec = otio.schema.V2d(1.0, 1.0)
 
-                if commands.propertyExists(
-                    f"{transform}.otio.global_translate"
-                ) and commands.propertyExists(f"{transform}.otio.global_scale"):
-                    global_translate = commands.getFloatProperty(
-                        f"{transform}.otio.global_translate"
-                    )
-                    global_scale = commands.getFloatProperty(
-                        f"{transform}.otio.global_scale"
-                    )
-                    global_translate_vec = otio.schema.V2d(
-                        global_translate[0], global_translate[1]
-                    )
+                if commands.propertyExists(f"{transform}.otio.global_translate") and commands.propertyExists(
+                    f"{transform}.otio.global_scale"
+                ):
+                    global_translate = commands.getFloatProperty(f"{transform}.otio.global_translate")
+                    global_scale = commands.getFloatProperty(f"{transform}.otio.global_scale")
+                    global_translate_vec = otio.schema.V2d(global_translate[0], global_translate[1])
                     global_scale_vec = otio.schema.V2d(global_scale[0], global_scale[1])
 
                 translate = commands.getFloatProperty(
@@ -87,9 +73,7 @@ def hook_function(
                 aspect_ratio = 1.0 if height == 0 else media_info["width"] / height
 
                 bounds_size = scale_vec / global_scale_vec
-                bounds_center = (
-                    translate_vec + global_translate_vec
-                ) / global_scale_vec
+                bounds_center = (translate_vec + global_translate_vec) / global_scale_vec
 
                 # Since pivot coordinates are not local to the source,
                 # we must remove the source transformation from them when
@@ -104,9 +88,7 @@ def hook_function(
                 pivot_y += 0.5
 
             sequence_group = argument_map["sequence"]
-            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[
-                0
-            ]
+            sequence = extra_commands.nodesInGroupOfType(sequence_group, "RVSequence")[0]
             composite_property = f"{sequence}.composite"
 
             effectHook.set_rv_effect_props(

--- a/src/plugins/rv-packages/otio_reader/compare_schema.py
+++ b/src/plugins/rv-packages/otio_reader/compare_schema.py
@@ -51,13 +51,9 @@ class Compare(otio.schema.Effect):
         self.secondary_element_id = secondary_element_id
         self.is_swapped = is_swapped
 
-    visible = otio.core.serializable_field(
-        "visible", required_type=bool, doc="visible: expects either true or false"
-    )
+    visible = otio.core.serializable_field("visible", required_type=bool, doc="visible: expects either true or false")
 
-    mode = otio.core.serializable_field(
-        "mode", required_type=str, doc="mode: expects a string"
-    )
+    mode = otio.core.serializable_field("mode", required_type=str, doc="mode: expects a string")
 
     _side_by_side = otio.core.serializable_field(
         "side_by_side",

--- a/src/plugins/rv-packages/otio_reader/customTransitionHook.py
+++ b/src/plugins/rv-packages/otio_reader/customTransitionHook.py
@@ -1,15 +1,13 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands
 
 
 def _create_node(in_transition, context={}):
-    return commands.newNode(
-        "CustomTransition", in_transition.name or "custom_transition"
-    )
+    return commands.newNode("CustomTransition", in_transition.name or "custom_transition")
 
 
 def hook_function(in_timeline, argument_map=None):

--- a/src/plugins/rv-packages/otio_reader/genericEffectHook.py
+++ b/src/plugins/rv-packages/otio_reader/genericEffectHook.py
@@ -1,8 +1,9 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
 #
+# SPDX-License-Identifier: Apache-2.0
+#
+
 
 def hook_function(in_timeline, argument_map=None):
     print("Warning: Unhandled effect (named {})".format(in_timeline.effect_name))

--- a/src/plugins/rv-packages/otio_reader/multiRepPostExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/multiRepPostExportHook.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, extra_commands
 import opentimelineio as otio

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -83,9 +83,7 @@ def _run_hook(hook_name, otio_obj, context={}, optional=True):
         return otio.hooks.run(hook_name, otio_obj, context)
     except KeyError:
         if not optional:
-            raise NoMappingForOtioTypeError(
-                str(type(otio_obj)) + " on object: {}".format(otio_obj)
-            )
+            raise NoMappingForOtioTypeError(str(type(otio_obj)) + " on object: {}".format(otio_obj))
 
 
 def create_rv_node_from_otio(otio_obj, context=None):
@@ -100,9 +98,7 @@ def create_rv_node_from_otio(otio_obj, context=None):
     }
 
     if type(otio_obj) in WRITE_TYPE_MAP:
-        process_schema = _run_hook(
-            "pre_hook_{}".format(otio_obj.schema_name()), otio_obj, context
-        )
+        process_schema = _run_hook("pre_hook_{}".format(otio_obj.schema_name()), otio_obj, context)
         if process_schema is False:
             return None
 
@@ -111,9 +107,7 @@ def create_rv_node_from_otio(otio_obj, context=None):
             _run_hook("post_hook_{}".format(otio_obj.schema_name()), otio_obj, context)
         return result
 
-    return _run_hook(
-        "{}_to_rv".format(otio_obj.schema_name()), otio_obj, context, optional=False
-    )
+    return _run_hook("{}_to_rv".format(otio_obj.schema_name()), otio_obj, context, optional=False)
 
 
 def _retime_trx_input(pre_item, post_item, context=None):
@@ -152,9 +146,7 @@ def _create_dissolve(in_dissolve, context=None):
 def _create_custom(in_transition, context=None):
     rv_trx = _run_hook("CustomTransition_to_rv", in_transition, context)
     if not rv_trx:
-        raise NoNodeFromHook(
-            "Custom Transition found but no node was returned from the hook"
-        )
+        raise NoNodeFromHook("Custom Transition found but no node was returned from the hook")
     return rv_trx
 
 
@@ -173,23 +165,15 @@ def _create_transition(pre_item, in_trx, post_item, context=None):
 
     commands.setFloatProperty(rv_trx + ".parameters.startFrame", [1.0], True)
 
-    num_frames = (
-        (in_trx.in_offset + in_trx.out_offset)
-        .rescaled_to(pre_item.trimmed_range().duration.rate)
-        .value
-    )
+    num_frames = (in_trx.in_offset + in_trx.out_offset).rescaled_to(pre_item.trimmed_range().duration.rate).value
 
     in_offset_prop = "{}.otio.in_offset".format(rv_trx)
     commands.newProperty(in_offset_prop, commands.IntType, 1)
     commands.setIntProperty(in_offset_prop, [in_trx.in_offset.to_frames()], True)
 
-    commands.setFloatProperty(
-        rv_trx + ".parameters.numFrames", [float(num_frames)], True
-    )
+    commands.setFloatProperty(rv_trx + ".parameters.numFrames", [float(num_frames)], True)
 
-    commands.setFloatProperty(
-        rv_trx + ".output.fps", [float(pre_item.trimmed_range().duration.rate)], True
-    )
+    commands.setFloatProperty(rv_trx + ".output.fps", [float(pre_item.trimmed_range().duration.rate)], True)
 
     trx_inputs = []
     with set_context(context, transition=rv_trx):
@@ -221,9 +205,7 @@ def _create_stack(in_stack, context=None):
 
     # disable reversed order blending so the top node is on top
     stack_node = extra_commands.nodesInGroupOfType(new_stack, "RVStack")[0]
-    commands.setIntProperty(
-        "{}.mode.supportReversedOrderBlending".format(stack_node), [0]
-    )
+    commands.setIntProperty("{}.mode.supportReversedOrderBlending".format(stack_node), [0])
 
     return new_stack
 
@@ -241,9 +223,7 @@ def _create_track(in_seq, context=None):
 
         edl_time = context.get("global_start_time")
         if not edl_time and len(items_to_serialize) > 0:
-            edl_time = otio.opentime.RationalTime(
-                0, items_to_serialize[0].trimmed_range().start_time.rate
-            )
+            edl_time = otio.opentime.RationalTime(0, items_to_serialize[0].trimmed_range().start_time.rate)
         edl = {
             "in": [],
             "out": [],
@@ -281,9 +261,7 @@ def _create_track(in_seq, context=None):
         _add_metadata_to_node(in_seq, new_seq)
 
         # disable reversed order blending so the top node is on top
-        commands.setIntProperty(
-            "{}.mode.supportReversedOrderBlending".format(seq_node), [0]
-        )
+        commands.setIntProperty("{}.mode.supportReversedOrderBlending".format(seq_node), [0])
 
     return new_seq
 
@@ -297,9 +275,7 @@ def _get_global_transform(tl, context) -> dict:
             try:
                 # get active clip and start prelodaing the movie in the background
                 if isinstance(clip.media_reference, otio.schema.ExternalReference):
-                    media_path = _get_media_path(
-                        str(clip.media_reference.target_url), context
-                    )
+                    media_path = _get_media_path(str(clip.media_reference.target_url), context)
                     # print("PRELOADING MOVIE: {}".format(media_path))
                     commands.startPreloadingMedia(media_path)
 
@@ -365,9 +341,7 @@ def _set_sequence_edl(sequence, edl_time, edl):
     commands.setIntProperty("{}.edl.in".format(sequence), edl["in"])
     commands.setIntProperty("{}.edl.out".format(sequence), edl["out"])
     commands.setIntProperty("{}.edl.frame".format(sequence), edl["frame"])
-    commands.setIntProperty(
-        "{}.edl.source".format(sequence), list(range(len(edl["frame"])))
-    )
+    commands.setIntProperty("{}.edl.source".format(sequence), list(range(len(edl["frame"]))))
     commands.setIntProperty("{}.mode.autoEDL".format(sequence), [0])
 
 
@@ -375,22 +349,13 @@ def _get_in_out_frame(it, range_to_read, seq_rate=None):
     in_frame = out_frame = None
 
     if hasattr(it, "media_reference") and it.media_reference:
-        if (
-            isinstance(it.media_reference, otio.schema.ImageSequenceReference)
-            and it.media_reference.available_range
-        ):
-            in_frame, out_frame = it.media_reference.frame_range_for_time_range(
-                range_to_read
-            )
+        if isinstance(it.media_reference, otio.schema.ImageSequenceReference) and it.media_reference.available_range:
+            in_frame, out_frame = it.media_reference.frame_range_for_time_range(range_to_read)
 
     if not in_frame and not out_frame:
         rate = seq_rate if seq_rate is not None else range_to_read.duration.rate
-        in_frame = otio.opentime.to_frames(
-            range_to_read.start_time.rescaled_to(rate), rate=rate
-        )
-        out_frame = otio.opentime.to_frames(
-            range_to_read.end_time_inclusive().rescaled_to(rate), rate=rate
-        )
+        in_frame = otio.opentime.to_frames(range_to_read.start_time.rescaled_to(rate), rate=rate)
+        out_frame = otio.opentime.to_frames(range_to_read.end_time_inclusive().rescaled_to(rate), rate=rate)
     return (in_frame, out_frame)
 
 
@@ -444,11 +409,7 @@ def _create_media(media_ref, trimmed_range, context=None):
     elif isinstance(media_ref, otio.schema.ImageSequenceReference):
         return [
             _get_media_path(
-                str(
-                    media_ref.abstract_target_url(
-                        symbol="%0{n}d".format(n=media_ref.frame_zero_padding)
-                    )
-                ),
+                str(media_ref.abstract_target_url(symbol="%0{n}d".format(n=media_ref.frame_zero_padding))),
                 context,
             )
         ]
@@ -486,9 +447,7 @@ def _create_sources(item, context=None):
             error_media = _create_movieproc(item.trimmed_range(), "smptebars")
             src = commands.addSourceVerbose([error_media])
 
-        commands.setFloatProperty(
-            src + ".group.fps", [item.trimmed_range().duration.rate]
-        )
+        commands.setFloatProperty(src + ".group.fps", [item.trimmed_range().duration.rate])
 
         _add_metadata_to_node(media_ref, src)
         active_src = cmd_args[0] if cmd_args else src
@@ -498,17 +457,11 @@ def _create_sources(item, context=None):
         return src
 
     if isinstance(item, otio.schema.Gap):
-        src = commands.addSourceVerbose(
-            [_create_movieproc(item.trimmed_range(), "blank")]
-        )
+        src = commands.addSourceVerbose([_create_movieproc(item.trimmed_range(), "blank")])
         return commands.nodeGroup(src), src
 
     active_source = None
-    active_key = (
-        item.active_media_reference_key
-        if hasattr(item, "active_media_reference_key")
-        else None
-    )
+    active_key = item.active_media_reference_key if hasattr(item, "active_media_reference_key") else None
     if hasattr(item, "media_reference") and item.media_reference:
         active_source = add_media(
             item.media_reference,
@@ -587,11 +540,7 @@ def _create_item(it, context=None):
         context,
         src=active_src,
         source_group=commands.nodeGroup(active_src),
-        switch_group=(
-            src_or_switch_group
-            if commands.nodeType(src_or_switch_group) == "RVSwitchGroup"
-            else None
-        ),
+        switch_group=(src_or_switch_group if commands.nodeType(src_or_switch_group) == "RVSwitchGroup" else None),
     ):
         if context.get("transition"):
             _add_transition_timings(it, range_to_read, src_or_switch_group)
@@ -641,12 +590,8 @@ def _add_markers(it, node):
             [color for rgba in colors for color in rgba],
             True,
         )
-        commands.newProperty(
-            "{}.markers.otio_metadata".format(node), commands.StringType, 1
-        )
-        commands.setStringProperty(
-            "{}.markers.otio_metadata".format(node), metadata, True
-        )
+        commands.newProperty("{}.markers.otio_metadata".format(node), commands.StringType, 1)
+        commands.setStringProperty("{}.markers.otio_metadata".format(node), metadata, True)
 
 
 def _get_color_from_name(name, defaultColor="PURPLE"):
@@ -695,9 +640,7 @@ def _add_source_bounds(media_ref, src, active_src, context=None):
         height = media_info["height"]
         aspect_ratio = media_info["width"] / height
     except Exception:
-        logging.exception(
-            "Unable to determine aspect ratio, using default value of 16:9"
-        )
+        logging.exception("Unable to determine aspect ratio, using default value of 16:9")
         aspect_ratio = 1920 / 1080
 
     translate = bounds.center() * global_scale - global_translate
@@ -705,21 +648,13 @@ def _add_source_bounds(media_ref, src, active_src, context=None):
 
     transform_node = extra_commands.associatedNode("RVTransform2D", src)
 
-    commands.setFloatProperty(
-        "{}.transform.scale".format(transform_node), [scale.x / aspect_ratio, scale.y]
-    )
-    commands.setFloatProperty(
-        "{}.transform.translate".format(transform_node), [translate.x, translate.y]
-    )
+    commands.setFloatProperty("{}.transform.scale".format(transform_node), [scale.x / aspect_ratio, scale.y])
+    commands.setFloatProperty("{}.transform.translate".format(transform_node), [translate.x, translate.y])
 
     # write the bounds global_scale and global_translate to the node so we can
     # preserve the original values if we round-trip
-    commands.newProperty(
-        "{}.otio.global_scale".format(transform_node), commands.FloatType, 2
-    )
-    commands.newProperty(
-        "{}.otio.global_translate".format(transform_node), commands.FloatType, 2
-    )
+    commands.newProperty("{}.otio.global_scale".format(transform_node), commands.FloatType, 2)
+    commands.newProperty("{}.otio.global_translate".format(transform_node), commands.FloatType, 2)
     commands.setFloatProperty(
         "{}.otio.global_scale".format(transform_node),
         [global_scale.x, global_scale.y],

--- a/src/plugins/rv-packages/otio_reader/paint_schema.py
+++ b/src/plugins/rv-packages/otio_reader/paint_schema.py
@@ -51,9 +51,7 @@ class Paint(otio.core.SerializableObject):
         self.layer_range = layer_range
         self.visible = visible
 
-    name = otio.core.serializable_field(
-        "name", required_type=str, doc=("name: expects a string")
-    )
+    name = otio.core.serializable_field("name", required_type=str, doc=("name: expects a string"))
 
     _points = otio.core.serializable_field(
         "points", required_type=list, doc=("points: expects a list of point objects")
@@ -67,9 +65,7 @@ class Paint(otio.core.SerializableObject):
     def points(self, val: list):
         self._points = val
 
-    _rgba = otio.core.serializable_field(
-        "rgba", required_type=list, doc=("rgba: expects a list of four floats")
-    )
+    _rgba = otio.core.serializable_field("rgba", required_type=list, doc=("rgba: expects a list of four floats"))
 
     @property
     def rgba(self) -> list:
@@ -79,13 +75,9 @@ class Paint(otio.core.SerializableObject):
     def rgba(self, val: list) -> None:
         self._rgba = val
 
-    type = otio.core.serializable_field(
-        "type", required_type=str, doc=("type: expects a string")
-    )
+    type = otio.core.serializable_field("type", required_type=str, doc=("type: expects a string"))
 
-    brush = otio.core.serializable_field(
-        "brush", required_type=str, doc=("brush: expects a string")
-    )
+    brush = otio.core.serializable_field("brush", required_type=str, doc=("brush: expects a string"))
 
     _layer_range = otio.core.serializable_field(
         "layer_range",
@@ -101,9 +93,7 @@ class Paint(otio.core.SerializableObject):
     def layer_range(self, val):
         self._layer_range = val
 
-    visible = otio.core.serializable_field(
-        "visible", required_type=bool, doc=("visible: expects either true or false")
-    )
+    visible = otio.core.serializable_field("visible", required_type=bool, doc=("visible: expects either true or false"))
 
     def __str__(self) -> str:
         return (

--- a/src/plugins/rv-packages/otio_reader/point_schema.py
+++ b/src/plugins/rv-packages/otio_reader/point_schema.py
@@ -31,30 +31,20 @@ class Point(otio.core.SerializableObject):
     _serializable_label = "Point.1"
     _name = "Point"
 
-    def __init__(
-        self, width: float | None = None, x: float | None = None, y: float | None = None
-    ) -> None:
+    def __init__(self, width: float | None = None, x: float | None = None, y: float | None = None) -> None:
         super().__init__()
         self.width = width
         self.x = x
         self.y = y
 
-    width = otio.core.serializable_field(
-        "width", required_type=float, doc=("width: expects a float")
-    )
+    width = otio.core.serializable_field("width", required_type=float, doc=("width: expects a float"))
 
-    x = otio.core.serializable_field(
-        "x", required_type=float, doc=("x: expects a float")
-    )
+    x = otio.core.serializable_field("x", required_type=float, doc=("x: expects a float"))
 
-    y = otio.core.serializable_field(
-        "y", required_type=float, doc=("y: expects a float")
-    )
+    y = otio.core.serializable_field("y", required_type=float, doc=("y: expects a float"))
 
     def __str__(self) -> str:
         return f"Point({self.width}, {self.x}, {self.y})"
 
     def __repr__(self) -> str:
-        return (
-            f"otio.schema.Point(width={self.width!r}, x={self.x!r}, " f"y={self.y!r})"
-        )
+        return f"otio.schema.Point(width={self.width!r}, x={self.x!r}, y={self.y!r})"

--- a/src/plugins/rv-packages/otio_reader/retimeExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/retimeExportHook.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import commands, extra_commands
 import opentimelineio as otio
@@ -24,9 +24,7 @@ def hook_function(in_timeline, argument_map):
     scalar = 1 / commands.getFloatProperty("{}.audio.scale".format(rv_node_name))[0]
 
     if is_close(scalar, 1.0):
-        scalar = (
-            1 / commands.getFloatProperty("{}.visual.scale".format(rv_node_name))[0]
-        )
+        scalar = 1 / commands.getFloatProperty("{}.visual.scale".format(rv_node_name))[0]
 
     key_frames = commands.getIntProperty("{}.warp.keyFrames".format(rv_node_name))
 
@@ -40,6 +38,4 @@ def hook_function(in_timeline, argument_map):
         return otio.schema.FreezeFrame(
             name=extra_commands.uiName(rv_node_name),
         )
-    return otio.schema.LinearTimeWarp(
-        name=extra_commands.uiName(rv_node_name), time_scalar=scalar
-    )
+    return otio.schema.LinearTimeWarp(name=extra_commands.uiName(rv_node_name), time_scalar=scalar)

--- a/src/plugins/rv-packages/pyhello/pyhello.py
+++ b/src/plugins/rv-packages/pyhello/pyhello.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import rvtypes, commands
 

--- a/src/plugins/rv-packages/pymystuff/pymystuff.py
+++ b/src/plugins/rv-packages/pymystuff/pymystuff.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv.rvtypes import MinorMode
 import rv.commands as commands

--- a/src/plugins/rv-packages/pyside_example/pyside_example.py
+++ b/src/plugins/rv-packages/pyside_example/pyside_example.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 import os
 
@@ -12,14 +12,14 @@ try:
     from PySide2.QtWidgets import *
     from PySide2.QtUiTools import QUiLoader
 except ImportError:
-  try:
-    from PySide6 import QtGui, QtCore, QtWidgets
-    from PySide6.QtGui import *
-    from PySide6.QtCore import *
-    from PySide6.QtWidgets import *
-    from PySide6.QtUiTools import QUiLoader
-  except ImportError:
-    pass
+    try:
+        from PySide6 import QtGui, QtCore, QtWidgets
+        from PySide6.QtGui import *
+        from PySide6.QtCore import *
+        from PySide6.QtWidgets import *
+        from PySide6.QtUiTools import QUiLoader
+    except ImportError:
+        pass
 
 from OpenGL.GL import *
 from OpenGL.GLUT import *
@@ -157,9 +157,7 @@ class PySideDockTest(rv.rvtypes.MinorMode):
         return array
 
     def hookup(self, checkbox, spins, dials, prop, last):
-        checkbox.released.connect(
-            self.checkBoxPressed(checkbox, "%s.node.active" % prop)
-        )
+        checkbox.released.connect(self.checkBoxPressed(checkbox, "%s.node.active" % prop))
         for i in range(0, 3):
             dial = dials[i]
             spin = spins[i]
@@ -173,11 +171,7 @@ class PySideDockTest(rv.rvtypes.MinorMode):
         self.init("pyside_example", None, None)
 
         self.loader = QUiLoader()
-        uifile = QFile(
-            os.path.join(
-                self.supportPath(pyside_example, "pyside_example"), "control.ui"
-            )
-        )
+        uifile = QFile(os.path.join(self.supportPath(pyside_example, "pyside_example"), "control.ui"))
         uifile.open(QFile.ReadOnly)
         self.dialog = self.loader.load(uifile)
         uifile.close()
@@ -192,9 +186,7 @@ class PySideDockTest(rv.rvtypes.MinorMode):
         # have to hold refs here so they don't get deleted
         self.radialDistortDials = self.findSet(QDial, ["k1Dial", "k2Dial", "k3Dial"])
 
-        self.radialDistortSpins = self.findSet(
-            QDoubleSpinBox, ["k1SpinBox", "k2SpinBox", "k3SpinBox"]
-        )
+        self.radialDistortSpins = self.findSet(QDoubleSpinBox, ["k1SpinBox", "k2SpinBox", "k3SpinBox"])
 
         self.lastRadialDistort = [0, 0, 0]
 

--- a/src/plugins/rv-packages/rvnuke/menu.py
+++ b/src/plugins/rv-packages/rvnuke/menu.py
@@ -4,27 +4,19 @@ import nuke
 menubar = nuke.menu("Nuke")
 
 menubar.addCommand("RV/Start RV", "rvNuke.startRv()", icon="rvNuke.png")
-menubar.addCommand(
-    "RV/Create Checkpoint", "rvNuke.createCheckpoint()", icon="rvNukeCheck.png"
-)
+menubar.addCommand("RV/Create Checkpoint", "rvNuke.createCheckpoint()", icon="rvNukeCheck.png")
 menubar.addCommand("RV/View in RV", "rvNuke.viewReadsInRv(False)", icon="Viewer.png")
 menubar.addCommand("RV/Render to RV", "rvNuke.Render()", icon="Write.png")
-menubar.addCommand(
-    "RV/Project Settings ...", "rvNuke.showSettingsPanel()", icon="Modify.png"
-)
+menubar.addCommand("RV/Project Settings ...", "rvNuke.showSettingsPanel()", icon="Modify.png")
 menubar.addCommand("RV/Preferences ...", "rvNuke.showPrefs()", icon="rvNukeGear.png")
 
 toolbar = nuke.toolbar("RV")
 
 toolbar.addCommand("Start RV", "rvNuke.startRv()", icon="rvNuke.png")
-toolbar.addCommand(
-    "Create Checkpoint", "rvNuke.createCheckpoint()", icon="rvNukeCheck.png"
-)
+toolbar.addCommand("Create Checkpoint", "rvNuke.createCheckpoint()", icon="rvNukeCheck.png")
 toolbar.addCommand("View in RV", "rvNuke.viewReadsInRv(False)", icon="Viewer.png")
 toolbar.addCommand("Render to RV", "rvNuke.Render()", icon="Write.png")
-toolbar.addCommand(
-    "Project Settings ...", "rvNuke.showSettingsPanel()", icon="Modify.png"
-)
+toolbar.addCommand("Project Settings ...", "rvNuke.showSettingsPanel()", icon="Modify.png")
 toolbar.addCommand("Preferences ...", "rvNuke.showPrefs()", icon="rvNukeGear.png")
 
 if rvNuke.doDebug:

--- a/src/plugins/rv-packages/rvnuke/rvNuke.py
+++ b/src/plugins/rv-packages/rvnuke/rvNuke.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from __future__ import print_function
 
@@ -44,7 +44,6 @@ def encodeNL(str):
 
 
 def initRvMon():
-
     global rvmon
     if not rvmon:
         rvmon = RvMonitor()
@@ -53,7 +52,6 @@ def initRvMon():
 
 
 def pythonHandler(eventContents):
-
     try:
         log("pythonHandler exec '%s'" % eventContents)
         exec(eventContents, globals(), locals())
@@ -153,7 +151,6 @@ class RvMonitor:
         nuke.addOnScriptLoad(self.onScriptLoad)
 
     def __del__(self):
-
         #   Squirrel away a ref to the Popen object because it has a bug that
         #   will print an error message when we delete it if we do it at this
         #   point.  This prevents it from getting garbage collected until later.
@@ -221,28 +218,21 @@ class RvMonitor:
         if not node or type(node).__name__ != "Node":
             return
 
-        if self.syncReadChanges and (
-            str(node.Class()) == "Read" or str(node.Class()) == "Write"
-        ):
+        if self.syncReadChanges and (str(node.Class()) == "Read" or str(node.Class()) == "Write"):
             self.queueCommand('self.viewReadsInRv(["%s"])' % node.name())
 
     def onDestroy(self):
-
         log("onDestroy")
         node = nuke.thisNode()
         if node and type(node).__name__ == "Node":
             log("destroying node of class '%s'" % str(node.Class()))
-            if self.syncReadChanges and (
-                str(node.Class()) == "Read" or str(node.Class()) == "Write"
-            ):
+            if self.syncReadChanges and (str(node.Class()) == "Read" or str(node.Class()) == "Write"):
                 self.queueCommand("self.removeObsoleteReads()")
 
     def updateAndSyncSelection(self, force=False):
-
         nodes = nuke.selectedNodes()
 
         if len(nodes) == 1:
-
             node = nodes[0]
 
             if node.Class() == "Viewer":
@@ -251,10 +241,7 @@ class RvMonitor:
             if not node:
                 return
 
-            log(
-                "updateAndSyncSelection old %s new %s"
-                % (self.selectedNode, node.name())
-            )
+            log("updateAndSyncSelection old %s new %s" % (self.selectedNode, node.name()))
             if force or node.name() != self.selectedNode:
                 self.selectedNode = node.name()
                 self.queueCommand("self.selectCurrentByNodeName()")
@@ -263,7 +250,6 @@ class RvMonitor:
             self.selectedNode = None
 
     def knobChanged(self):
-
         nname = ""
         kname = ""
         if doDebug:
@@ -276,21 +262,14 @@ class RvMonitor:
                     pass
             if nuke.thisKnob():
                 kname = nuke.thisKnob().name()
-            log(
-                "knobChanged node '%s' knob '%s' val '%s'\n"
-                % (nname, kname, str(nuke.thisKnob().value()))
-            )
+            log("knobChanged node '%s' knob '%s' val '%s'\n" % (nname, kname, str(nuke.thisKnob().value())))
 
         node = nuke.thisNode()
         knob = nuke.thisKnob()
         if not node or not knob:
             return
 
-        if (
-            type(node).__name__ != "Node"
-            and type(node).__name__ != "Root"
-            and type(node).__name__ != "Viewer"
-        ):
+        if type(node).__name__ != "Node" and type(node).__name__ != "Root" and type(node).__name__ != "Viewer":
             return
 
         #
@@ -303,12 +282,7 @@ class RvMonitor:
         #
         #   Track frame changes
         #
-        elif (
-            self.syncFrameChange
-            and str(node.Class()) == "Viewer"
-            and knob.name() == "frame"
-            and self.running
-        ):
+        elif self.syncFrameChange and str(node.Class()) == "Viewer" and knob.name() == "frame" and self.running:
             log("frame change")
             self.queueCommand("self.changeFrame(%d)" % knob.value())
 
@@ -401,7 +375,6 @@ class RvMonitor:
             return
 
         while self.running:
-
             if not self.rvc.connected:
                 log("not connected in spawn loop")
                 self.running = False
@@ -542,13 +515,9 @@ class RvMonitor:
             self.rvProc = subprocess.Popen(fullcmd)
             self.rvProc.poll()
             if self.rvProc.returncode:
-                log(
-                    "ERROR: failed to start RV '%s' return: %d"
-                    % (cmd[0], self.rvProc.returncode)
-                )
+                log("ERROR: failed to start RV '%s' return: %d" % (cmd[0], self.rvProc.returncode))
                 print(
-                    "ERROR: failed to start RV '%s' return: %d\n"
-                    % (cmd[0], self.rvProc.returncode),
+                    "ERROR: failed to start RV '%s' return: %d\n" % (cmd[0], self.rvProc.returncode),
                     file=sys.stderr,
                 )
                 return
@@ -587,12 +556,10 @@ class RvMonitor:
             self.rvc.handlers["remote-python-eval"] = pythonHandler
 
     def queueCommand(self, cmd):
-
         log("queueCommand '%s'" % cmd)
         self.commands.append(cmd)
 
     def setSessionDir(self):
-
         #    XXX check running ?
         self.rvc.remoteEval(
             """
@@ -607,14 +574,10 @@ class RvMonitor:
             return
 
         if self.syncReadChanges:
-
             readNodes = [
                 n.name()
                 for n in nuke.allNodes()
-                if (
-                    type(n).__name__ == "Node"
-                    and (n.Class() == "Read" or n.Class() == "Write")
-                )
+                if (type(n).__name__ == "Node" and (n.Class() == "Read" or n.Class() == "Write"))
             ]
             if readNodes:
                 self.queueCommand("self.viewReadsInRv(%s)" % str(readNodes))
@@ -628,7 +591,6 @@ class RvMonitor:
             self.queueCommand("self.changeFrame(%d)" % nuke.frame())
 
     def prepForRender(self, node, renderType):
-
         log("prepForRender %s %s" % (node.name(), renderType))
 
         baseDir = self.sessionDir + "/" + renderType
@@ -650,7 +612,6 @@ class RvMonitor:
         return dateString
 
     def renderTmpFiles(self, node, seqDir, start, end, incr):
-
         log("renderTmpFiles %s %s %s %s %s" % (node.name(), seqDir, start, end, incr))
 
         """
@@ -785,10 +746,7 @@ class RvMonitor:
         readNodes = [
             n.name()
             for n in nuke.allNodes()
-            if (
-                type(n).__name__ == "Node"
-                and (n.Class() == "Read" or n.Class() == "Write")
-            )
+            if (type(n).__name__ == "Node" and (n.Class() == "Read" or n.Class() == "Write"))
         ]
         if not readNodes:
             readsStr = "string[] {}"
@@ -800,11 +758,7 @@ class RvMonitor:
 
         log("    readsStr %s" % readsStr)
 
-        remote = (
-            "require rvnuke_mode; rvnuke_mode.theMode().removeObsoleteReads ("
-            + readsStr
-            + ");"
-        )
+        remote = "require rvnuke_mode; rvnuke_mode.theMode().removeObsoleteReads (" + readsStr + ");"
 
         log("    remote %s" % remote)
         self.rvc.remoteEval(remote)
@@ -832,9 +786,7 @@ class RvMonitor:
             # lasts.append  (node["last"].value())
             firsts.append(node.firstFrame())
             lasts.append(node.lastFrame())
-            spaces.append(
-                re.sub("default \((.*)\)", "\g<1>", node["colorspace"].value())
-            )
+            spaces.append(re.sub("default \((.*)\)", "\g<1>", node["colorspace"].value()))
             labels.append(encodeNL(node["label"].value()))
             classes.append(node.Class())
             ro = "0"
@@ -875,18 +827,15 @@ class RvMonitor:
 
         log("    nameStr %s" % nameStr)
 
-        remote = (
-            "require rvnuke_mode; rvnuke_mode.theMode().viewReadNodes (%s, %s, %s, %s, %s, %s, %s, %s);"
-            % (
-                nameStr,
-                mediaStr,
-                spaceStr,
-                firstStr,
-                lastStr,
-                labelStr,
-                classStr,
-                offsetStr,
-            )
+        remote = "require rvnuke_mode; rvnuke_mode.theMode().viewReadNodes (%s, %s, %s, %s, %s, %s, %s, %s);" % (
+            nameStr,
+            mediaStr,
+            spaceStr,
+            firstStr,
+            lastStr,
+            labelStr,
+            classStr,
+            offsetStr,
         )
 
         log("    remote %s" % remote)
@@ -897,7 +846,6 @@ class RvMonitor:
         exec(s, globals(), locals())
 
     def zoomToNode(self):
-
         log("zoomToNode '%s'" % self.zoomTargetNode)
 
         if not self.zoomTargetNode:
@@ -946,7 +894,6 @@ class RvSettings:
         self.updateFromRoot()
 
     def rebuildSettingsKnobs(self, r):
-
         log("rebuilding settings knobs")
 
         #
@@ -975,29 +922,19 @@ class RvSettings:
         n = "rvSettings_"
 
         k = nuke.File_Knob(n + "sessionDir", "Session Directory")
-        k.setTooltip(
-            "Root directory of RV session data.  Should be unique to this Nuke script"
-        )
+        k.setTooltip("Root directory of RV session data.  Should be unique to this Nuke script")
         k.setValue(self.settings["sessionDir"])
         r.addKnob(k)
 
-        k = nuke.Enumeration_Knob(
-            n + "outputFileFormat", "Render File Format", ["rgb", "exr", "dpx", "jpg"]
-        )
+        k = nuke.Enumeration_Knob(n + "outputFileFormat", "Render File Format", ["rgb", "exr", "dpx", "jpg"])
         k.setTooltip("File format for renders, usual 'rgb' or 'exr'.")
         k.setValue(self.settings["outputFileFormat"])
         r.addKnob(k)
 
         # r.addKnob (nuke.BeginTabGroup_Knob ("rvSettings_syncOptionsBegin", "Sync Options"))
-        r.addKnob(
-            nuke.Tab_Knob(
-                "rvSettings_syncOptionsStart", "Sync Options", nuke.TABBEGINGROUP
-            )
-        )
+        r.addKnob(nuke.Tab_Knob("rvSettings_syncOptionsStart", "Sync Options", nuke.TABBEGINGROUP))
 
-        k = nuke.Boolean_Knob(
-            n + "syncSelection", "Nuke Node Selection  ->  RV Current View"
-        )
+        k = nuke.Boolean_Knob(n + "syncSelection", "Nuke Node Selection  ->  RV Current View")
         k.setTooltip("Sync RV current view to Nuke node selection.")
         k.setValue(self.settings["syncSelection"])
         k.setFlag(nuke.STARTLINE)
@@ -1009,19 +946,13 @@ class RvSettings:
         k.setFlag(nuke.STARTLINE)
         r.addKnob(k)
 
-        k = nuke.Boolean_Knob(
-            n + "syncReadChanges", "Nuke Read/Write Node Changes  ->  RV Sources"
-        )
-        k.setTooltip(
-            "Sync creation/deletion/modification of Read and Write nodes to corresponding sources in RV."
-        )
+        k = nuke.Boolean_Knob(n + "syncReadChanges", "Nuke Read/Write Node Changes  ->  RV Sources")
+        k.setTooltip("Sync creation/deletion/modification of Read and Write nodes to corresponding sources in RV.")
         k.setValue(self.settings["syncReadChanges"])
         k.setFlag(nuke.STARTLINE)
         r.addKnob(k)
 
-        r.addKnob(
-            nuke.Tab_Knob("rvSettings_syncOptionsEnd", "Sync Options", nuke.TABENDGROUP)
-        )
+        r.addKnob(nuke.Tab_Knob("rvSettings_syncOptionsEnd", "Sync Options", nuke.TABENDGROUP))
         # r.addKnob (nuke.EndTabGroup_Knob ("rvSettings_syncOptionsEnd", "Sync Options"))
 
     def updateFromRoot(self):
@@ -1089,7 +1020,6 @@ class RvPreferences:
         self.updateFromDisk()
 
     def prefsPath(self):
-
         home = os.path.expanduser("~")
         nukeDir = home + "/.nuke"
 
@@ -1099,7 +1029,6 @@ class RvPreferences:
         return nukeDir + "/rvprefs"
 
     def updateFromDisk(self):
-
         log("RvPreferences.updateFromDisk")
 
         prefsFileName = self.prefsPath()
@@ -1115,7 +1044,6 @@ class RvPreferences:
         log("    prefs %s" % str(self.prefs))
 
     def saveToDisk(self):
-
         log("RvPreferences.saveToDisk")
 
         prefsFileName = self.prefsPath()
@@ -1134,9 +1062,7 @@ class RvPreferencesPanel(nukescripts.PythonPanel):
         """
         self._constructing = True
 
-        nukescripts.PythonPanel.__init__(
-            self, "Rv Preferences", "com.tweaksoftware.RvPreferencesPanel"
-        )
+        nukescripts.PythonPanel.__init__(self, "Rv Preferences", "com.tweaksoftware.RvPreferencesPanel")
 
         self.rvPrefs = RvPreferences()
 
@@ -1146,15 +1072,11 @@ class RvPreferencesPanel(nukescripts.PythonPanel):
         self.addKnob(self.rvExecPath)
 
         self.extraArgs = nuke.String_Knob("extraArgs", "Default Command Line Args")
-        self.extraArgs.setTooltip(
-            "Additional arguments to be added to the command line when RV is run."
-        )
+        self.extraArgs.setTooltip("Additional arguments to be added to the command line when RV is run.")
         self.extraArgs.setValue(self.rvPrefs.prefs["extraArgs"])
         self.addKnob(self.extraArgs)
 
-        self.sessionDirBase = nuke.File_Knob(
-            "sessionDirBase", "Default Session Dir Base"
-        )
+        self.sessionDirBase = nuke.File_Knob("sessionDirBase", "Default Session Dir Base")
         self.sessionDirBase.setTooltip(
             "Path to base directory from which to form sessionDirectories. $NUKE_TEMP_DIR will be used if this is not set."
         )
@@ -1228,24 +1150,18 @@ def showSettingsPanel():
 
 
 def startRv():
-
     rvmon = initRvMon()
     rvmon.initializeRvSide()
 
 
 def viewReadsInRv(all):
-
     if all:
         nodes = nuke.allNodes()
     else:
         nodes = nuke.selectedNodes()
 
     readNodes = [
-        n.name()
-        for n in nodes
-        if (
-            type(n).__name__ == "Node" and (n.Class() == "Read" or n.Class() == "Write")
-        )
+        n.name() for n in nodes if (type(n).__name__ == "Node" and (n.Class() == "Read" or n.Class() == "Write"))
     ]
 
     log("    reads for viewing: %s\n" % str(readNodes))
@@ -1259,7 +1175,6 @@ def viewReadsInRv(all):
 
 
 def createCheckpoint():
-
     nodes = nuke.selectedNodes()
 
     if len(nodes) != 1:
@@ -1269,16 +1184,11 @@ def createCheckpoint():
     node = nodes[0]
 
     if type(node).__name__ != "Node" and type(node).__name__ != "Viewer":
-        nuke.message(
-            "Node '%s' is not renderable, pleases select a node that can be rendered."
-            % node.name()
-        )
+        nuke.message("Node '%s' is not renderable, pleases select a node that can be rendered." % node.name())
         return
 
     if node.Class() == "Read" or node.Class() == "Write":
-        nuke.message(
-            "There's no need to checkpoint Read or Write nodes, since they can be viewed directly in RV."
-        )
+        nuke.message("There's no need to checkpoint Read or Write nodes, since they can be viewed directly in RV.")
         return
 
     log("createCheckpoint %s" % node.name())
@@ -1344,9 +1254,7 @@ class RvRenderPanel(nukescripts.PythonPanel):
     def __init__(self):
         """RV Render UI"""
         log("RvRenderPanel init")
-        nukescripts.PythonPanel.__init__(
-            self, "RvRenderPanel", "com.tweaksoftware.RenderPanel"
-        )
+        nukescripts.PythonPanel.__init__(self, "RvRenderPanel", "com.tweaksoftware.RenderPanel")
 
         self.outputNode = nuke.String_Knob("outputNode", "Output Node")
         self.outputNode.setValue("")
@@ -1422,12 +1330,7 @@ class RvRenderPanel(nukescripts.PythonPanel):
         else:
             k = kd["RvRenderPrefs"]
 
-        s = self.writeKnobs(
-            nuke.TO_SCRIPT
-            | nuke.TO_VALUE
-            | nuke.WRITE_ALL
-            | nuke.WRITE_NON_DEFAULT_ONLY
-        )
+        s = self.writeKnobs(nuke.TO_SCRIPT | nuke.TO_VALUE | nuke.WRITE_ALL | nuke.WRITE_NON_DEFAULT_ONLY)
         # log ("saving knobs to Root '%s'" % s)
         k.setValue(s)
         k.setVisible(False)
@@ -1534,7 +1437,6 @@ def createReadNode(infos):
     if infos:
         nuke.Undo().begin("Create Read Nodes From RV")
         try:
-
             nukescripts.misc.clear_selection_recursive()
 
             if rvmon:
@@ -1606,7 +1508,6 @@ def restoreCheckpoint(nukeScript, nodeName, date):
 
 
 def killRV():
-
     if rvmon:
         # if (rvmon.rvc.connected) :
         #     rvmon.rvc.disconnect()

--- a/src/plugins/rv-packages/source_setup/source_setup.py
+++ b/src/plugins/rv-packages/source_setup/source_setup.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 from rv import rvtypes
 from rv import commands
@@ -45,7 +45,6 @@ class SourceSetupMode(rvtypes.MinorMode):
     """
 
     def sourceSetup(self, event, noColorChanges=False):
-
         #
         #  event.reject() is done to allow other functions bound to
         #  this event to get a chance to modify the state as well. If
@@ -111,12 +110,7 @@ class SourceSetupMode(rvtypes.MinorMode):
             return
 
         if srcAttrs is None:
-            print(
-                (
-                    "ERROR: SourceSetup: source %s/%s has no attributes"
-                    % (source, fileName)
-                )
-            )
+            print(("ERROR: SourceSetup: source %s/%s has no attributes" % (source, fileName)))
             return
 
         attrDict = dict(zip([i[0] for i in srcAttrs], [j[1] for j in srcAttrs]))
@@ -157,10 +151,7 @@ class SourceSetupMode(rvtypes.MinorMode):
         #
 
         if ext == "DPX":
-            if (
-                srcInfo["DPXCreator"] == "AppleComputers.libcineon"
-                or srcInfo["DPXCreator"] == "AUTODESK"
-            ):
+            if srcInfo["DPXCreator"] == "AppleComputers.libcineon" or srcInfo["DPXCreator"] == "AUTODESK":
                 #
                 #  Final Cut's "Color" and Maya write out bogus DPX
                 #  header info with the aspect ratio fields set
@@ -170,9 +161,7 @@ class SourceSetupMode(rvtypes.MinorMode):
 
                 if float(srcInfo["PixelAspectRatio"]) == 0.0:
                     self.setPixelAspect(lensNode, 1.0)
-            elif (
-                srcInfo["ColorSpace"] == "" or srcInfo["ColorSpace"] == "Other (0)"
-            ) and (
+            elif (srcInfo["ColorSpace"] == "" or srcInfo["ColorSpace"] == "Other (0)") and (
                 srcInfo["DPX0Transfer"] == "" or srcInfo["DPX0Transfer"] == "Other (0)"
             ):
                 #
@@ -192,10 +181,7 @@ class SourceSetupMode(rvtypes.MinorMode):
                 srcInfo["TransferFunction"] = "sRGB"
             else:
                 srcInfo["TransferFunction"] = "Linear"
-        elif ext == "ARI" and (
-            srcInfo["TransferFunction"] == ""
-            or srcInfo["TransferFunction"] == "ARRI LogC"
-        ):
+        elif ext == "ARI" and (srcInfo["TransferFunction"] == "" or srcInfo["TransferFunction"] == "ARRI LogC"):
             #
             #  Assume tif files are linear if there's no other indication
             #
@@ -207,19 +193,13 @@ class SourceSetupMode(rvtypes.MinorMode):
             #
 
             srcInfo["TransferFunction"] = "ALEXA LogC Film"
-        elif (
-            ext in ["JPEG", "JPG", "MOV", "AVI", "MP4"]
-            and srcInfo["TransferFunction"] == ""
-        ):
+        elif ext in ["JPEG", "JPG", "MOV", "AVI", "MP4"] and srcInfo["TransferFunction"] == "":
             #
             #  Assume jpeg/mov is in sRGB space if none is specified
             #
 
             srcInfo["TransferFunction"] = "sRGB"
-        elif (
-            ext in ["J2C", "J2K", "JPT", "JP2"]
-            and srcInfo["ColorSpacePrimaries"] == "UNSPECIFIED"
-        ):
+        elif ext in ["J2C", "J2K", "JPT", "JP2"] and srcInfo["ColorSpacePrimaries"] == "UNSPECIFIED":
             #
             #  If we're assuming XYZ primaries, but ignoring primaries just set
             #  transfer to sRGB.
@@ -249,9 +229,7 @@ class SourceSetupMode(rvtypes.MinorMode):
                     [float(srcInfo["ICCProfileVer"])],
                     True,
                 )
-                commands.setByteProperty(
-                    ICCNode + ".inProfile.data", srcInfo["ICCProfileData"], True
-                )
+                commands.setByteProperty(ICCNode + ".inProfile.data", srcInfo["ICCProfileData"], True)
                 commands.setIntProperty(ICCNode + ".node.active", [1], True)
                 srcInfo["TransferFunction"] = "Linear"
             else:
@@ -274,12 +252,7 @@ class SourceSetupMode(rvtypes.MinorMode):
             #  Get around maya bugs
             #
 
-            print(
-                (
-                    "WARNING: Assuming %s was created by Maya with a bad pixel aspect ratio\n"
-                    % fileName
-                )
-            )
+            print(("WARNING: Assuming %s was created by Maya with a bad pixel aspect ratio\n" % fileName))
             self.setPixelAspect(lensNode, 1.0)
 
         if srcInfo["JPEGPixelAspect"] != "" and srcInfo["JPEGDensity"] != "":
@@ -293,12 +266,7 @@ class SourceSetupMode(rvtypes.MinorMode):
                 #  Maya JPEG -- fix pixel aspect
                 #
 
-                print(
-                    (
-                        "WARNING: Assuming %s was created by Maya with a bad pixel aspect ratio\n"
-                        % fileName
-                    )
-                )
+                print(("WARNING: Assuming %s was created by Maya with a bad pixel aspect ratio\n" % fileName))
                 self.setPixelAspect(lensNode, 1.0)
 
         #
@@ -332,14 +300,9 @@ class SourceSetupMode(rvtypes.MinorMode):
             #
             #  Allow user to override with environment variables
             #
-            srcInfo["TransferFunction"] = self.checkEnvVar(
-                ext, mInfo["bitsPerChannel"], srcInfo["TransferFunction"]
-            )
+            srcInfo["TransferFunction"] = self.checkEnvVar(ext, mInfo["bitsPerChannel"], srcInfo["TransferFunction"])
 
-            if self.setFileColorSpace(
-                linNode, srcInfo["TransferFunction"], srcInfo["ColorSpace"]
-            ):
-
+            if self.setFileColorSpace(linNode, srcInfo["TransferFunction"], srcInfo["ColorSpace"]):
                 #
                 #  The default display correction is sRGB if the
                 #  pixels can be converted to (or are already in)
@@ -386,7 +349,6 @@ class SourceSetupMode(rvtypes.MinorMode):
         #
 
         for dnode in commands.nodesOfType("RVDisplayColor"):
-
             #
             #  If we managed to recognize a transform to linear, default
             #  to a display to a linear -> sRGB
@@ -399,41 +361,20 @@ class SourceSetupMode(rvtypes.MinorMode):
             if dICCNode:
                 commands.setIntProperty(dICCNode + ".node.active", [0], True)
 
-            if (
-                dgroup is not None
-                and commands.nodeType(dgroup) == "RVDisplayGroup"
-                and dgroup not in dnodesWithProfile
-            ):
-
+            if dgroup is not None and commands.nodeType(dgroup) == "RVDisplayGroup" and dgroup not in dnodesWithProfile:
                 dICC = commands.getStringProperty(dgroup + ".device.systemProfileURL")
                 if dICCNode and len(dICC) == 1 and not dICC[0] == "":
                     dICCPath = urlparse(dICC[0].replace("%20", " ")).path
-                    if "windows" in platform.platform().lower() and re.match(
-                        "^/.:.*$", dICCPath
-                    ):
+                    if "windows" in platform.platform().lower() and re.match("^/.:.*$", dICCPath):
                         dICCPath = dICCPath[1:]
-                    commands.setStringProperty(
-                        dICCNode + ".outProfile.url", [dICCPath], True
-                    )
+                    commands.setStringProperty(dICCNode + ".outProfile.url", [dICCPath], True)
                     commands.setIntProperty(dICCNode + ".node.active", [1], True)
                 else:
-                    sRGBDisplay = (
-                        commands.getIntProperty(dnode + ".color.sRGB", 0, 20000)[0] != 0
-                    )
-                    rec709Display = (
-                        commands.getIntProperty(dnode + ".color.Rec709", 0, 20000)[0]
-                        != 0
-                    )
-                    gammaDisplay = (
-                        commands.getFloatProperty(dnode + ".color.gamma", 0, 20000)[0]
-                        != 1.0
-                    )
-                    lutDisplay = (
-                        commands.getIntProperty(dnode + ".lut.active", 0, 20000)[0] != 0
-                    )
-                    anyDisplay = (
-                        sRGBDisplay or rec709Display or gammaDisplay or lutDisplay
-                    )
+                    sRGBDisplay = commands.getIntProperty(dnode + ".color.sRGB", 0, 20000)[0] != 0
+                    rec709Display = commands.getIntProperty(dnode + ".color.Rec709", 0, 20000)[0] != 0
+                    gammaDisplay = commands.getFloatProperty(dnode + ".color.gamma", 0, 20000)[0] != 1.0
+                    lutDisplay = commands.getIntProperty(dnode + ".lut.active", 0, 20000)[0] != 0
+                    anyDisplay = sRGBDisplay or rec709Display or gammaDisplay or lutDisplay
 
                     if not anyDisplay:
                         commands.setIntProperty(dnode + ".color.sRGB", [1], True)

--- a/src/plugins/rv-packages/webview2/webview2.py
+++ b/src/plugins/rv-packages/webview2/webview2.py
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved. 
-# 
-# SPDX-License-Identifier: Apache-2.0 
+# Copyright (C) 2023  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 #
 
 import sys
@@ -23,19 +23,19 @@ try:
     )  # import qApp#, QMainWindow, QLabel, QPixmap, QColor, QGridLayout, QWidget, QPushButton, QComboBox
     from PySide2.QtWidgets import QDockWidget
 except ImportError:
-  try:
-    from PySide6 import QtCore
-    from PySide6 import QtWidgets
-    from PySide6 import QtWebChannel
-    from PySide6 import QtWebEngineWidgets
-    from PySide6 import QtQml
+    try:
+        from PySide6 import QtCore
+        from PySide6 import QtWidgets
+        from PySide6 import QtWebChannel
+        from PySide6 import QtWebEngineWidgets
+        from PySide6 import QtQml
 
-    from PySide6.QtWidgets import (
-        qApp,
-    )  # import qApp#, QMainWindow, QLabel, QPixmap, QColor, QGridLayout, QWidget, QPushButton, QComboBox
-    from PySide6.QtWidgets import QDockWidget
-  except ImportError:
-    pass
+        from PySide6.QtWidgets import (
+            qApp,
+        )  # import qApp#, QMainWindow, QLabel, QPixmap, QColor, QGridLayout, QWidget, QPushButton, QComboBox
+        from PySide6.QtWidgets import QDockWidget
+    except ImportError:
+        pass
 
 print(QtWebEngineWidgets.__file__)
 
@@ -56,9 +56,7 @@ class WebView2(rvtypes.MinorMode):
 
         qtutils.javascriptExport(self.webview.page())
 
-        defaultpath = "file:///" + os.path.join(
-            self.supportPath(sys.modules[__name__]), "webview_example.html"
-        )
+        defaultpath = "file:///" + os.path.join(self.supportPath(sys.modules[__name__]), "webview_example.html")
         self.webview.load(defaultpath)
 
     def activate(self):


### PR DESCRIPTION
### Format Python code with Ruff

### Summarize your change.

Run `ruff format` on all Python files with the default formatting rules.

The formatting was done following the default rules but the line length was increased to 120 in `ruff.toml` that is added in another PR.

### Describe the reason for the change.

Ruff is a tool that can do exactly what Black was doing as a formatter while also being able to lint and fix the code following PEP8 at the same time. Using the same tool for both makes the steps of linting and formatting easier to run locally, with pre-commit and on the CI.