### PR TITLE
Remove forgotten std::cout from a previous PR

### DIFF
--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -754,7 +754,6 @@ namespace IPCore
         {
             m_disabledEventCategories.push_back(category);
         }
-        std::cout << "Disabled event category: " << category << std::endl;
     }
 
     bool Session::isEventCategoryDisabled(std::string_view category) const


### PR DESCRIPTION
### Remove forgotten std::cout from a previous PR

### Linked issues
n/a

### Summarize your change.
Remove a superflous std:cout

### Describe the reason for the change.
Forgotten std::cout from a previous PR

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.