### PR TITLE
SG-34355 - Fix wrong TIFF compression being displayed

### DIFF
--- a/src/lib/image/IOtiff/IOtiff.cpp
+++ b/src/lib/image/IOtiff/IOtiff.cpp
@@ -337,6 +337,8 @@ namespace TwkFB
             if (fip->field_tag != TIFFTAG_ICCPROFILE && // exclude tags we handle seperately
                 fip->field_tag != EXIFTAG_COLORSPACE &&
 
+                fip->field_tag != TIFFTAG_COMPRESSION && // prevent the overwriting of the compression type with numerical value
+
                 fip->field_tag != TIFFTAG_XRESOLUTION && fip->field_tag != TIFFTAG_YRESOLUTION && fip->field_tag != TIFFTAG_SOFTWARE
                 && fip->field_tag != EXIFTAG_PIXELXDIMENSION && fip->field_tag != EXIFTAG_PIXELYDIMENSION
                 && fip->field_tag != TIFFTAG_RESOLUTIONUNIT && fip->field_tag != TIFFTAG_PLANARCONFIG &&
@@ -1543,7 +1545,7 @@ namespace TwkFB
 
             char* software = NULL;
             bool isMaya = false;
-            unsigned int compression;
+            unsigned short compression;
 
             if (TIFFGetField(tif, TIFFTAG_COMPRESSION, &compression))
             {


### PR DESCRIPTION
### **[SG-34355](https://jira.autodesk.com/browse/SG-34355): RV is not returning proper compression information of TIFF files anymore**

### Summarize your change.

Made sure the compression variable is the same type as the one used to store the compression type (changed to unsigned short from unsigned int) so it is consistent with the function it is used with. Added TIFFTAG_COMPRESSION to the list of tags that we handle manually. 

### Describe the reason for the change.

Previously, the TIFFTAG_COMPRESSION was being overwritten every time we call readAllTags() causing the compression type to be a numerical value instead of the actual compression name.

### Describe what you have tested and on which operating system.

This fix was tested on macOS with Tiff sequences compressed using LZW and RLE.

### If possible, provide screenshots.

Under TIFF/Compression, the correct compression type is displayed instead of a number.

<img width="1024" height="663" alt="Screenshot 2026-01-09 at 12 02 45 PM" src="https://github.com/user-attachments/assets/44185c22-0e50-4c18-8bc0-d85df540a086" />
