### PR TITLE
Optimize media loading when loading an .rv session file

### DIFF
--- a/src/lib/app/RvApp/RvSession.cpp
+++ b/src/lib/app/RvApp/RvSession.cpp
@@ -3123,6 +3123,30 @@ namespace Rv
                 string p = protocol(pc);
                 if (isProgressionProtocol(p))
                     ++m_gtoSourceTotal;
+
+                // Optimization: Start preloading media if this is an
+                // RVFileSource with active media
+                if (p == "RVFileSource"
+                    && !Options::sharedOptions().progressiveSourceLoading)
+                {
+                    IntProperty* mediaActive =
+                        pc->property<IntProperty>("media.active");
+                    if (mediaActive && !mediaActive->empty()
+                        && mediaActive->front() == 1)
+                    {
+                        StringProperty* movie =
+                            pc->property<StringProperty>("media.movie");
+                        if (movie && !movie->empty())
+                        {
+                            // Start preloading for all movie instances in the
+                            // container
+                            for (size_t j = 0; j < movie->size(); j++)
+                            {
+                                startPreloadingMedia((*movie)[j]);
+                            }
+                        }
+                    }
+                }
             }
 
             m_gtoSourceCount = 0;


### PR DESCRIPTION
### Optimize media loading when loading an .rv session file

### Linked issues
NA

### Describe the reason for the change.

Slow .rv session file loading when multiple sources were present. The new media loading optimization (startPreloadingMedia) was not leveraged when loading a .rv session file. 

### Summarize your change.

This commit now levereges the new startPreloadingMedia when loading a .rv session file. 

### Describe what you have tested and on which operating system.
Sucessfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.