### PR TITLE
Return to building OTIO from source

### DIFF
--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -8,10 +8,6 @@ SET(_python3_target
     "RV_DEPS_PYTHON3"
 )
 
-SET(_opentimelineio_target
-    "RV_DEPS_OPENTIMELINEIO"
-)
-
 RV_VFX_SET_VARIABLE(_pyside_target CY2023 "RV_DEPS_PYSIDE2" CY2024 "RV_DEPS_PYSIDE6")
 
 SET(PYTHON_VERSION_MAJOR
@@ -33,12 +29,16 @@ SET(RV_DEPS_PYTHON_VERSION_SHORT
     "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
 )
 
-# This version is used for:
-# 1. Building OpenTimelineIO from source for Windows debug builds
-# 2. Generating src/build/requirements.txt from requirements.txt.in template
-#    (used by all other platforms/builds to install from PyPI)
+# This version is used for generating src/build/requirements.txt from requirements.txt.in template
+# All platforms install OpenTimelineIO from git to ensure consistent source builds.
 SET(_opentimelineio_version
     "0.18.1"
+)
+
+# Construct the full git URL for pip to use in requirements.txt
+# Using this avoids @ symbol conflicts in CONFIGURE_FILE
+SET(_opentimelineio_pip_url
+    "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO@v${_opentimelineio_version}#egg=OpenTimelineIO"
 )
 
 RV_VFX_SET_VARIABLE(_pyside_version CY2023 "5.15.10" CY2024 "6.5.3")
@@ -47,13 +47,6 @@ SET(_python3_download_url
     "https://github.com/python/cpython/archive/refs/tags/v${_python3_version}.zip"
 )
 RV_VFX_SET_VARIABLE(_python3_download_hash CY2023 "21b32503f31386b37f0c42172dfe5637" CY2024 "392eccd4386936ffcc46ed08057db3e7")
-
-SET(_opentimelineio_download_url
-    "https://github.com/AcademySoftwareFoundation/OpenTimelineIO"
-)
-SET(_opentimelineio_git_tag
-    "v${_opentimelineio_version}"
-)
 
 RV_VFX_SET_VARIABLE(
   _pyside_archive_url
@@ -75,18 +68,8 @@ SET(_build_dir
     ${RV_DEPS_BASE_DIR}/${_python3_target}/build
 )
 
-IF(RV_TARGET_WINDOWS)
-
-  FETCHCONTENT_DECLARE(
-    ${_opentimelineio_target}
-    GIT_REPOSITORY ${_opentimelineio_download_url}
-    GIT_TAG ${_opentimelineio_git_tag}
-    SOURCE_SUBDIR "src" # Avoids the top level CMakeLists.txt
-  )
-
-  FETCHCONTENT_MAKEAVAILABLE(${_opentimelineio_target})
-
-ENDIF()
+# Note: OpenTimelineIO is now installed via requirements.txt from git URL for all platforms.
+# This ensures consistent source builds across Windows, Mac, and Linux.
 
 FETCHCONTENT_DECLARE(
   ${_pyside_target}
@@ -121,8 +104,6 @@ IF(DEFINED RV_DEPS_OPENSSL_INSTALL_DIR)
   LIST(APPEND _python3_make_command ${RV_DEPS_OPENSSL_INSTALL_DIR})
 ENDIF()
 IF(RV_TARGET_WINDOWS)
-  LIST(APPEND _python3_make_command "--opentimelineio-source-dir")
-  LIST(APPEND _python3_make_command ${rv_deps_opentimelineio_SOURCE_DIR})
   LIST(APPEND _python3_make_command "--python-version")
   LIST(APPEND _python3_make_command "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
 ENDIF()

--- a/src/build/make_python.py
+++ b/src/build/make_python.py
@@ -32,7 +32,6 @@ OUTPUT_DIR = ""
 TEMP_DIR = ""
 VARIANT = ""
 ARCH = ""
-OPENTIMELINEIO_SOURCE_DIR = ""
 
 LIB_DIR = ""
 
@@ -120,8 +119,9 @@ def get_python_interpreter_args(python_home: str, variant: str) -> List[str]:
     :return: Path to the python interpreter
     """
 
-    build_opentimelineio = platform.system() == "Windows" and variant == "Debug"
-    python_name_pattern = "python*" if not build_opentimelineio else "python_d*"
+    # On Windows Debug, use the debug Python interpreter (python_d.exe)
+    use_debug_python = platform.system() == "Windows" and variant == "Debug"
+    python_name_pattern = "python*" if not use_debug_python else "python_d*"
 
     python_interpreters = glob.glob(os.path.join(python_home, python_name_pattern), recursive=True)
     python_interpreters += glob.glob(os.path.join(python_home, "bin", python_name_pattern))
@@ -279,48 +279,8 @@ def test_python_distribution(python_home: str) -> None:
 
         python_interpreter_args = get_python_interpreter_args(tmp_python_home, VARIANT)
 
-        # Note: We need to build opentimelineio from sources in Windows+Debug
-        #       because the official wheel links with the release version of
-        #       python while RV uses the debug version.
-        build_opentimelineio = platform.system() == "Windows" and VARIANT == "Debug"
-        if build_opentimelineio:
-            print("Building opentimelineio")
-
-            # Request an opentimelineio debug build
-            my_env = os.environ.copy()
-            my_env["OTIO_CXX_DEBUG_BUILD"] = "1"
-
-            # Specify the location of the debug python import lib (eg. python39_d.lib)
-            python_include_dirs = os.path.join(tmp_python_home, "include")
-            python_lib = os.path.join(tmp_python_home, "libs", f"python{PYTHON_VERSION}_d.lib")
-            my_env["CMAKE_ARGS"] = f"-DPython_LIBRARY={python_lib} -DCMAKE_INCLUDE_PATH={python_include_dirs}"
-
-            opentimelineio_install_arg = python_interpreter_args + [
-                "-m",
-                "pip",
-                "install",
-                ".",
-            ]
-
-            subprocess.run(
-                opentimelineio_install_arg,
-                env=my_env,
-                cwd=OPENTIMELINEIO_SOURCE_DIR,
-            ).check_returncode()
-
-            # Note : The OpenTimelineIO build will generate the pyd with names that are not loadable by default
-            # Example: _opentimed_d.cp39-win_amd64.pyd instead of _opentime_d.pyd
-            # and _otiod_d.cp39-win_amd64.pyd instead of _otio_d.pyd
-            # We fix those names here
-            otio_module_dir = os.path.join(tmp_python_home, "lib", "site-packages", "opentimelineio")
-            for _file in os.listdir(otio_module_dir):
-                if _file.endswith("pyd"):
-                    otio_lib_name_split = os.path.basename(_file).split(".")
-                    if len(otio_lib_name_split) > 2:
-                        new_otio_lib_name = otio_lib_name_split[0].replace("d_d", "_d") + ".pyd"
-                        src_file = os.path.join(otio_module_dir, _file)
-                        dst_file = os.path.join(otio_module_dir, new_otio_lib_name)
-                        shutil.copyfile(src_file, dst_file)
+        # Note: OpenTimelineIO is installed via requirements.txt for all platforms and build types.
+        # The git URL in requirements.txt ensures it builds from source with proper linkage.
 
         wheel_install_arg = python_interpreter_args + [
             "-m",
@@ -329,10 +289,7 @@ def test_python_distribution(python_home: str) -> None:
             "cryptography",
         ]
 
-        if not build_opentimelineio:
-            wheel_install_arg.append("opentimelineio")
-
-        print(f"Validating the that we can install a wheel with {wheel_install_arg}")
+        print(f"Validating that we can install a wheel with {wheel_install_arg}")
         subprocess.run(wheel_install_arg).check_returncode()
 
         python_validation_args = python_interpreter_args + [
@@ -786,14 +743,6 @@ if __name__ == "__main__":
 
     parser.add_argument("--vfx_platform", dest="vfx_platform", type=int, required=True)
 
-    parser.add_argument(
-        "--opentimelineio-source-dir",
-        dest="otio_source_dir",
-        type=str,
-        required=False,
-        default="",
-    )
-
     if platform.system() == "Windows":
         # Major and minor version of Python without dots. E.g. 3.10.3 -> 310
         parser.add_argument(
@@ -814,7 +763,6 @@ if __name__ == "__main__":
     OPENSSL_OUTPUT_DIR = args.openssl
     VARIANT = args.variant
     ARCH = args.arch
-    OPENTIMELINEIO_SOURCE_DIR = args.otio_source_dir
     VFX_PLATFORM = args.vfx_platform
 
     if platform.system() == "Darwin":

--- a/src/build/requirements.txt.in
+++ b/src/build/requirements.txt.in
@@ -4,7 +4,7 @@
 
 pip                     # License: MIT License (MIT)
 setuptools              # License: MIT License
-OpenTimelineIO==@_opentimelineio_version@ # License: Other/Proprietary License (Modified Apache 2.0 License)
+@_opentimelineio_pip_url@ # License: Other/Proprietary License (Modified Apache 2.0 License)
 PyOpenGL                # License: BSD License (BSD)
 
 # MacOS only - PyOpenGL_accelerate is built from source in python3.cmake as a workaround until the fix


### PR DESCRIPTION
### Fix occasional segault on Windows release startup

### Summarize your change.

In commit https://github.com/AcademySoftwareFoundation/OpenRV/commit/93819da3a2af14c63fcb00c1b61fc3d3e4394c2f to pin the OTIO version, I change the requirements.txt file used to install OTIO to point to a version number instead of a git commit like it was doing before.

This introduced an unintended side effect. When you point to a particular git commit the wheel will always be built locally before installing, which makes sense when you think about it because there are no pre-built wheels hosted in git. Conversely, when you use a version number, pip will check pypi for a pre-built wheel before building and install that if it exists. The only pre-built wheel that has a match is Windows release -- there are no debug versions, we don't use the same flavour of Linux as OTIO pre-built wheels nor the same verison of mac OS.  This causes a problem because we are building our own version of python and unless the compilers, shared lib versions, etc match exactly there is a potential for ABI in compatibilities and resulting crashes.

To fix it, we will simply go back to using a git commit so we always build our own wheels.  However, we will use the version to to match the tag in git so we are still pinned which was the point of the previous commit.

Lastly, there was a portion of custom code for Windows debug version to build OTIO for the exact problem we're trying to solve here. However, since we started pointing at a git commit this all became useless since once requirements.txt is already doing exactly the same thing.  Thus, I removed all the code and we will only have a single code path to build OTIO. 

### Describe the reason for the change.

Fix an occasional startup crash on Windows (depending on your compiler and shared lib versions).

### Describe what you have tested and on which operating system.

Windows 11.  Built and launched successfully.
