### PR TITLE
SG-40184: Cancel clear if plugin refuses

### DIFF
--- a/src/lib/app/mu_rvui/rvui.mu
+++ b/src/lib/app/mu_rvui/rvui.mu
@@ -3604,7 +3604,9 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
     let mode = cacheMode(),
         presMode = presentationMode();
 
-    sendInternalEvent ("before-session-clear-everything", "", "rvui");
+    let result = sendInternalEvent ("before-session-clear-everything", "", "rvui");
+    if (result == "cancel")
+        return;
 
     setPresentationMode(false);
     clearSession();


### PR DESCRIPTION

### Linked issues

SG-40184

### Summarize your change.

Super simple change where we return early if an event handler catches the before-clear event and returns "cancel".

### Describe the reason for the change.

We dont usually check for confirmation before clearing the session, but in upcoming live review changes it will pop up a confirmation dialog if a review session is in progress.

### Describe what you have tested and on which operating system.

macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.