### PR TITLE
Fix annotate_mode.mu loading error caused by bad merge

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -2074,14 +2074,13 @@ class: AnnotateMinorMode : MinorMode
         {
             let answer = alertPanel(true, InfoAlert, "Clear all annotations from the current timeline?", nil, "OK", "Cancel", nil);
 
-        if (answer != 0)
-        {
-            return;
+            if (answer != 0)
+            {
+                return;
+            }
         }
-        else
-        {
-            clearAllPaint();
-        }
+
+        clearAllPaint();
 
         updateFrameDependentState();
         redraw();


### PR DESCRIPTION
### Fix annotate_mode.mu loading error caused by bad merge

### Linked issues
NA

### Describe the reason for the change.
A bad automatic merge occurred for the annotate_mode.mu resulting in an error at load time.

### Summarize your change.
Fixed the bad merge

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.