### PR TITLE
SG-41787: Add undo/redo/clear UI update event for Live Review

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -2318,6 +2318,7 @@ class: AnnotateMinorMode : MinorMode
     method: redoEvent (void; Event event) { redoSlot(true); }
     method: clearEvent (void; Event event) { clearSlot(true); }
     method: clearAllEvent (void; Event event) { clearAllSlot(true); }
+    method: undoRedoClearUpdateEvent (void; Event event) { undoRedoClearUpdate(); }
 
     method: keyUndoEvent (void; Event event)
     {
@@ -3206,6 +3207,7 @@ class: AnnotateMinorMode : MinorMode
               ("clear-annotations-current-frame", clearEvent, "Clear annotations on current frame"),
               ("clear-annotations-all-frames", clearAllEvent, "Clear annotations on all frames"),
               ("set-current-annotate-mode-node", setCurrentNodeEvent, "Set current paint node"),
+              ("undo-redo-clear-ui-update", undoRedoClearUpdateEvent, "Update the undo, redo and clear state"),
               // --------------------------------------------------------------
               // For NDC drawing support used in automated testing
               ("stylus-color-rgb", setColorRGB, "Select color RGB"),


### PR DESCRIPTION
### [SG-41787](https://jira.autodesk.com/browse/SG-41787): Add undo/redo/clear UI update event for Live Review

### Summarize your change.

Add an undo/redo/clear UI update event in Annotate mode.

### Describe the reason for the change.

In an OTIO-based Live Review session, the state of the buttons in the Annotate mode is not updated when receiving a clear or delete event from another participant. The per-user undo-redo stack is updated properly but not the UI, giving the impression that something could still be undone or redone when there is nothing.

### Describe what you have tested and on which operating system.

Making the host of the session clear or submit annotations made by RV was successfully tested on macOS using this fix and another one in the Commercial RV repo.