### PR TITLE
Fix ERROR: while loading source module inspector.mu

### DIFF
--- a/src/lib/app/mu_rvui/inspector.mu
+++ b/src/lib/app/mu_rvui/inspector.mu
@@ -336,11 +336,11 @@ class: Inspector : Widget
                 menuItem("Final Rendered Color", "", "info_category", optFinalColor(this, true,), \: (int;) { isShowingFinalColor(this, true); }),
                 menuItem("Source Color", "", "info_category", optFinalColor(this, false,), \: (int;) { isShowingFinalColor(this, false); }),
                 menuSeparator(),
-                menuItem("Normalized [0.0, 1.0]", "info_category", "", optNumericScale(this, 1,), \: (int;) { isNumericScale(this, 1); }),
-                menuItem("8 Bit [0, 255]", "info_category", "", optNumericScale(this, 8,), \: (int;) { isNumericScale(this, 8); }),
-                menuItem("10 Bit [0, 1023]", "info_category", "", optNumericScale(this, 10,), \: (int;) { isNumericScale(this, 10); }),
-                menuItem("12 Bit [0, 4095]", "info_category", "", optNumericScale(this, 12,), \: (int;) { isNumericScale(this, 12); }),
-                menuItem("16 Bit [0, 65535]", "info_category", "", optNumericScale(this, 16,), \: (int;) { isNumericScale(this, 16); }),
+                menuItem("Normalized [0.0, 1.0]", "", "info_category", optNumericScale(this, 1,), \: (int;) { isNumericScale(this, 1); }),
+                menuItem("8 Bit [0, 255]", "", "info_category", optNumericScale(this, 8,), \: (int;) { isNumericScale(this, 8); }),
+                menuItem("10 Bit [0, 1023]", "", "info_category", optNumericScale(this, 10,), \: (int;) { isNumericScale(this, 10); }),
+                menuItem("12 Bit [0, 4095]", "", "info_category", optNumericScale(this, 12,), \: (int;) { isNumericScale(this, 12); }),
+                menuItem("16 Bit [0, 65535]", "", "info_category", optNumericScale(this, 16,), \: (int;) { isNumericScale(this, 16); }),
                 menuSeparator(),
                 menuItem("Plain Pointer", "", "system_category", optPointerStyle(this, PointerStylePlain,), \: (int;) { isPointerStyle(this, PointerStylePlain); }),
                 menuItem("Cross Pointer", "", "system_category", optPointerStyle(this, PointerStyleCross,), \: (int;) { isPointerStyle(this, PointerStyleCross); }),
@@ -349,7 +349,7 @@ class: Inspector : Widget
                 menuItem("Close Button Always", "", "system_category", optCloseButtonStyle(this, CloseButtonAlways,), \: (int;) { isCloseButtonStyle(this, CloseButtonAlways); }),
                 menuItem("Close Button When Nearby", "", "system_category", optCloseButtonStyle(this, CloseButtonNearby,), \: (int;) { isCloseButtonStyle(this, CloseButtonNearby); }),
                 menuSeparator(),
-                menuItem("Close Inspector", "", "system_category", \: (void; Event event) { this.toggle(); }, \: (int;) { UncheckedMenuState; }),
+                menuItem("Close Inspector", "", "system_category", \: (void; Event event) { this.toggle(); }, \: (int;) { UncheckedMenuState; })
             })
         );
     }


### PR DESCRIPTION
### Fix ERROR: while loading source module inspector.mu

### Linked issues
NA

### Describe the reason for the change.
When activating the Color Inspector, its menu failed to initialize properly and the following error was reported:
```
ERROR: while loading source module "../Mu/inspector.mu"
ERROR: syntax error
```

This is a recent regression

### Summarize your change.
Removed the trailing comma at the end of the color inspector's menu definition which was the source of the error
(At the end of "Close Inspector")

Also in this commit: Fixed the eventPattern, category inversion for the 8bits/10bits/12bits/16bits menu items.

Thanks to @markreidvfx for reporting it !

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.