### PR TITLE
SG-41101: Fix crash canceling quicktime export

### DIFF
--- a/src/lib/app/mu_rvui/HUD.mu
+++ b/src/lib/app/mu_rvui/HUD.mu
@@ -503,16 +503,7 @@ class: ProcessInfo : Widget
     \: killProcess (void; Event ev)
     {
         State state = data();
-        
-        // Look up the process from state instead of capturing it in the closure
         ExternalProcess p = state.externalProcess;
-        
-        // Check if process is still valid (might have finished already)
-        if (p eq nil || p.isFinished())
-        {
-            redraw();
-            return;
-        }
         
         let details = if (p._cancelDetails neq nil) then p._cancelDetails else ("Do you want to quit \"%s\"?" % p._name);
         int choice = alertPanel(true, // associated panel (sheet on OSX)


### PR DESCRIPTION
### Linked issues
SG-41101

### Summarize your change.

Crash when canceling quicktime export.

Crash seemed to occur when trying to call killProcess when pressing the X button.
For some reason, repeatedly setting the _callback to a partial function instance seems to cause mu to crash.  

This might be due to the fact that we set the callback from the render loop, creating a new function partial instance at every render  "_callback = killProcess(p,);" , the old will go stale, and when we call killProcess on a stale partial function instance, it will crash if there's a render call in between, I'm not sure. Either way, setting the callback to killProcess directly probably causes no new symbol to be created, and hence we can call it, avoiding the crash; we simply retrieve the current process from the state, which is fine.

That, or it's an old mu bug that is manifesting itself again, but since the fix above works that's what It'll be.

### Describe the reason for the change.

Crash

### Describe what you have tested and on which operating system.

macOS

### Add a list of changes, and note any that might need special attention during the review.

N/A

### If possible, provide screenshots.