### PR TITLE
Fix building on CY2025 on MacOS

### DIFF
--- a/cmake/dependencies/openexr.cmake
+++ b/cmake/dependencies/openexr.cmake
@@ -163,6 +163,10 @@ ENDIF()
 # OpenEXR tools are not needed.
 LIST(APPEND _configure_options "-DOPENEXR_BUILD_TOOLS=OFF")
 
+# Disable OpenEXR's automatic rpath setup to avoid conflicts with RV's rpath management
+# OpenEXR 3.3+ automatically adds @loader_path/../lib which conflicts with our install scripts
+LIST(APPEND _configure_options "-DCMAKE_INSTALL_RPATH=")
+
 EXTERNALPROJECT_ADD(
   ${_target}
   URL "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v${_version}.zip"

--- a/cmake/dependencies/png.cmake
+++ b/cmake/dependencies/png.cmake
@@ -39,6 +39,9 @@ LIST(APPEND _configure_options "-DPNG_EXECUTABLES=OFF")
 LIST(APPEND _configure_options "-DPNG_TESTS=OFF")
 LIST(APPEND _configure_options "-DPNG_FRAMEWORK=OFF")
 
+# Disable PNG's automatic rpath setup to avoid conflicts with RV's rpath management
+LIST(APPEND _configure_options "-DCMAKE_INSTALL_RPATH=")
+
 EXTERNALPROJECT_ADD(
   ${_target}
   URL ${_download_url}


### PR DESCRIPTION
### Fix building with MacOS on CY2025

### Summarize your change.

The versions of openexr and png included with CY2025 introduce rpath setups, which ends up conflicting with RV's own rpath management on macos.  And resulting in build errors like the following when RV tries to overwrite them.
```
/Users/nelsonr/git/rv/_build_debug/RV_DEPS_OPENEXR/install/lib/libOpenEXRUtil-3_2_d.32.3.3.6.dylib (for architecture arm64) option "-add_rpath @loader_path/../lib" would duplicate path, file already has LC_RPATH for: @loader_path/../lib
```

The simplest olution is just to disable the rpath generation in those libraries, and let RV handle it as its currently doing for earlier versions.  An corollary fix was required in the RV rpath script that removes rpaths to not to fail if there is no rpath (since we now effectively remove it at the build stage). Another script later in the build process will add the correct rpath back in.

### Describe the reason for the change.

Fix building on MacOS with CY2025

### Describe what you have tested and on which operating system.

MacOS 26.1

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.