### PR TITLE
SG-40349 - Use tooltip from toolbar-set-disabled-prefix event in RvTopViewToolBar.cpp

### DIFF
--- a/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
+++ b/src/lib/app/RvCommon/RvBottomViewToolBar.cpp
@@ -467,7 +467,6 @@ namespace Rv
             }
             else if (name == "event-category-state-changed")
             {
-                // Update action availability when presenter changes or session mode changes
                 updateActionAvailability();
             }
             else if (name == "toolbar-set-cannot-use-tooltip")

--- a/src/lib/app/RvCommon/RvCommon/RvTopViewToolBar.h
+++ b/src/lib/app/RvCommon/RvCommon/RvTopViewToolBar.h
@@ -145,6 +145,7 @@ namespace Rv
 
     private:
         IPCore::Session* m_session;
+        QString m_customDisabledPrefix;
         QAction* m_viewBackAction;
         QAction* m_viewForwardAction;
         QComboBox* m_viewCombo;

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -282,8 +282,6 @@ namespace Rv
 
         //
         //  Create UI blocking overlay - transparent widget that captures all input
-        //  Used during presenter transitions in Live Review to prevent interaction
-        //  without closing panels
         //
         m_blockingOverlay = new QWidget(this);
         m_blockingOverlay->setObjectName("UIBlockingOverlay");

--- a/src/lib/app/RvCommon/RvTopViewToolBar.cpp
+++ b/src/lib/app/RvCommon/RvTopViewToolBar.cpp
@@ -515,7 +515,11 @@ namespace Rv
             }
             else if (name == "event-category-state-changed")
             {
-                // Update action availability when presenter changes or session mode changes
+                updateActionAvailability();
+            }
+            else if (name == "toolbar-set-disabled-prefix")
+            {
+                m_customDisabledPrefix = QString::fromUtf8(contents.c_str());
                 updateActionAvailability();
             }
         }
@@ -1391,8 +1395,17 @@ namespace Rv
                 bool categoryEnabled = m_session->isEventCategoryEnabled(mapping.category);
 
                 mapping.action->setEnabled(categoryEnabled);
-                mapping.action->setToolTip(categoryEnabled ? mapping.defaultTooltip
-                                                           : QString("You must be presenter to use ") + mapping.defaultTooltip);
+                if (categoryEnabled)
+                {
+                    mapping.action->setToolTip(mapping.defaultTooltip);
+                }
+                else
+                {
+                    QString tooltip = m_customDisabledPrefix.isEmpty() 
+                                      ? mapping.defaultTooltip 
+                                      : m_customDisabledPrefix + mapping.defaultTooltip;
+                    mapping.action->setToolTip(tooltip);
+                }
             }
         }
     }


### PR DESCRIPTION
### SG-40349 - Use tooltip from toolbar-set-disabled-prefix event in RvTopViewToolBar.cpp

### Linked issues
n/a

### Summarize your change.
Use the the custom tooltip (if set) in `RvTopViewToolBar` (just like `RvBottomViewToolBar`)

### Describe the reason for the change.
Forgot to update `RvTopViewToolBar`

### Describe what you have tested and on which operating system.
MacOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.