### PR TITLE
fix: SG-41698: Add Alt modifier check for mouse wheel events

### DIFF
--- a/src/lib/app/RvCommon/QTTranslator.cpp
+++ b/src/lib/app/RvCommon/QTTranslator.cpp
@@ -664,7 +664,7 @@ namespace Rv
         n += "wheel";
         // use pixelDelta() or angleDelta() instead of delta() (deprecated)
         // Alt key means horizontal scroll on Linux and Windows, whereas it is the Shift key on macOS
-        Qt::KeyboardModifier horizontalModifier = 
+        Qt::KeyboardModifier horizontalModifier =
 #ifdef PLATFORM_DARWIN
             Qt::ShiftModifier;
 #else


### PR DESCRIPTION
### Linked issues

### Summarize your change.

Added a check for Alt modifier to QTTranslator::sendMouseWheelEvent()

### Describe the reason for the change.

The Alt key combined with the mouse wheel triggers horizontal scrolling, and will be reported in angleDelta().x() instead of angleDelta().y().  I added a check for the Alt modifier for whether to use angleDelta().x() or angleDelta().y() as the delta for determining if the wheel is moving down or up.

### Describe what you have tested and on which operating system.

Successfully tested on Rocky Linux 9.5

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.