### PR TITLE
SG-41087 - Remove filterLiveReviewEvents

### DIFF
--- a/src/lib/app/py_rvui/rv_commands_setup.py
+++ b/src/lib/app/py_rvui/rv_commands_setup.py
@@ -302,7 +302,6 @@ all_mu_commands = [
     "getReleaseVariant",
     "isDebug",
     "setFilterLiveReviewEvents",
-    "filterLiveReviewEvents",
     "enableEventCategory",
     "disableEventCategory",
     "isEventCategoryEnabled",

--- a/src/lib/ip/IPCore/IPCore/Session.h
+++ b/src/lib/ip/IPCore/IPCore/Session.h
@@ -782,8 +782,6 @@ namespace IPCore
         void setGlobalAudioOffset(float, bool internal = false);
         void setGlobalSwapEyes(bool);
 
-        bool filterLiveReviewEvents();
-
         //
         //  Event Category Blocking
         //
@@ -1239,7 +1237,6 @@ namespace IPCore
         int m_avPlaybackVersion;
         bool m_enableFastTurnAround;
         double m_lastDrawingTime;
-        bool m_filterLiveReviewEvents{false};
         std::vector<std::string_view> m_disabledEventCategories; // List of blocked event categories
 
         class FpsCalculator;

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -680,8 +680,6 @@ namespace IPCore
         }
     }
 
-    bool Session::filterLiveReviewEvents() { return m_filterLiveReviewEvents; }
-
     //----------------------------------------------------------------------
     // Event Category Blocking
     //----------------------------------------------------------------------

--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -3896,12 +3896,6 @@ namespace IPMu
         }
     }
 
-    NODE_IMPLEMENTATION(filterLiveReviewEvents, bool)
-    {
-        Session* s = Session::currentSession();
-        NODE_RETURN(s->filterLiveReviewEvents());
-    }
-
     NODE_IMPLEMENTATION(enableEventCategory, void)
     {
         Session* s = Session::currentSession();
@@ -5863,8 +5857,6 @@ namespace IPMu
 
             new Function(c, "setFilterLiveReviewEvents", setFilterLiveReviewEvents, None, Return, "void", Parameters,
                          new Param(c, "shouldFilterEvents", "bool"), End),
-
-            new Function(c, "filterLiveReviewEvents", filterLiveReviewEvents, None, Return, "bool", End),
 
             new Function(c, "enableEventCategory", enableEventCategory, None, Return, "void", Parameters,
                          new Param(c, "category", "string"), End),


### PR DESCRIPTION
### SG-41087 - Remove filterLiveReviewEvents

### Linked issues
n/a

### Summarize your change.
Remove filterLiveReviewEvents

### Describe the reason for the change.
Remove filterLiveReviewEvents because the categories based filtering has been implemented.

### Describe what you have tested and on which operating system.
MacOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.