### PR TITLE
Fix help menu

### DIFF
--- a/src/plugins/rv-packages/openrv_help_menu/openrv_help_menu_mode.mu
+++ b/src/plugins/rv-packages/openrv_help_menu/openrv_help_menu_mode.mu
@@ -154,7 +154,7 @@ class: OpenRVHelpMenuMinorMode : MinorMode
         });
 
         Menu menu = newMenu(MenuItem[] {
-            subMenu("Help", menuList.items)
+            subMenu("Help", menuList)
         });
 
         \: bindDescribe (void; string name, EventFunc F)


### PR DESCRIPTION
### Fix help menu

### Summarize your change.

Remove `.items` in the menuList of the "Help" submenu. Note that the same line without the `.items` is in the Commercial RV version of the help menu mode file.

### Describe the reason for the change.

When launching Open RV, the following error was being displayed in the console: `openrv_help_menu_mode.mu, line 157, char 42: Unresolved member reference to "items" in type "MenuItem[]"`

### Describe what you have tested and on which operating system.

Launching Open RV on macOS 15.6.1 with the fix removed the error in the console.