### PR TITLE
SG-41742: Fix Annotation hook

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -122,7 +122,7 @@ def hook_function(in_timeline: otio.schemadef.Annotation.Annotation, argument_ma
             pen_component,
             {
                 "color": list(map(float, layer.rgba)),
-                "brush": layer.brush,
+                "brush": [layer.brush],
                 "debug": 1,
                 "join": 3,
                 "cap": 1,
@@ -130,7 +130,8 @@ def hook_function(in_timeline: otio.schemadef.Annotation.Annotation, argument_ma
                 "mode": 0 if layer.type == "COLOR" else 1,
                 "startFrame": start_time,
                 "duration": duration,
-                "uuid": layer.id,
+                "softDeleted": layer.soft_deleted,
+                "uuid": [layer.id],
             },
         )
 


### PR DESCRIPTION
### [SG-41742](https://jira.autodesk.com/browse/SG-41742): Fix Annotation hook

### Summarize your change.

Set the uuid value as a list in the paint node property to avoid each char being added separately. Otherwise, it was stored as ["e", "5", "2", "7", ...] instead of ["e527a621-75b6-4ecf-8204-bef59fe4c6c5"]. Note that this issue made me realize the `brush` property was parsed the same way even if it wasn't causing any issues visually. The `softDeleted` property is not required to be stored here, but I added it anyway for consistency.

### Describe the reason for the change.

The wrong format of the uuid was preventing the PAINT_BATCH_UPDATE event in the Live Review plugin from being handled properly since it wasn't matching the one parsed by the Annotation hook when receiving the OTIO timeline when joining a session.

### Describe what you have tested and on which operating system.

Undoing and redoing in a session where annotations were already present was tested on macOS.