### PR TITLE
SG-41606: Create new softDeleted property if it doesn't exist yet

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -1621,10 +1621,11 @@ class: AnnotateMinorMode : MinorMode
                         let frame = int(parts[2]);
 
                         let softDeleted = "%s.%s.softDeleted" % (node, stroke);
-                        if (propertyExists(softDeleted))
+                        if (!propertyExists(softDeleted))
                         {
-                            setIntProperty(softDeleted, int[] {0}, true);
+                            newProperty(softDeleted, IntType, 1);
                         }
+                        setIntProperty(softDeleted, int[] {0}, true);
 
                         let orderName = frameOrderName(node, frame);
 
@@ -1694,10 +1695,11 @@ class: AnnotateMinorMode : MinorMode
                 if (stroke != "")
                 {
                     let softDeleted = "%s.%s.softDeleted" % (_currentNode, stroke);
-                    if (propertyExists(softDeleted))
+                    if (!propertyExists(softDeleted))
                     {
-                        setIntProperty(softDeleted, int[] {1}, true);
+                        newProperty(softDeleted, IntType, 1);
                     }
+                    setIntProperty(softDeleted, int[] {1}, true);
                     
                     for_index(i; order)
                     {
@@ -1737,10 +1739,11 @@ class: AnnotateMinorMode : MinorMode
                     let stroke = findStrokeByUuid(_currentNode, frame, uuid);
                     
                     let softDeleted = "%s.%s.softDeleted" % (_currentNode, stroke);
-                    if (propertyExists(softDeleted))
+                    if (!propertyExists(softDeleted))
                     {
-                        setIntProperty(softDeleted, int[] {0}, true);
+                        newProperty(softDeleted, IntType, 1);
                     }
+                    setIntProperty(softDeleted, int[] {0}, true);
                     
                     order.push_back(stroke);
                 }
@@ -1797,10 +1800,11 @@ class: AnnotateMinorMode : MinorMode
                         let frame = int(parts[2]);
 
                         let softDeleted = "%s.%s.softDeleted" % (node, stroke);
-                        if (propertyExists(softDeleted))
+                        if (!propertyExists(softDeleted))
                         {
-                            setIntProperty(softDeleted, int[] {1}, true);
+                            newProperty(softDeleted, IntType, 1);
                         }
+                        setIntProperty(softDeleted, int[] {1}, true);
 
                         let orderName = frameOrderName(node, frame);
                         if (propertyExists(orderName))
@@ -1876,10 +1880,11 @@ class: AnnotateMinorMode : MinorMode
                 if (stroke != "")
                 {
                     let softDeleted = "%s.%s.softDeleted" % (_currentNode, stroke);
-                    if (propertyExists(softDeleted))
+                    if (!propertyExists(softDeleted))
                     {
-                        setIntProperty(softDeleted, int[] {0}, true);
+                        newProperty(softDeleted, IntType, 1);
                     }
+                    setIntProperty(softDeleted, int[] {0}, true);
                     
                     order.push_back(stroke);
                     
@@ -1912,10 +1917,11 @@ class: AnnotateMinorMode : MinorMode
                     let stroke = findStrokeByUuid(_currentNode, frame, uuid);
                     
                     let softDeleted = "%s.%s.softDeleted" % (_currentNode, stroke);
-                    if (propertyExists(softDeleted))
+                    if (!propertyExists(softDeleted))
                     {
-                        setIntProperty(softDeleted, int[] {1}, true);
+                        newProperty(softDeleted, IntType, 1);
                     }
+                    setIntProperty(softDeleted, int[] {1}, true);
                     
                     for_index(i; order)
                     {
@@ -1997,10 +2003,11 @@ class: AnnotateMinorMode : MinorMode
                         affectedStrokes.push_back(uuid);
                         
                         let softDeleted = "%s.%s.softDeleted" % (node, stroke);
-                        if (propertyExists(softDeleted))
+                        if (!propertyExists(softDeleted))
                         {
-                            setIntProperty(softDeleted, int[] {1}, true);
+                            newProperty(softDeleted, IntType, 1);
                         }
+                        setIntProperty(softDeleted, int[] {1}, true);
                     }
                 }
                 undo.push_back(string(order.size()));
@@ -2066,10 +2073,11 @@ class: AnnotateMinorMode : MinorMode
                             affectedStrokes.push_back(uuid);
                             
                             let softDeleted = "%s.%s.softDeleted" % (node, stroke);
-                            if (propertyExists(softDeleted))
+                            if (!propertyExists(softDeleted))
                             {
-                                setIntProperty(softDeleted, int[] {1}, true);
+                                newProperty(softDeleted, IntType, 1);
                             }
+                            setIntProperty(softDeleted, int[] {1}, true);
                         }
                     }
 
@@ -2095,10 +2103,11 @@ class: AnnotateMinorMode : MinorMode
                                 affectedStrokes.push_back(uuid);
                                 
                                 let softDeleted = "%s.%s.softDeleted" % (node, stroke);
-                                if (propertyExists(softDeleted))
+                                if (!propertyExists(softDeleted))
                                 {
-                                    setIntProperty(softDeleted, int[] {1}, true);
+                                    newProperty(softDeleted, IntType, 1);
                                 }
+                                setIntProperty(softDeleted, int[] {1}, true);
                             }
                         }
                         


### PR DESCRIPTION
### [SG-41606](https://jira.autodesk.com/browse/SG-41606): Create new softDeleted property if it doesn't exist yet

### Summarize your change.

Instead of only setting the value of the `softDeleted` property if it exist, we should always make sure the property exist and is updated by the different undo/redo/clear operations.

### Describe the reason for the change.

An issue was found in the Live Review plugin where clear actions would not clear the annotations for the other participants if the softDeleted property was not updated by the instance who made the action. The fix for this issue will be part of another PR in the Commercial RV repo, but it also make sense for the annotation tool to always make sure the `softDeleted` property has a value.