### PR TITLE
Fix Qt version selection in rvcmds.sh

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -81,58 +81,53 @@ if [ -z "$QT_HOME" ]; then
   echo "Searching for Qt installation..."
 
   if [[ "$OSTYPE" == "linux"* ]]; then
-    QT_HOME_6_8=$(find ~/Qt*/6.8.* -maxdepth 4 -type d -path '*/gcc_64' | sort -V | tail -n 1)
-    QT_HOME_6_5=$(find ~/Qt*/6.5* -maxdepth 4 -type d -path '*/gcc_64' | sort -V | tail -n 1)
-    QT_HOME_5=$(find ~/Qt*/5.15* -maxdepth 4 -type d -path '*/gcc_64' | sort -V | tail -n 1)
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-    QT_HOME_6_8=$(find ~/Qt*/6.8.* -maxdepth 4 -type d -path '*/macos' | sort -V | tail -n 1)
-    QT_HOME_6_5=$(find ~/Qt*/6.5* -maxdepth 4 -type d -path '*/macos' | sort -V | tail -n 1)
-    QT_HOME_5=$(find ~/Qt*/5.15* -maxdepth 4 -type d -path '*/macos' | sort -V | tail -n 1)
-
-    # If no macos installation found, try clang_64
-    if [ -z "$QT_HOME_6_8" ]; then
-      QT_HOME_6_8=$(find ~/Qt*/6.8.* -maxdepth 4 -type d -path '*/clang_64' | sort -V | tail -n 1)
-    fi
-    if [ -z "$QT_HOME_6_5" ]; then
-      QT_HOME_6_5=$(find ~/Qt*/6.5* -maxdepth 4 -type d -path '*/clang_64' | sort -V | tail -n 1)
-    fi
-    if [ -z "$QT_HOME_5" ]; then
-      QT_HOME_5=$(find ~/Qt*/5.15* -maxdepth 4 -type d -path '*/clang_64' | sort -V | tail -n 1)
-    fi
-
-  elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then
-    QT_HOME_6_8=$(find c:/Qt*/6.8* -maxdepth 4 -type d -path '*/msvc2019_64' | sort -V | tail -n 1)
-    QT_HOME_6_5=$(find c:/Qt*/6.5* -maxdepth 4 -type d -path '*/msvc2019_64' | sort -V | tail -n 1)
-    QT_HOME_5=$(find c:/Qt*/5.15* -maxdepth 4 -type d -path '*/msvc2019_64' | sort -V | tail -n 1)
-  fi
-
-  # Set Qt based on RV_VFX_PLATFORM
-  if [[ "$RV_VFX_PLATFORM" == "CY2023" ]]; then
-    if [ -n "$QT_HOME_5" ]; then
-      QT_HOME="$QT_HOME_5"
-      QT_VERSION="5.15"
-    else
-      echo "Error: CY2023 requires a Qt 5.15 installation, but none was found."
-    fi
-  elif [[ "$RV_VFX_PLATFORM" == "CY2024" || "$RV_VFX_PLATFORM" == "CY2025" ]]; then
-    if [ -n "$QT_HOME_6_5" ]; then
-      QT_HOME="$QT_HOME_6_5"
-      QT_VERSION="6.5"
-    else
-      echo "Error: $RV_VFX_PLATFORM requires a Qt 6.5 installation, but none was found."
-    fi
-  elif [[ "$RV_VFX_PLATFORM" == "CY2026" ]]; then
-    if [ -n "$QT_HOME_6_8" ]; then
-      QT_HOME="$QT_HOME_6_8"
+    if [[ "$RV_VFX_PLATFORM" == "CY2026" ]]; then
+      QT_HOME=$(find ~/Qt*/6.8.* -maxdepth 4 -type d -path '*/gcc_64' | sort -V | tail -n 1)
       QT_VERSION="6.8"
