### PR TITLE
CI - Moving CY2024 MacOS Intel build from macos-13 to macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
       matrix:
         include:
           # VFX2024
-          - os: "macos-13"
+          - os: "macos-15"
             arch-type: "x86_64"
             build-type: "Release"
             qt-version: "6.5.3"
@@ -404,7 +404,7 @@ jobs:
             python-version: "3.11"
             cmake-version: "3.31.6"
             vfx-platform: "CY2024"
-          - os: "macos-13"
+          - os: "macos-15"
             arch-type: "x86_64"
             build-type: "Debug"
             qt-version: "6.5.3"


### PR DESCRIPTION
### CI - Moving CY2024 MacOS Intel build from macos-13 to macos-15

### Linked issues
n/a

### Summarize your change.
Moving CY2024 MacOS Intel build from macos-13 to macos-15

### Describe the reason for the change.
macos-13 are getting removed.

### Describe what you have tested and on which operating system.
CI

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.