### PR TITLE
Fix building with multiple XCodes installed

### DIFF
--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -311,10 +311,6 @@ IF(RV_TARGET_DARWIN
   SET(_sdkroot_env
       "SDKROOT=${CMAKE_OSX_SYSROOT}"
   )
-ELSE()
-  SET(_sdkroot_env
-      ""
-  )
 ENDIF()
 
 # Phase 1: Install build dependencies for phase 2. Note: RV_PYTHON_BUILD_DEPS is kept as a CMake list (semicolon-separated) so it expands to separate arguments.


### PR DESCRIPTION
### Build Fix Mac: Use SDK version matching XCode version

### Summarize your change.

When building the python packages on Mac, `pip` will use the latest SDK version available be default.  So if you compile RV with XCode 16 (as is required) and have a later SDK installed that will be used to build the python packages potentially making them incompatible with python.

To fix this, we'll pass the SDKROOT from the CMake environment to `pip` to ensure if uses the same one as OpenRV.

### Describe the reason for the change.

Fix building with multiple SDKs installed.

### Describe what you have tested and on which operating system.

Mac OS 26.1 with XCode 26 and 16 installed.