### PR TITLE
SG-41334: Silence skipping qeventpoint message from qt

### DIFF
--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -132,7 +132,11 @@ namespace
 
                                     // Another known warning/error which we can safely ignore.
                                     "Release of profile requested but WebEnginePage still not "
-                                    "deleted"sv};
+                                    "deleted"sv,
+
+                                    // Qt pointer dispatch warning when touch events arrive without
+                                    // a target window (harmless, happens during window transitions)
+                                    "skipping QEventPoint"sv};
 
         return any_of(silenced.begin(), silenced.end(), [text](const auto& msg) { return text.find(msg) != string::npos; });
     }


### PR DESCRIPTION

### Linked issues

[SG-41334](https://jira.autodesk.com/browse/SG-41334)

### Summarize your change.

Add "skipping QEventPoint" to the list of silences Qt warnings that are issued to the console.

### Describe the reason for the change.

We sometimes (but rarely) see this warning from within Qt. It's harmless, but annoying, so silenced it.

_**WARNING: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=1465.03,909.258 gbl=1465.03,909.258 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-1465.03,-909.258 last=-1465.03,-909.258 Δ 1465.03,909.258) : no target window**_


### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.