### PR TITLE
feat: SG-41515: Add support for optional major.minor.PATCH version number in packages and bundles

### DIFF
--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -435,13 +435,8 @@ FUNCTION(rv_stage)
         MESSAGE(DEBUG "Found version for '${arg_TARGET}.rvpkg' package version ${_pkg_version} ...")
       ENDIF()
 
-      # Normalize version to major.minor format for filename (strip patch if present)
-      # This ensures compatibility with existing package loading code that expects X.X format
-      STRING(REGEX REPLACE "^([0-9]+)\\.([0-9]+)(\\.[0-9]+)?.*" "\\1.\\2" _pkg_version_normalized "${_pkg_version}")
-      MESSAGE(DEBUG "Normalized package version from '${_pkg_version}' to '${_pkg_version_normalized}' for filename")
-
       SET(_package_filename
-          "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version_normalized}.rvpkg"
+          "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version}.rvpkg"
       )
 
       LIST(APPEND RV_PACKAGE_LIST "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version}.rvpkg")

--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -431,11 +431,19 @@ FUNCTION(rv_stage)
         MESSAGE(DEBUG "Found version for '${arg_TARGET}.rvpkg' package version ${_pkg_version} ...")
       ENDIF()
 
+      # Normalize version for filename: strip .0 patch if present, keep non-zero patches
+      # Only strip if it's a 3-part version ending in .0 (e.g. 2.5.0 -> 2.5, but keep 2.0 as-is)
+      SET(_pkg_version_normalized "${_pkg_version}")
+      STRING(REGEX REPLACE "^([0-9]+\\.[0-9]+)\\.0$" "\\1" _pkg_version_normalized "${_pkg_version}")
+      IF(NOT "${_pkg_version}" STREQUAL "${_pkg_version_normalized}")
+        MESSAGE(DEBUG "Normalized package version from '${_pkg_version}' to '${_pkg_version_normalized}' for filename")
+      ENDIF()
+
       SET(_package_filename
-          "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version}.rvpkg"
+          "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version_normalized}.rvpkg"
       )
 
-      LIST(APPEND RV_PACKAGE_LIST "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version}.rvpkg")
+      LIST(APPEND RV_PACKAGE_LIST "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version_normalized}.rvpkg")
       LIST(REMOVE_DUPLICATES RV_PACKAGE_LIST)
       SET(RV_PACKAGE_LIST
           ${RV_PACKAGE_LIST}
@@ -472,11 +480,11 @@ FUNCTION(rv_stage)
       )
 
       ADD_CUSTOM_TARGET(
-        ${arg_TARGET}-${_pkg_version}.rvpkg ALL
+        ${arg_TARGET}-${_pkg_version_normalized}.rvpkg ALL
         DEPENDS ${_package_filename}
       )
 
-      ADD_DEPENDENCIES(packages ${arg_TARGET}-${_pkg_version}.rvpkg)
+      ADD_DEPENDENCIES(packages ${arg_TARGET}-${_pkg_version_normalized}.rvpkg)
     ENDIF()
 
   ELSEIF(${arg_TYPE} STREQUAL "IMAGE_FORMAT")

--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -409,10 +409,6 @@ FUNCTION(rv_stage)
       ENDIF()
 
       LIST(REMOVE_ITEM _files Makefile CMakeLists.txt ${_package_file})
-      
-      # Remove macOS metadata files
-      LIST(FILTER _files EXCLUDE REGEX ".*\\.DS_Store$")
-      LIST(FILTER _files EXCLUDE REGEX "^__MACOSX/.*")
 
       IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${_package_file})
         MESSAGE(FATAL_ERROR "Couldn't find expected package descriptor file: '${_package_file}'")

--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -409,6 +409,10 @@ FUNCTION(rv_stage)
       ENDIF()
 
       LIST(REMOVE_ITEM _files Makefile CMakeLists.txt ${_package_file})
+      
+      # Remove macOS metadata files
+      LIST(FILTER _files EXCLUDE REGEX ".*\\.DS_Store$")
+      LIST(FILTER _files EXCLUDE REGEX "^__MACOSX/.*")
 
       IF(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${_package_file})
         MESSAGE(FATAL_ERROR "Couldn't find expected package descriptor file: '${_package_file}'")
@@ -431,8 +435,13 @@ FUNCTION(rv_stage)
         MESSAGE(DEBUG "Found version for '${arg_TARGET}.rvpkg' package version ${_pkg_version} ...")
       ENDIF()
 
