### PR TITLE
SG-41715: Send internal event on about to show menu

### DIFF
--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -1469,6 +1469,7 @@ namespace Rv
 
     void RvDocument::aboutToShowMenu()
     {
+        session()->userGenericEvent("about-to-show-menu", "");
         if (QMenu* menu = dynamic_cast<QMenu*>(sender()))
         {
             QList<QAction*> actions = menu->actions();


### PR DESCRIPTION
### [SG-41715](https://jira.autodesk.com/browse/SG-41715): Send internal event on about to show menu

### Summarize your change.

Send an internal event on about to show top menu bar. Note that this fix needs a second PR in the Live Review plugin to fix the issue.

### Describe the reason for the change.

A race condition is happening during Live Review sessions that is preventing the menu items to stay blocked while RV is handling graph changes while rebuilding the trop menu bar. To avoid making too much changes to the code at this moment, I proposed a quick fix where we simply make sure to inform the menu is about to be shown so that we can make sure to disable again the required categories.

### Describe what you have tested and on which operating system.
The repro steps in the ticket were successfully tested on macOS.