### PR TITLE
SG-40506: Add space between option and arrow and make cmake detect changes

### DIFF
--- a/src/lib/app/RvCommon/rv_linux_dark.qss
+++ b/src/lib/app/RvCommon/rv_linux_dark.qss
@@ -170,7 +170,7 @@ QMenu::item {
     padding-top: 1px;
     padding-bottom: 1px;
     padding-left: 8px;
-    padding-right: 8px;
+    padding-right: 20px;  /* Create gap between arrow and text */
     margin: 2px;
     border-radius: 4px;
 }

--- a/src/lib/app/RvCommon/rv_linux_dark.qss.template
+++ b/src/lib/app/RvCommon/rv_linux_dark.qss.template
@@ -170,7 +170,7 @@ QMenu::item {
     padding-top: 1px;
     padding-bottom: 1px;
     padding-left: 8px;
-    padding-right: 8px;
+    padding-right: 20px;  /* Create gap between arrow and text */
     margin: 2px;
     border-radius: 4px;
 }

--- a/src/lib/app/RvCommon/rv_mac_dark.qss
+++ b/src/lib/app/RvCommon/rv_mac_dark.qss
@@ -160,7 +160,7 @@ QMenu::item {
     padding-top: 1px;
     padding-bottom: 1px;
     padding-left: 8px;
-    padding-right: 8px;
+    padding-right: 20px;  /* Create gap between arrow and text */
     margin: 2px;
     border-radius: 4px;
 }

--- a/src/lib/app/RvCommon/rv_mac_dark.qss.template
+++ b/src/lib/app/RvCommon/rv_mac_dark.qss.template
@@ -161,7 +161,7 @@ QMenu::item {
     padding-top: 1px;
     padding-bottom: 1px;
     padding-left: 8px;
-    padding-right: 8px;
+    padding-right: 20px;  /* Create gap between arrow and text */
     margin: 2px;
     border-radius: 4px;
 }


### PR DESCRIPTION
### **[SG-40506](https://jira.autodesk.com/browse/SG-40506): Flow Production Tracking' option collides with arrow indicator within File menu in timeline**

### Summarize your change.

Increased padding-right to the menu items such that the right arrow is no longer right next to the menu item text. Changed the cmake file to be able to detect changes to the qss files and update the binaries when change is made.

### Describe the reason for the change.

Previously, the right arrow would be extremely close to the menu item text that was the longest. This fix makes the menu look less cramped. As for the cmake file, we realized that when updating the .qss files, despite rebuilding RV, the changes would not get picked up. After changing the cmake file, when making changes in the .qss files, they get picked up correctly and the new build would properly show the changes.

### Describe what you have tested and on which operating system.

Tested the cmake file to see if it detects changes to .qss files and include them when rebuilding and tested the extra padding to see if the text is still cramped. Both were tested on macOS

### If possible, provide screenshots.

The right arrow is no longer right next to the longest menu item

<img width="2052" height="1328" alt="image" src="https://github.com/user-attachments/assets/4d20a4c3-6206-4c7e-b6bc-52e0209b72f6" />