+      # Normalize version to major.minor format for filename (strip patch if present)
+      # This ensures compatibility with existing package loading code that expects X.X format
+      STRING(REGEX REPLACE "^([0-9]+)\\.([0-9]+)(\\.[0-9]+)?.*" "\\1.\\2" _pkg_version_normalized "${_pkg_version}")
+      MESSAGE(DEBUG "Normalized package version from '${_pkg_version}' to '${_pkg_version_normalized}' for filename")
+
       SET(_package_filename
-          "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version}.rvpkg"
+          "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version_normalized}.rvpkg"
       )
 
       LIST(APPEND RV_PACKAGE_LIST "${RV_PACKAGES_DIR}/${arg_TARGET}-${_pkg_version}.rvpkg")

--- a/src/lib/app/RvPackage/PackageManager.cpp
+++ b/src/lib/app/RvPackage/PackageManager.cpp
@@ -67,27 +67,6 @@ namespace Rv
         }
 
         string fullPath = outputPath + "/" + filename;
-        
-        // Check if this is a directory entry (ends with /)
-        if (fullPath.back() == '/')
-        {
-            unzCloseCurrentFile(uf);
-            return ""; // Skip directory entries
-        }
-        
-        // Create parent directories if needed
-        QFileInfo fileInfo_qt(QString::fromStdString(fullPath));
-        QDir parentDir = fileInfo_qt.dir();
-        if (!parentDir.exists())
-        {
-            if (!parentDir.mkpath("."))
-            {
-                cerr << "ERROR: Unable to create directory: " << parentDir.absolutePath().toStdString() << endl;
-                unzCloseCurrentFile(uf);
-                return "";
-            }
-        }
-        
         FILE* outFile = std::fopen(fullPath.c_str(), "wb");
         if (outFile == nullptr)
         {

--- a/src/lib/app/RvPackage/PackageManager.cpp
+++ b/src/lib/app/RvPackage/PackageManager.cpp
@@ -24,6 +24,31 @@ namespace Rv
 {
     using namespace std;
 
+    // Normalize version string to major.minor.patch format
+    // If only major.minor is provided, append .0 for patch
+    QString normalizeVersion(const QString& version)
+    {
+        QString v = version.trimmed();
+        
+        // Count the number of dots
+        int dotCount = v.count('.');
+        
+        // If we have 0 or 1 dots, we need to add patch version
+        if (dotCount == 0)
+        {
+            // major only -> major.0.0
+            return v + ".0.0";
+        }
+        else if (dotCount == 1)
+        {
+            // major.minor -> major.minor.0
+            return v + ".0";
+        }
+        
+        // Already has 2+ dots, return as-is
+        return v;
+    }
+
     QString extractFile(unzFile uf, const string& outputPath)
     {
         char filename[256];
@@ -42,10 +67,33 @@ namespace Rv
         }
 
         string fullPath = outputPath + "/" + filename;
+        
+        // Check if this is a directory entry (ends with /)
+        if (fullPath.back() == '/')
+        {
+            unzCloseCurrentFile(uf);
+            return ""; // Skip directory entries
+        }
+        
+        // Create parent directories if needed
+        QFileInfo fileInfo_qt(QString::fromStdString(fullPath));
+        QDir parentDir = fileInfo_qt.dir();
+        if (!parentDir.exists())
+        {
+            if (!parentDir.mkpath("."))
+            {
+                cerr << "ERROR: Unable to create directory: " << parentDir.absolutePath().toStdString() << endl;
+                unzCloseCurrentFile(uf);
+                return "";
+            }
+        }
+        
         FILE* outFile = std::fopen(fullPath.c_str(), "wb");
         if (outFile == nullptr)
         {
-            cerr << "ERROR: Unable to open output file" << endl;
+            cerr << "ERROR: Unable to open output file: " << fullPath << endl;
+            cerr << "       Directory: " << parentDir.absolutePath().toStdString() << endl;
+            cerr << "       Check permissions and disk space." << endl;
             unzCloseCurrentFile(uf);
             return "";
         }
@@ -87,11 +135,8 @@ namespace Rv
         do
         {
             QString extractedFilePath = extractFile(uf, outputPath);
-            if (extractedFilePath == "")
-            {
-                cerr << "ERROR: Unable to extract zip file" << endl;
-            }
-            else
+            // Only add .rvpkg files to the list, ignore directories and other files
+            if (!extractedFilePath.isEmpty() && extractedFilePath.endsWith(".rvpkg"))
             {
                 includedPackages.push_back(extractedFilePath);
             }
@@ -1291,7 +1336,7 @@ namespace Rv
                                 else if (pname == "contact")
                                     package.contact = v;
                                 else if (pname == "version")
-                                    package.version = v;
+                                    package.version = normalizeVersion(v);
                                 else if (pname == "requires")
                                 package.
                                     requires
@@ -1346,7 +1391,8 @@ namespace Rv
                                       });
                     }
 
