### PR TITLE
SG-41075 - Remove jobs for CY2023 MacOS Intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,21 +387,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: "macos-13"
-            arch-type: "x86_64"
-            build-type: "Release"
-            qt-version: "5.15.2"
-            python-version: "3.10"
-            cmake-version: "3.31.6"
-            vfx-platform: "CY2023"
-          - os: "macos-13"
-            arch-type: "x86_64"
-            build-type: "Debug"
-            qt-version: "5.15.2"
-            python-version: "3.10"
-            cmake-version: "3.31.6"
-            vfx-platform: "CY2023"
-
           # VFX2024
           - os: "macos-13"
             arch-type: "x86_64"


### PR DESCRIPTION
### SG-41075 - Remove jobs for CY2023 MacOS Intel

### Linked issues
n/a

### Summarize your change.
Remove CY2023 MacOS Intel jobs in the CI

### Describe the reason for the change.

Due to the removal of the GitHub Action runner `macos-13` and how old is PySide2 to work with recent versions of XCode, we decided to remove the CI jobs for `CY2023 MacOS Intel`

### Describe what you have tested and on which operating system.
CI

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.