### PR TITLE
Build all python package dependencies

### DIFF
--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -31,18 +31,12 @@ SET(RV_DEPS_PYTHON_VERSION_SHORT
 )
 
 # This version is used for generating src/build/requirements.txt from requirements.txt.in template
-# All platforms install OpenTimelineIO from git to ensure consistent source builds.
 SET(_opentimelineio_version
     "${RV_DEPS_OTIO_VERSION}"
 )
 
 SET(_pyside_version 
     "${RV_DEPS_PYSIDE_VERSION}"
-)
-# Construct the full git URL for pip to use in requirements.txt
-# Using this avoids @ symbol conflicts in CONFIGURE_FILE
-SET(_opentimelineio_pip_url
-    "git+https://github.com/AcademySoftwareFoundation/OpenTimelineIO@v${_opentimelineio_version}#egg=OpenTimelineIO"
 )
 
 SET(_python3_download_url
@@ -78,9 +72,6 @@ SET(_source_dir
 SET(_build_dir
     ${RV_DEPS_BASE_DIR}/${_python3_target}/build
 )
-
-# Note: OpenTimelineIO is now installed via requirements.txt from git URL for all platforms.
-# This ensures consistent source builds across Windows, Mac, and Linux.
 
 FETCHCONTENT_DECLARE(
   ${_pyside_target}
@@ -283,12 +274,13 @@ ELSE()
   SET(_otio_debug_env "")
 ENDIF()
 
-# Single unified command for all platforms and build types
+# Using --no-binary :all: to ensure all packages with native extensions are built from source
+# against our custom Python build, preventing ABI compatibility issues.
 SET(_requirements_install_command
     ${CMAKE_COMMAND} -E env
     ${_otio_debug_env}
     "CMAKE_ARGS=-DPYTHON_LIBRARY=${_python3_cmake_library} -DPYTHON_INCLUDE_DIR=${_include_dir} -DPYTHON_EXECUTABLE=${_python3_executable}"
-    "${_python3_executable}" -m pip install --upgrade --no-cache-dir --force-reinstall -r "${_requirements_output_file}"
+    "${_python3_executable}" -m pip install --upgrade --no-cache-dir --force-reinstall --no-binary :all: -r "${_requirements_output_file}"
 )
 
 IF(RV_TARGET_WINDOWS)

--- a/src/build/requirements.txt.in
+++ b/src/build/requirements.txt.in
@@ -1,10 +1,11 @@
 # This file contains all the packages that will be packaged with RV. Please add the license next to the package.
 # NOTE: This is a CMake template file. The actual requirements.txt is generated during CMake configuration.
 #       To update OpenTimelineIO version, edit _opentimelineio_version in cmake/dependencies/python3.cmake
+# NOTE: Using --no-binary :all: in pip install ensures all packages are built from source against our custom Python.
 
 pip                     # License: MIT License (MIT)
 setuptools              # License: MIT License
-@_opentimelineio_pip_url@ # License: Other/Proprietary License (Modified Apache 2.0 License)
+opentimelineio==@_opentimelineio_version@ # License: Other/Proprietary License (Modified Apache 2.0 License)
 PyOpenGL                # License: BSD License (BSD)
 
 # MacOS only - PyOpenGL_accelerate is built from source in python3.cmake as a workaround until the fix


### PR DESCRIPTION
### Build all python dependencies from source

### Summarize your change.

After fixing ABI compatibility issues with OTIO arising from the fact that we are building our own custom python, I checked the other packages and there are indeed others that also have binary components (PyOpenGL_accelerate, pydantic, and cryptography).

Because of this, we should just always build the packages from source with the same compiler we use to build python, and we can do that using the --no-binary option from pip. Although this might be a little bit slower, it will ensure that any package with binary components won't have ABI compatibility issues and for pure python packages it has no effect anyway.

### Describe the reason for the change.

ABI safety

### Describe what you have tested and on which operating system.

Built on Mac OS 26.1.
