### PR TITLE
Pin the commit for OpenGL-Registry (downloaded when building GLEW)

### DIFF
--- a/cmake/dependencies/glew.cmake
+++ b/cmake/dependencies/glew.cmake
@@ -55,12 +55,14 @@ EXTERNALPROJECT_ADD(
   # Patch to fix the build issue with OpenGL-Registry
   # Pinning the OpenGL-Registry version to a specific commit
   # https://github.com/nigels-com/glew/issues/449
+  # Also clone the required glfixes repository
   PATCH_COMMAND 
     cd auto && 
     git clone https://github.com/KhronosGroup/OpenGL-Registry.git || true &&
     cd OpenGL-Registry && 
     git checkout a77f5b6ffd0b0b74904f755ae977fa278eac4e95 && 
     cd .. && 
+    git clone --depth=1 --branch glew https://github.com/nigels-com/glfixes glfixes || true &&
     touch OpenGL-Registry/.dummy &&
     cd ..
   CONFIGURE_COMMAND cd auto && ${_make_command} && cd .. && ${_make_command}


### PR DESCRIPTION
### Pin the commit for OpenGL-Registry (downloaded when building GLEW)

### Linked issues
n/a

### Summarize your change.

To fix this, `glew.cmake` will clone the `OpenGL-Registry` and checkout the latest working commit before executing the `make` command. It will prevent the build system of GLEW to checkout the master of `OpenGL-Registry`, and it will continue as usual.

### Describe the reason for the change.
A recent changes in https://github.com/KhronosGroup/OpenGL-Registry (https://github.com/KhronosGroup/OpenGL-Registry/commit/d38ff693f3e99ac5a61e3858de76c6c02976fa67) is causing C++ redefinition of typedef which causes a bunch of errors.

See an opened issue in GLEW repository: https://github.com/nigels-com/glew/issues/449

### Describe what you have tested and on which operating system.
CI