### PR TITLE
CI - Add retry for a step for Rocky Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,29 @@ jobs:
       - name: Install other system dependencies
         if: ${{ matrix.rocky-version == '9' }}
         run: |
-          dnf install -y perl-CPAN
-          cpan FindBin
+          retry_count=0
+          max_retries=5
+
+          until [ $retry_count -ge $max_retries ]; do
+            echo "Attempt $((retry_count + 1)) of $max_retries"
+
+            if dnf install -y perl-CPAN && \
+              cpan FindBin; then
+              echo "Dependencies installed successfully"
+              break
+            else
+              retry_count=$((retry_count + 1))
+              if [ $retry_count -lt $max_retries ]; then
+                echo "Attempt $retry_count failed. Retrying in 5 seconds..."
+                sleep 5
+              fi
+            fi
+          done
+          
+          if [ $retry_count -ge $max_retries ]; then
+            echo "Failed to install dependencies after $max_retries attempts"
+            exit 1
+          fi
 
       - name: Check out repository code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7


### PR DESCRIPTION
### CI - Add retry for a step for Rocky Linux

### Linked issues
n/a

### Summarize your change.
Added the retry mechanism to step `Install other system dependencies`

### Describe the reason for the change.
Builds fails on Rocky Linux due to network issue

### Describe what you have tested and on which operating system.
CI