-    else
-      echo "Error: $RV_VFX_PLATFORM requires a Qt 6.8.3 installation, but none was found."
+    elif [[ "$RV_VFX_PLATFORM" == "CY2025" || "$RV_VFX_PLATFORM" == "CY2024" ]]; then
+      QT_HOME=$(find ~/Qt*/6.5* -maxdepth 4 -type d -path '*/gcc_64' | sort -V | tail -n 1)
+      QT_VERSION="6.5"
+    elif [[ "$RV_VFX_PLATFORM" == "CY2023" ]]; then
+      QT_HOME=$(find ~/Qt*/5.15* -maxdepth 4 -type d -path '*/gcc_64' | sort -V | tail -n 1)
+      QT_VERSION="5.15"
+    fi
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ "$RV_VFX_PLATFORM" == "CY2026" ]]; then
+      QT_HOME=$(find ~/Qt*/6.8.* -maxdepth 4 -type d -path '*/macos' | sort -V | tail -n 1)
+      if [ -z "$QT_HOME" ]; then
+        QT_HOME=$(find ~/Qt*/6.8.* -maxdepth 4 -type d -path '*/clang_64' | sort -V | tail -n 1)
+      fi
+      QT_VERSION="6.8"
+    elif [[ "$RV_VFX_PLATFORM" == "CY2025" || "$RV_VFX_PLATFORM" == "CY2024" ]]; then
+      QT_HOME=$(find ~/Qt*/6.5* -maxdepth 4 -type d -path '*/macos' | sort -V | tail -n 1)
+      if [ -z "$QT_HOME" ]; then
+        QT_HOME=$(find ~/Qt*/6.5* -maxdepth 4 -type d -path '*/clang_64' | sort -V | tail -n 1)
+      fi
+      QT_VERSION="6.5"
+    elif [[ "$RV_VFX_PLATFORM" == "CY2023" ]]; then
+      QT_HOME=$(find ~/Qt*/5.15* -maxdepth 4 -type d -path '*/macos' | sort -V | tail -n 1)
+      if [ -z "$QT_HOME" ]; then
+        QT_HOME=$(find ~/Qt*/5.15* -maxdepth 4 -type d -path '*/clang_64' | sort -V | tail -n 1)
+      fi
+      QT_VERSION="5.15"
+    fi
+  elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then
+    if [[ "$RV_VFX_PLATFORM" == "CY2026" ]]; then
+      QT_HOME=$(find c:/Qt*/6.8* -maxdepth 4 -type d -path '*/msvc2019_64' | sort -V | tail -n 1)
+      QT_VERSION="6.8"
+    elif [[ "$RV_VFX_PLATFORM" == "CY2025" || "$RV_VFX_PLATFORM" == "CY2024" ]]; then
+      QT_HOME=$(find c:/Qt*/6.5* -maxdepth 4 -type d -path '*/msvc2019_64' | sort -V | tail -n 1)
+      QT_VERSION="6.5"
+    elif [[ "$RV_VFX_PLATFORM" == "CY2023" ]]; then
+      QT_HOME=$(find c:/Qt*/5.15* -maxdepth 4 -type d -path '*/msvc2019_64' | sort -V | tail -n 1)
+      QT_VERSION="5.15"
     fi
   fi
 
   if [ -n "$QT_HOME" ]; then
     echo "Found Qt $QT_VERSION installation at $QT_HOME"
   else
+    echo "Error: $RV_VFX_PLATFORM requires a Qt $QT_VERSION installation, but none was found."
     echo "Could not find required Qt installation. Please set QT_HOME to the correct path in your environment variables."
   fi
  


### PR DESCRIPTION
### Fix rvcmds.sh Qt version selection

### Summarize your change.

The Qt version selection section of `rvcmds.sh` was refactored to only search for the version that matches the VFX Reference Platform that was chosen.

### Describe the reason for the change.

`rvcmds.sh` was simply looking first for Qt 6.8, then Qt 6.5, then Qt 5.15, which means unnecessary errors were being outputted to the console like so:
```
Please select the VFX Platform year to build for:
1) CY2023  2) CY2024  3) CY2025  4) CY2026  
Enter a number: 2
Using VFX Platform: CY2024
Searching for Qt installation...
OpenRV/rvcmds.sh:88: no matches found: /Users/brossee1/Qt*/6.8.*
OpenRV/rvcmds.sh:94: no matches found: /Users/brossee1/Qt*/6.8.*
Found Qt 6.5 installation at /Users/brossee1/Qt/6.5.3/macos
Please ensure you have installed any required dependencies from doc/build_system/config_[os]
```

With this change, we instead get this:
```
Please select the VFX Platform year to build for:
1) CY2023  2) CY2024  3) CY2025  4) CY2026  
Enter a number: 2
Using VFX Platform: CY2024
Searching for Qt installation...
Found Qt 6.5 installation at /Users/brossee1/Qt/6.5.3/macos
Please ensure you have installed any required dependencies from doc/build_system/config_[os]
```

### Describe what you have tested and on which operating system.
Running `source rvcmds.sh` for each VFX Reference Platform was tested on macOS.