### PR TITLE
Fix syntax error in rvtypes

### DIFF
--- a/src/lib/app/mu_rvui/rvtypes.mu
+++ b/src/lib/app/mu_rvui/rvtypes.mu
@@ -48,7 +48,7 @@ class: FeedbackMessage
 {
     string  text;
     float   duration;
-    Glyph   glyph;
+    Glyph   glyphFunc;
     float[] textSizes;
     
     method: FeedbackMessage (FeedbackMessage; 
@@ -59,10 +59,10 @@ class: FeedbackMessage
     {
         text = t;
         duration = d;
-        glyph = g;
+        glyphFunc = g;
         textSizes = sizes;
     }
-};
+}
 
 StringPair          := (string, string);
 MenuStateFunc       := (int;);

--- a/src/lib/app/mu_rvui/rvui.mu
+++ b/src/lib/app/mu_rvui/rvui.mu
@@ -4905,7 +4905,7 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
                 // Extract values from FeedbackMessage class
                 state.feedbackText = nextMessage.text;
                 state.feedback = nextMessage.duration;
-                state.feedbackGlyph = nextMessage.glyph;
+                state.feedbackGlyph = nextMessage.glyphFunc;
                 state.feedbackTextSizes = nextMessage.textSizes;
                 startTimer();
             }


### PR DESCRIPTION
### Fix rvtypes syntax error

### Summarize your change.

When using a tool that uses rvtypes, like rvio you can see a syntax error in the shell. For example:
```
./rvio -v -err-to-out /dev/null -o /tmp/t.mov -leader simpleslate test
```
An error like this appears in the output:
```
ERROR: while loading source module "/Users/nelsonr/git/rv/_build_debug/stage/app/RV.app/Contents/PlugIns/Mu/rvtypes.mu"
ERROR: syntax error
```

It turns out the cause of this the variable named glyph.  There is also a module named glyph which shadows the variable, and hence when the code references the variable it resolves to the module and generates a syntax error. 


### Describe the reason for the change.

In the context of rvio this never really caused a problem since the glyph variable is only used in the UI, but it's worth fixing anyway since it could cause potential problems in the UI and seeing that output in rvio makes users question whether it actually worked or not.

### Describe what you have tested and on which operating system.

Mac OS Tahoe 26.1

