### PR TITLE
Fix typo of original contributor's name

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,7 +40,7 @@ A special recognition to the Tweak Software original founders, and to all the de
 * Alan Trombla
 * Jon Morley
 * Arkell Rasiah
-* Danielle Ann
+* Danielle An
 * Louise Rasmussen
 * Chris Horvath
 * Seth Rosenthal


### PR DESCRIPTION
### Fix typo of original contributor's name

### Linked issues
NA

### Summarize your change.

Fix typo of original contributor's name

We had mispelled Danielle An's name 
The correct spelling is "Danielle An"

Sorry about that Danielle !

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.