-                    QRegularExpression rvpkgRE(R"((.*)-[0-9]+\.[0-9]+\.rvpkg)");
+                    // Add support for optional packages with patch version
+                    QRegularExpression rvpkgRE(R"((.*)-[0-9]+\.[0-9]+(\.[0-9]+)?\.rvpkg)");
                     QRegularExpression zipRE(R"((.*)\.zip)");
 
                     QRegularExpressionMatch match = rvpkgRE.match(finfo.fileName());
@@ -1722,8 +1768,9 @@ namespace Rv
         //  First check that package files exist and have legal names
         //
 
-        QRegularExpression rvpkgRE(R"((.*)-[0-9]+\.[0-9]+\.rvpkg)");
-        QRegularExpression rvpkgsRE(R"(.*)-[0-9]+\.[0-9]+\.rvpkgs)"); // bundle
+        // Add support for optional packages with patch version
+        QRegularExpression rvpkgRE(R"((.*)-[0-9]+\.[0-9]+(\.[0-9]+)?\.rvpkg)");
+        QRegularExpression rvpkgsRE(R"(.*)-[0-9]+\.[0-9]+(\.[0-9]+)?\.rvpkgs)"); // bundle
         QRegularExpression zipRE(R"((.*)\.zip)");
 
         for (size_t i = 0; i < files.size(); i++)

--- a/src/lib/app/mu_rvui/mode_manager.mu
+++ b/src/lib/app/mu_rvui/mode_manager.mu
@@ -126,6 +126,7 @@ class: ModeManagerMode : MinorMode
         string  base;
         int     major;
         int     minor;
+        int     patch;
         Package existing;
     }
 
@@ -531,6 +532,7 @@ class: ModeManagerMode : MinorMode
 
         int major = 1;
         int minor = 0;
+        int patch = 0;
 
         if (ext == "rvpkg")
         {
@@ -538,8 +540,19 @@ class: ModeManagerMode : MinorMode
             try
             {
                 let vparts = name.split("-")[1].split(".");
-                major = int(vparts[0]);
-                minor = int(vparts[1]);
+                // Support both major.minor and major.minor.patch formats
+                if (vparts.size() >= 2)
+                {
+                    major = int(vparts[0]);
+                    minor = int(vparts[1]);
+
+                    if (vparts.size() > 2)
+                        patch = int(vparts[2]);
+                }
+                else
+                {
+                    error = true;
+                }
             }
             catch (...)
             {
@@ -547,12 +560,12 @@ class: ModeManagerMode : MinorMode
             }
 
             if (error) {
-                print("ERROR: bad rvpkg package name \"%s\" expecting name-X.X.rvpkg\n" % name);
+                print("ERROR: bad rvpkg package name \"%s\" expecting name-X.X.rvpkg or name-X.X.X.rvpkg\n" % name);
                 return nil;
             }
         }
 
-        _packages.push_back(Package(name, without_extension(name), base, major, minor, existing));
+        _packages.push_back(Package(name, without_extension(name), base, major, minor, patch, existing));
         return _packages.back();
     }
 


### PR DESCRIPTION
### Linked issues

SG-41515

### Summarize your change and reason for change

Package and bundle files only had major.minor version numbers. This made it extremely cumbersome and awkward to issue patch releases with a patch number for hotfixes. 

Now the package manager handles an optional major.minor.PATCH number. It is backwards compatible with just major.minor, and will assume ".0" for patch number in this case.

Users reported that when we added a  "version" tag in the PACKAGE file with an extra dot/number, it didn't work. But that's because the rvpkg executable appears to load the PACKAGE file, and will blindly create a file with the extra dot/number. But the rvpkg **loader** validates the filename against a regular expression, and the filename with the extra dot/number failed the regex check.

So it's not that the "version" tag didn't support the extra dot/number. It's that the rvpkg **loader** didn't like the filename format... sigh.

In any case, the fix makes RV able to load old filenames with major.minor, and major.minor.patch also...

... but unfortunately, old RVs will still be unable to read **pluginname_major.minor.patch.rvpkg** files, just "pluginname_major.minor.rvpkg" files.

note:

As an alternative to breaking old RVs, maybe we can rename the rvpkg files by adding a service pack number (sp) to the version number, like this:

```
if patch == 0, then 
   filename = plugin_name-major.minor.rvpkg
else
   filename = plugin_name_sp{patch}.major.minor.rvpkg

```
but it's unclear if this would work correctly for install/uninstall of old bundles and packages that need conflict resolutions.


### Describe what you have tested and on which operating system.

macOS.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.