### PR TITLE
Disable FFmpeg for OIIO

### DIFF
--- a/cmake/dependencies/oiio.cmake
+++ b/cmake/dependencies/oiio.cmake
@@ -90,26 +90,7 @@ LIST(APPEND _configure_options "-DOPENJPEG_INCLUDE_DIR=${_openjpeg_include_dir}"
 
 LIST(APPEND _configure_options "-DTIFF_ROOT=${RV_DEPS_TIFF_ROOT_DIR}")
 
-GET_TARGET_PROPERTY(_ffmpeg_include_dir ffmpeg::avcodec INTERFACE_INCLUDE_DIRECTORIES)
-IF(RV_TARGET_WINDOWS)
-  GET_TARGET_PROPERTY(_ffmpeg_libavcodec ffmpeg::avcodec IMPORTED_IMPLIB)
-  GET_TARGET_PROPERTY(_ffmpeg_libavformat ffmpeg::avformat IMPORTED_IMPLIB)
-  GET_TARGET_PROPERTY(_ffmpeg_libavutil ffmpeg::avutil IMPORTED_IMPLIB)
-  GET_TARGET_PROPERTY(_ffmpeg_libswscale ffmpeg::swscale IMPORTED_IMPLIB)
-ELSE()
-  GET_TARGET_PROPERTY(_ffmpeg_libavcodec ffmpeg::avcodec IMPORTED_LOCATION)
-  GET_TARGET_PROPERTY(_ffmpeg_libavformat ffmpeg::avformat IMPORTED_LOCATION)
-  GET_TARGET_PROPERTY(_ffmpeg_libavutil ffmpeg::avutil IMPORTED_LOCATION)
-  GET_TARGET_PROPERTY(_ffmpeg_libswscale ffmpeg::swscale IMPORTED_LOCATION)
-ENDIF()
-LIST(APPEND _configure_options "-DFFMPEG_INCLUDE_DIR=${_ffmpeg_include_dir}")
-LIST(APPEND _configure_options "-DFFMPEG_INCLUDES=${_ffmpeg_include_dir}")
-LIST(APPEND _configure_options "-DFFMPEG_AVCODEC_INCLUDE_DIR=${_ffmpeg_include_dir}")
-LIST(APPEND _configure_options "-DFFMPEG_LIBRARIES=${_ffmpeg_libavcodec} ${_ffmpeg_libavformat} ${_ffmpeg_libavutil} ${_ffmpeg_libswscale}")
-LIST(APPEND _configure_options "-DFFMPEG_LIBAVCODEC=${_ffmpeg_libavcodec}")
-LIST(APPEND _configure_options "-DFFMPEG_LIBAVFORMAT=${_ffmpeg_libavformat}")
-LIST(APPEND _configure_options "-DFFMPEG_LIBAVUTIL=${_ffmpeg_libavutil}")
-LIST(APPEND _configure_options "-DFFMPEG_LIBSWSCALE=${_ffmpeg_libswscale}")
+LIST(APPEND _configure_options "-USE_FFMPEG=0")
 
 IF(RV_TARGET_LINUX)
   MESSAGE(STATUS "Building OpenImageIO using system's freetype library.")
@@ -167,10 +148,6 @@ IF(NOT RV_TARGET_WINDOWS)
             Imath::Imath
             Webp::Webp
             Raw::Raw
-            ffmpeg::swresample
-            ffmpeg::swscale
-            ffmpeg::avcodec
-            ffmpeg::swresample
             ZLIB::ZLIB
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options}
     BUILD_COMMAND ${_cmake_build_command}
@@ -225,10 +202,6 @@ ELSE()
             Imath::Imath
             Webp::Webp
             Raw::Raw
-            ffmpeg::swresample
-            ffmpeg::swscale
-            ffmpeg::avcodec
-            ffmpeg::swresample
             ZLIB::ZLIB
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options}
     BUILD_COMMAND ${CMAKE_COMMAND} ${_oiio_build_options}


### PR DESCRIPTION
### Disable FFMPEG for OIIO

### Linked issues
n/a

### Summarize your change.
Disabled FFmpeg for OIIO by passing `USE_FFMPEG=0` to OIIO.

Here the list of file format  read bu the io_oiio plugin in OpenRV:
https://github.com/AcademySoftwareFoundation/OpenRV/blob/41c4b872038a53dc8c3dc5aa50d5366d426d6f34/src/lib/image/IOoiio/IOoiio.cpp#L24-L73

For references, OIIO can read the following format, but again, that functionality is not used in OpenRV:
https://openimageio.readthedocs.io/en/v3.1.6.1/builtinplugins.html#movie-formats-using-ffmpeg

Format | Extensions
-- | --
AVI | .avi
QuickTime | .qt, .mov
MPEG-4 | .mp4, .m4a, .m4v
3GPP files | .3gp, .3g2
Motion JPEG-2000 | .mj2
Apple M4V | .m4v
MPEG-1/MPEG-2 | .mpg



### Describe the reason for the change.
OpenRV does not use OIIO to read video format. Therefore, FFmpeg is not needed for OIIO.

### Describe what you have tested and on which operating system.
MacOS, CI