### PR TITLE
SG-40541: fix alignment glitch with QAlertPanel

### DIFF
--- a/src/lib/app/RvCommon/QAlertPanel.cpp
+++ b/src/lib/app/RvCommon/QAlertPanel.cpp
@@ -187,7 +187,10 @@ void QAlertPanel::adjustBestFitDimensions()
 
         // Try different widths to find the best text wrapping
         float bestFitRatio = 1e100;
-        int bestWidth = 100; // Start with a reasonable width
+        // Start with a reasonable width to acount at least for margins and
+        // such: left margin (20) + icon (32) + spacing (15) + right margin (20)
+        // = 87
+        int bestWidth = 100;
         int bestHeight = 50;
 
         float targetBestFitRatio = 2.0;
@@ -215,7 +218,8 @@ void QAlertPanel::adjustBestFitDimensions()
         }
 
         // Calculate dialog size with reasonable padding
-        int dialogWidth = bestWidth + 80; // Add padding for icon and margins
+        int dialogWidth =
+            bestWidth + 100; // Add padding for icon and margins (87 + buffer)
         int dialogHeight =
             bestHeight + 80; // Add padding for buttons and margins
 


### PR DESCRIPTION

### Linked issues

Fixes SG-40541

### Summarize your change.

in some cases, when text was just a little bit longer than the message I had before, the last line might have gotten clipped.  This is because the minimum width was less than the sum of the actual width if you include margins, icons, padding, etc (80px vs 87 px required).  This 7px difference was enough to cause such disruption. 

It took me a while to figure this out, but the fix appears to be trivial.

I dont think it requires pre-checkin test.  

### Describe the reason for the change.

Last line was clipped sometimes. 

### Describe what you have tested and on which operating system.

macOS 

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

<img width="414" height="224" alt="image" src="https://github.com/user-attachments/assets/607166e6-6199-436d-998f-3c78dccf714b" />


