### PR TITLE
SG-40392: Fix Presentation mode's Pointer option issue on High-DPI monitors

### DIFF
--- a/src/lib/app/mu_rvui/extra_commands.mu
+++ b/src/lib/app/mu_rvui/extra_commands.mu
@@ -281,7 +281,8 @@ require system;
 
             if (sourceName != "")
             {
-                let normalizedIP = eventToImageSpace(sourceName, p, true);
+                let devicePixelRatio = devicePixelRatio(),
+                    normalizedIP = eventToImageSpace(sourceName, p*devicePixelRatio, true);
                 state.pointerPositionNormalized = normalizedIP;
             }
         }

--- a/src/lib/app/mu_rvui/presentation_mode.mu
+++ b/src/lib/app/mu_rvui/presentation_mode.mu
@@ -136,20 +136,21 @@ class: PresentationControlMinorMode : MinorMode
     method: move (void; Event event)
     {
         event.reject();
-	State state = data();
-	state.perPixelInfoValid = false;
+        State state = data();
+        state.perPixelInfoValid = false;
     }
 
     method: _drawCross (void; Point p, float t)
     {
-        let x0 = Vec2(2, 0),
-            x1 = Vec2(10, 0),
-            y0 = Vec2(0, 2),
-            y1 = Vec2(0, 10);
+        let devicePixelRatio = devicePixelRatio(),
+            x0 = Vec2(2*devicePixelRatio, 0),
+            x1 = Vec2(10*devicePixelRatio, 0),
+            y0 = Vec2(0, 2*devicePixelRatio),
+            y1 = Vec2(0, 10*devicePixelRatio);
 
        float f = t/2.0;
 
-        glLineWidth(3.0);
+        glLineWidth(3.0*devicePixelRatio);
 
         glColor(0.5-t,0.5-t,0.5-t,1);
 
@@ -160,7 +161,7 @@ class: PresentationControlMinorMode : MinorMode
         glVertex(p - y0); glVertex(p - y1);
         glEnd();
 
-        glLineWidth(1.0);
+        glLineWidth(1.0*devicePixelRatio);
         glColor(0.5+t,0.5+t,0.5+t,1);
 
         glBegin(GL_LINES);


### PR DESCRIPTION
### SG-40392: Fix Presentation mode's Pointer option issue on High-DPI monitors

### Linked issues
NA

### Describe the reason for the change.

The presentation mode's Pointer option (disabled by default) did not support high-DPI displays

### Summarize your change.

Added support for high-DPI displays when drawing the presentation mode's pointers,

### Describe what you have tested and on which operating system.
Successfully tested on macOS + NDI

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.