### PR TITLE
SG-41502 - Do not send category-event-blocked on mode state check, only when action is triggered

### DIFF
--- a/src/lib/app/mu_rvui/mode_manager.mu
+++ b/src/lib/app/mu_rvui/mode_manager.mu
@@ -214,15 +214,16 @@ class: ModeManagerMode : MinorMode
         \: (int; )
         {
             // Special handling of mode toggling if certain categories of actions are disabled.
+            // Note: We only return the disabled state here. The "category-event-blocked" event
+            // is sent by toggleModeEntry() when the user actually tries to invoke the action,
+            // not when just checking if the menu item should be disabled.
             if (!commands.isEventCategoryEnabled("annotate_category") && entry.name == "annotate_mode")
             {
-                sendInternalEvent("category-event-blocked", "annotate_category");
                 return DisabledMenuState;
             }
     
             if (!commands.isEventCategoryEnabled("sessionmanager_category") && entry.name == "session_manager")
             {
-                sendInternalEvent("category-event-blocked", "sessionmanager_category");
                 return DisabledMenuState;
             }
     


### PR DESCRIPTION
### SG-41502 - Do not send category-event-blocked on mode state check, only when action is triggered

### Linked issues
none

### Summarize your change.
I removed the call to `sendInternalEvent("category-event-blocked", ...)` when we are checking the mode state. The event will only be sent if the action is actually triggered (e.g. using keyboard shortcut).

### Describe the reason for the change.

In a live review session (in some scenarios), the Tools menu was showing a "You are not the Host" notification because OpenRV was sending a `category-event-blocked` event when checking the mode state in `modeEntryStateFunc`.


### Describe what you have tested and on which operating system.
MacOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.