### PR TITLE
feat: PROOF OF CONCEPT: Fixing 10bit rendering support

### DIFF
--- a/src/bin/nsapps/RV/main.cpp
+++ b/src/bin/nsapps/RV/main.cpp
@@ -558,6 +558,12 @@ int main(int argc, char* argv[])
     // fmt.setProfile(QSurfaceFormat::CoreProfile);
     // fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
 
+    // Set 10-10-10-2 RGBA mode
+    fmt.setRedBufferSize(10);
+    fmt.setGreenBufferSize(10);
+    fmt.setBlueBufferSize(10);
+    fmt.setAlphaBufferSize(2);
+
     QSurfaceFormat::setDefaultFormat(fmt);
 
     // Install/remove temporary handler to silence opengl message when

--- a/src/lib/app/RvApp/Options.cpp
+++ b/src/lib/app/RvApp/Options.cpp
@@ -299,10 +299,10 @@ namespace Rv
         sync = 0;
         lqt_decoder = 0;
         exrcpus = 0;
-        dispRedBits = 8;
-        dispGreenBits = 8;
-        dispBlueBits = 8;
-        dispAlphaBits = 8;
+        dispRedBits = 10;
+        dispGreenBits = 10;
+        dispBlueBits = 10;
+        dispAlphaBits = 2;
         networkPort = 0;
         networkHost = NULL;
         networkTag = NULL;

