### PR TITLE
Summarize build errors

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -337,8 +337,17 @@ __rv_build_with_errors() {
     
     # Extract and display compilation errors
     if [[ -f "${build_log}" ]]; then
-      # Extract error messages (looking for common error patterns)
-      grep -E "error:|fatal error:|undefined reference|❌|FAILED:" "${build_log}" | grep -v "warnings being treated as errors" | head -50 > "${error_summary}" 2>/dev/null || true
+      # Extract error messages (looking for common error patterns across platforms)
+      # Patterns cover:
+      #   - GCC/Clang:  "error:", "fatal error:", "undefined reference"
+      #   - MSVC:       "error C####:", "error LNK####:", ": error :"
+      #   - Ninja:      "FAILED:"
+      #   - CMake:      "CMake Error"
+      #   - Linker:     "unresolved external symbol", "undefined symbol"
+      grep -E "(error C[0-9]+:|error LNK[0-9]+:|: error :|error:|fatal error:|undefined reference|undefined symbol|unresolved external symbol|FAILED:|CMake Error)" "${build_log}" | \
+        grep -v "warnings being treated as errors" | \
+        grep -v "0 error" | \
+        head -50 > "${error_summary}" 2>/dev/null || true
       
       if [[ -s "${error_summary}" ]]; then
         echo "🔥 Compilation Errors Found:"


### PR DESCRIPTION
### Summarize build errors

### Summarize your change.

This branch will create a summary of the build errors whenever the build fails.  Sometimes it can be difficult to figure out exactly what went wrong in the very verbose build output. We'll now capture the output in a build log, and if it fails grep the resulting log for know error prefixes and output them.  This is not 100% foolproof, but it is an improvement.

There's also a `rverrsummary` that will re-output the summary for the last build, and an `rverrors` that will output the whole build log for a failed build.
We now capture all the build output to a log

### Describe the reason for the change.

Speed up debugging build failures.

### Describe what you have tested and on which operating system.

Build on macos.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

Before:
```
ninja: build stopped: cannot make progress due to previous errors.
```

After:
```
════════════════════════════════════════════════════════════════
✗ BUILD FAILED - Error Summary
════════════════════════════════════════════════════════════════

🔥 Compilation Errors Found:
────────────────────────────────────────────────────────────────
error: /Applications/Xcode16.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: for: /Users/nelsonr/git/rv/_build_debug/RV_DEPS_OPENEXR/install/lib/libOpenEXRUtil-3_2_d.32.3.3.6.dylib (for architecture arm64) option "-add_rpath @loader_path/../lib" would duplicate path, file already has LC_RPATH for: @loader_path/../lib

────────────────────────────────────────────────────────────────

📝 Full build log: /Users/nelsonr/git/rv/_build_debug/build_errors.log
📝 Error summary: /Users/nelsonr/git/rv/_build_debug/error_summary.txt

💡 Tips:
  • Review the error summary above
  • Check full log: less /Users/nelsonr/git/rv/_build_debug/build_errors.log
  • Search for specific errors: grep -i 'your_error' /Users/nelsonr/git/rv/_build_debug/build_errors.log
════════════════════════════════════════════════════════════════
```