### PR TITLE
SG-41684 Fix media res not in UI when timeline imported via OTIO

### DIFF
--- a/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep_utils.py
+++ b/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep_utils.py
@@ -139,9 +139,14 @@ def get_common_source_media_infos(sources):
         for i in range(1, len(sources)):
             new_infos = get_source_media_info(sources[i])
             new_width = new_infos.get("width")
+            new_height = new_infos.get("height")
+
+            # Skip gaps
+            if new_width == 1 and new_height == 1:
+                continue
+
             if new_width != info_width:
                 info_width = ""
-            new_height = new_infos.get("height")
             if new_height != info_height:
                 info_height = ""
             new_extension = get_extension_from_info_file(new_infos.get("file"))


### PR DESCRIPTION
### SG-41684 Fix media res not in UI when timeline imported via OTIO

### Linked issues
NA

### Summarize your change.

The resolution for a media is displayed in the bottom toolbar only when all the media representations have the same resolution. The gaps (modelized with width=1 and height=1) included as part of the OTIO import were taken into account in this algorithm which was making this same resolution check fails and thus prevented the resolution from being displayed.

### Describe the reason for the change.

The media resolution was not shown in the bottom toolbar when the media had been imported via OTIO (Web-RV Live Review)

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

Before the fix:
<img width="1066" height="529" alt="bad_no_resolution_when_in_cr_to_rv_live_review" src="https://github.com/user-attachments/assets/2aeb37db-a73b-46ab-bbd4-e0194cd9d08f" />

After tghe fix:
<img width="869" height="447" alt="good_play_in_rv" src="https://github.com/user-attachments/assets/ad1d9b86-4ba9-483a-be75-b10617a79dcd" />

