### PR TITLE
SG-41513: Prevent tiff build from depending on libzstd (-Dzstd=OFF)

### DIFF
--- a/cmake/dependencies/tiff.cmake
+++ b/cmake/dependencies/tiff.cmake
@@ -51,7 +51,6 @@ GET_TARGET_PROPERTY(zlib_include_dir ZLIB::ZLIB INTERFACE_INCLUDE_DIRECTORIES)
 LIST(APPEND _configure_options "-DZLIB_INCLUDE_DIR=${zlib_include_dir}")
 LIST(APPEND _configure_options "-DZLIB_LIBRARY=${zlib_library}")
 
-
 IF(RV_TARGET_WINDOWS)
   GET_TARGET_PROPERTY(jpeg_library jpeg-turbo::jpeg IMPORTED_IMPLIB)
 ELSE()
@@ -63,8 +62,9 @@ LIST(APPEND _configure_options "-DJPEG_LIBRARY=${jpeg_library}")
 
 LIST(APPEND _configure_options "-Djpeg=ON")
 LIST(APPEND _configure_options "-Dlzma=OFF")
-LIST(APPEND _configure_options "-Dzlib=ON")
 LIST(APPEND _configure_options "-Dwebp=OFF")
+LIST(APPEND _configure_options "-Dzlib=ON")
+LIST(APPEND _configure_options "-Dzstd=OFF")
 
 # Do not need TIFF tools.
 LIST(APPEND _configure_options "-Dtiff-tools=OFF")
@@ -110,9 +110,13 @@ SET_PROPERTY(
 )
 IF(RV_TARGET_WINDOWS)
   IF(${CMAKE_BUILD_TYPE} STREQUAL "Release")
-    SET(_tiff_lib_name "tiff.lib")
+    SET(_tiff_lib_name
+        "tiff.lib"
+    )
   ELSEIF(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    SET(_tiff_lib_name "tiffd.lib")
+    SET(_tiff_lib_name
+        "tiffd.lib"
+    )
   ENDIF()
 
   SET_PROPERTY(

--- a/src/lib/app/mu_rvui/app_utils.mu
+++ b/src/lib/app/mu_rvui/app_utils.mu
@@ -28,7 +28,7 @@ MenuStateFunc   := (int;);
 
 \: checkAndBlockEventCategory(bool; string category)
 {
-    if (!commands.isEventCategoryEnabled("category"))
+    if (!commands.isEventCategoryEnabled(category))
     {
         sendInternalEvent("category-event-blocked", category);
         return false;


### PR DESCRIPTION
### SG-41513: Prevent tiff build from depending on libzstd (-Dzstd=OFF)

### Linked issues
NA

### Describe the reason for the change.
When building the tiff library, the libzstd would be added as a dependency if it was found on the build agent.
This ended up adding an undesirable dependency to libtiff which prevented RV/OpenRV from launching on system without the libzstd dependency:

```
RV.app/Contents/MacOS/RV 
dyld[70560]: Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
  Referenced from: <53E188D2-B08B-3962-BF49-8D0029A61CDF> /Users/Shared/Jenkins/rv/rv_build/RV/RV.app/Contents/lib/libtiff.6.dylib
  Reason: tried: '/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/usr/lib/libzstd.1.dylib' (no such file, not in dyld cache)
zsh: abort      /Users/Shared/Jenkins/rv/rv_build/RV/RV.app/Contents/MacOS/RV
```


BAD:
otool -L  /Users/administrator/tmp/toTest/latest_latest/RV.app/Contents/lib/libtiff.6.dylib:
	@rpath/libtiff.6.dylib (compatibility version 6.0.0, current version 6.0.2)
	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.3.1)
	@rpath/libjpeg.62.dylib (compatibility version 62.0.0, current version 62.3.0)
	/usr/local/opt/zstd/lib/libzstd.1.dylib (compatibility version 1.0.0, current version 1.5.7)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)

GOOD:
otool -L  /Users/administrator/tmp/toTest/latest_5ee/RV.app/Contents/lib/libtiff.6.dylib:
	@rpath/libtiff.6.dylib (compatibility version 6.0.0, current version 6.0.2)
	@rpath/libz.1.dylib (compatibility version 1.0.0, current version 1.3.1)
	@rpath/libjpeg.62.dylib (compatibility version 62.0.0, current version 62.3.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)


### Summarize your change.

Now preventing tiff build from depending on libzstd by specifying -Dzstd=OFF on the configure options,

### Describe what you have tested and on which operating system.
Successfully tested on macOS Intel

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.