--- a/src/lib/app/RvCommon/DesktopVideoDevice.cpp
+++ b/src/lib/app/RvCommon/DesktopVideoDevice.cpp
@@ -157,12 +157,23 @@ namespace Rv
     {
         TWK_GLDEBUG;
 
-        QSurfaceFormat fmt = shareDevice()->widget()->format();
+        QSurfaceFormat fmt;
+        if (shareDevice()->window())
+        {
+            fmt = shareDevice()->window()->format();
+        }
+        else if (shareDevice()->widget())
+        {
+            fmt = shareDevice()->widget()->format();
+        }
         fmt.setSwapInterval(m_vsync ? 1 : 0);
 
-        ScreenView* vw = new ScreenView(fmt, 0, shareDevice()->widget(), Qt::Window);
+        // Note: Cannot share context between QOpenGLWindow and QOpenGLWidget
+        // ScreenView will have its own context - data will be transferred via FBO copy
+        ScreenView* vw = new ScreenView(fmt, 0, nullptr, Qt::Window);
         setViewWidget(vw);
 
+        // Create QTGLVideoDevice with QOpenGLWidget overload
         QTGLVideoDevice* vd = new QTGLVideoDevice(0, "local view", vw);
         setViewDevice(vd);
 

--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -140,6 +140,13 @@ namespace Rv
         , m_syncThreadData(0)
     {
         setFormat(rvGLFormat(stereo, vsync, doubleBuffer, red, green, blue, alpha));
+        
+        // Set FBO internal texture format to GL_RGB10_A2 for 10-10-10-2 mode
+        if (red == 10 && green == 10 && blue == 10 && alpha == 2)
+        {
+            setTextureFormat(GL_RGB10_A2);
+            cout << "INFO: Setting QOpenGLWidget FBO texture format to GL_RGB10_A2" << endl;
+        }
 
         ostringstream str;
         str << UI_APPLICATION_NAME " Main Window" << "/" << m_doc;
@@ -263,6 +270,25 @@ namespace Rv
 
             // NOTE_QT6: QGLFormat is deprecated. Using QSurfaceFormat now.
             QSurfaceFormat f = context()->format();
+
+            // Print actual RGBA color depths
+            cout << "INFO: OpenGL context RGBA color depths: "
+                 << f.redBufferSize() << "-" << f.greenBufferSize() << "-" 
+                 << f.blueBufferSize() << "-" << f.alphaBufferSize() << endl;
+
+            // Validate FBO creation for 10-10-10-2 mode
+            if (m_red == 10 && m_green == 10 && m_blue == 10 && m_alpha == 2)
+            {
+                if (!isValid())
+                {
+                    cout << "ERROR: QOpenGLWidget initialization failed!" << endl;
+                    cout << "       10-10-10-2 surface format or GL_RGB10_A2 FBO may not be supported." << endl;
+                }
+                else
+                {
+                    cout << "INFO: Successfully initialized with 10-10-10-2 surface and GL_RGB10_A2 FBO!" << endl;
+                }
+            }
 
 #ifndef PLATFORM_DARWIN
             //

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -383,9 +383,8 @@ namespace Rv
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
-        QWidget* w = doc->view();
-
-        GLView* glview = dynamic_cast<GLView*>(w);
+        GLView* glview = doc->view();
+        QWidget* w = doc->viewContainer();
 
         Mu::Vector4f v;
         v[0] = 0;
@@ -653,7 +652,7 @@ namespace Rv
 
         rvDoc->setDocumentDisabled(false, true);
         bool result = dialog.exec();
-        rvDoc->view()->setFocus(Qt::OtherFocusReason);
+        rvDoc->viewContainer()->setFocus(Qt::OtherFocusReason);
         rvDoc->setDocumentDisabled(false, false);
 
         if (result)
@@ -776,7 +775,7 @@ namespace Rv
 
         rvDoc->setDocumentDisabled(false, true);
         bool result = dialog.exec();
-        rvDoc->view()->setFocus(Qt::OtherFocusReason);
+        rvDoc->viewContainer()->setFocus(Qt::OtherFocusReason);
         rvDoc->setDocumentDisabled(false, false);
 
         if (result)
@@ -885,7 +884,7 @@ namespace Rv
         {
             rvDoc->setDocumentDisabled(false, true);
             bool result = dialog.exec();
-            rvDoc->view()->setFocus(Qt::OtherFocusReason);
+            rvDoc->viewContainer()->setFocus(Qt::OtherFocusReason);
             rvDoc->setDocumentDisabled(false, false);
 
             if (result)
@@ -1016,7 +1015,7 @@ namespace Rv
         else if (box.clickedButton() == q3 && b3)
             result = 2;
 
-        doc->view()->setFocus(Qt::OtherFocusReason);
+        doc->viewContainer()->setFocus(Qt::OtherFocusReason);
         NODE_RETURN(result);
     }
 
@@ -1721,7 +1720,7 @@ namespace Rv
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
-        QWidget* w = doc->view();
+        QWidget* w = doc->viewContainer();
 
         const QWidgetType* type = c->findSymbolOfTypeByQualifiedName<QWidgetType>(c->internName("qt.QWidget"), false);
 

--- a/src/lib/app/RvCommon/RvCommon/GLView.h
+++ b/src/lib/app/RvCommon/RvCommon/GLView.h
@@ -8,7 +8,7 @@
 #ifndef __rv_qt__GLView__h__
 #define __rv_qt__GLView__h__
 #include <TwkGLF/GL.h>
-#include <QOpenGLWidget>
+#include <QOpenGLWindow>
 #include <QOpenGLFunctions>
 #include <QSurfaceFormat>
 #include <QOffscreenSurface>
@@ -23,7 +23,7 @@ namespace Rv
     class QTGLVideoDevice;
 
     class GLView
-        : public QOpenGLWidget
+        : public QOpenGLWindow
         , protected QOpenGLFunctions
     {
         Q_OBJECT
@@ -31,7 +31,7 @@ namespace Rv
     public:
         typedef TwkUtil::Timer Timer;
 
-        GLView(QWidget* parent, QOpenGLContext* sharedContext, RvDocument* doc, bool stereo = false, bool vsync = true,
+        GLView(QOpenGLContext* sharedContext, RvDocument* doc, bool stereo = false, bool vsync = true,
                bool doubleBuffer = true, int red = 0, int green = 0, int blue = 0, int alpha = 0, bool noResize = true);
         ~GLView();
 
@@ -41,6 +41,8 @@ namespace Rv
         void absolutePosition(int& x, int& y) const;
 
         QTGLVideoDevice* videoDevice() const { return m_videoDevice; }
+
+        void setEventWidget(QWidget* widget);
 
         void stopProcessingEvents();
 
@@ -97,6 +99,7 @@ namespace Rv
         bool m_stopProcessingEvents;
         void* m_syncThreadData;
         QOpenGLContext* m_sharedContext;
+        QWidget* m_eventWidget;
     };
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
@@ -9,6 +9,7 @@
 #define __RvCommon__QTGLVideoDevice__h__
 #include <iostream>
 #include <TwkGLF/GLVideoDevice.h>
+#include <QOpenGLWindow>
 #include <QOpenGLWidget>
 #include <QWindow>
 #include <QtWidgets/QWidget>
@@ -20,7 +21,7 @@ namespace Rv
     //
     //  QTGLVideoDevice
     //
-    //  Wraps a QGLWidget as a TwkGLF::GLVideoDevice. This gives a handle
+    //  Wraps a QOpenGLWindow as a TwkGLF::GLVideoDevice. This gives a handle
     //  on a concrete window system device. QTGLVideoDevice can generate
     //  events from the window system
     //
@@ -28,13 +29,22 @@ namespace Rv
     class QTGLVideoDevice : public TwkGLF::GLVideoDevice
     {
     public:
+        // QOpenGLWindow constructors (for main GLView)
+        QTGLVideoDevice(TwkApp::VideoModule*, const std::string& name, QOpenGLWindow* view, QWidget* eventWidget = nullptr);
+        
+        // QOpenGLWidget constructors (for ScreenView and legacy code)
         QTGLVideoDevice(TwkApp::VideoModule*, const std::string& name, QOpenGLWidget* view);
+        
         QTGLVideoDevice(TwkApp::VideoModule*, const std::string& name);
         virtual ~QTGLVideoDevice();
 
+        void setWindow(QOpenGLWindow*);
         void setWidget(QOpenGLWidget*);
+        void setEventWidget(QWidget* widget);
 
-        QOpenGLWidget* widget() const { return m_view; }
+        QOpenGLWindow* window() const { return m_window; }
+        QOpenGLWidget* widget() const { return m_widget; }
+        QWidget* eventWidget() const { return m_eventWidget; }
 
         virtual void makeCurrent() const;
 
@@ -77,6 +87,7 @@ namespace Rv
         float devicePixelRatio() const override { return m_devicePixelRatio; }
 
     protected:
+        QTGLVideoDevice(const std::string& name, QOpenGLWindow* view, QWidget* eventWidget = nullptr);
         QTGLVideoDevice(const std::string& name, QOpenGLWidget* view);
 
     protected:
@@ -84,7 +95,9 @@ namespace Rv
         int m_y;
         float m_refresh;
         float m_devicePixelRatio{1.0f};
-        QOpenGLWidget* m_view;
+        QOpenGLWindow* m_window;
+        QOpenGLWidget* m_widget;
+        QWidget* m_eventWidget;
         QTTranslator* m_translator;
     };
 

--- a/src/lib/app/RvCommon/RvCommon/RvDocument.h
+++ b/src/lib/app/RvCommon/RvCommon/RvDocument.h
@@ -72,6 +72,7 @@ namespace Rv
         QMenu* mainPopup() const { return m_mainPopup; }
 
         GLView* view() const;
+        QWidget* viewContainer() const;
 
         const QAction* lastPopupAction() const { return m_lastPopupAction; }
 
@@ -167,6 +168,7 @@ namespace Rv
         DiagnosticsView* m_diagnosticsView;
         QDockWidget* m_diagnosticsDock;
         GLView* m_glView;
+        QWidget* m_glViewContainer;
         GLView* m_oldGLView;
         QWidget* m_viewContainerWidget;
         RvTopViewToolBar* m_topViewToolBar;


### PR DESCRIPTION
### Linked issues

SG-XXXXX

### Summarize your change and reason for the change

**NOTE: THIS CANNOT MAKE RV 2025.1 RELEASE**

**NOTE: THIS "FIX" IS A PROOF OF CONCEPT TO SHOW A BASELINE SOLUTION TO MAKE 10-BIT RENDERING WORK AGAIN. IT IS NOT PRODUCTION READY, ITS NOT PERFECT, ITS INCOMPLETE, AND IMPLEMENTS A REFACTOR/WORKAROUND THAT I DO NOT LIKE.**

RV displayed visible banding artifacts when rendering 10-bit and 12-bit content, appearing quantized to 8-bit despite proper file loading, and despite enabling 10-bit support when loading DPX files. This is a regression when compared to RV 2024.1, where things worked ok. 

The main difference, and the root cause, is that RV 2024.1 uses QGLWidget (which renders directly to the screen's pixels) and the Qt6 branch which uses QOpenGLWidget (which renders to an offscreen FBO which is then transferred to the Qt application compositor). The Qt6 approach is generally better code and allows better integration of heterogenous widgets regardless of their rendering method).

Indeed, the root cause appears to be the Qt6 compositor using the FBO content rendered into QOpenGLWidgets, which, even though might have a 10-10-10-2 OpenGL context and 10-10-10-2 backend FBO, appears to quantize everything back to 8-8-8-8 when transferring the 10-bit FBO to the compositor, which makes the entire use of using a 10-bit context, and 10-bit FBO, completely pointless and that's why we see 8-bit banding of 10-bit content.

After countless ways of trying to make this work with the compositor, the only way I've found to fix this (and this is as per Qt support's suggestion as well) is to actually to bypass the compositor entirely and make GLView a QOpenGL**Window** instead of a QOpenGL**Widget**.  Indeed, a QOpenGL**Window** does not have a FBO backing surface at all, and renders to the screen surface directly; so if we've enabled a 10-10-10-2 context, and we use GL_RGB10_A2 textures and DPX content, then things actually draw with high precision depth color on the screen.

**CHANGES**

1) Change GLView to inherit from QOpenGLWindow vs QOpenGLWidget.

2) Use a special QWindowContainer to "host" a QOpenGLWindow in the RV document layout. The QWindowContainer is a special widgets that moves, resizes and constrains the dimensions of a "floating" window so that it always "appears" to be a child of the layout. But I dont think it's actually a child, It just "appears" this way.

3) Because the API of a QWidget is different than QWindow, we must redirect some calls to the WindowContainer, and some redirect to the view. 

4) This introduces changes to things like QTTranslator, QTVideoDevice, and other things that we'd rather not touch. We have to do some more manipulations to handle window focus, keyboard focus, etc. 

5) This introduces some changes to Mu code that assumes the Mu function "mainViewWidget()" is actually the GLView. That is no longer the case. The mainViewWidget is in fact the QWindowContainer. So we cannot call exposed functions in it. Instead we must redirect some calls to the window when we used to do it from the widget.  We must also adjust other Mu functions that call into the GLView directly.  Mu Code can still call normal functions like getting dimensions of the window container

**CAVEATS**

6) The changes proposed in this PR may not all be required / necessary. For example in this PR we have (maybe unnecessary) code that sets the default preferences values to 10-10-10-2 instead of 8-8-8-8, and PLANAR_RGB8 to PLANAR_RGB16. These may not be required. We may be able to leaver them to what they were previously.

7) On macOS, this requires a patched/recompiled libqcocoa.dylib to be placed in the Qt6 and RV folder, because it's not possible to create a 10-10-10-2 OpenGL context.  Copy the file like this: 

* Patched file:  /Volumes/Qt6_5_3/qt-build/qtbase/plugins/platforms/libqcocoa.dylib 
* Copied to: /Users/{username}/Qt6_5_3/6.5.3/macos/plugins/platforms
* Copied to: /Users/{username}/RV/_build/stage/app/RV.app/Contents/PlugIns/Qt/platforms
* Copied to: /Users/{username}/RV/_build_debug/stage/app/RV.app/Contents/PlugIns/Qt/platforms

Note: "/Volumes/Qt_6_5_3" is a mounted shared folder on the Qt 6.5.3 installation folder on the Qt build machine

8) Some files may be dirty and not optimal solution. For example, "QTGLVideoDevice.cpp" tries to be compatible with being attached to either a QWidget or QWindow. I'm not sure this is necessary or desirable. I


### Describe what you have tested and on which operating system.

macOS. 

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.