### PR TITLE
SG-41718 - Add a specific category for the view control in the top bar

### DIFF
--- a/src/lib/app/RvCommon/RvTopViewToolBar.cpp
+++ b/src/lib/app/RvCommon/RvTopViewToolBar.cpp
@@ -377,9 +377,9 @@ namespace Rv
         connect(m_dither10, SIGNAL(triggered()), this, SLOT(dither10()));
 
         // Map toolbar actions to their corresponding event categories
-        m_actionCategoryMappings = {{{m_viewBackAction, IPCore::EventCategories::viewmodeCategory, m_viewBackAction->toolTip()},
-                                     {m_viewForwardAction, IPCore::EventCategories::viewmodeCategory, m_viewForwardAction->toolTip()},
-                                     {m_viewMenuAction, IPCore::EventCategories::viewmodeCategory, m_viewMenuAction->toolTip()},
+        m_actionCategoryMappings = {{{m_viewBackAction, IPCore::EventCategories::viewNavigationCategory, m_viewBackAction->toolTip()},
+                                     {m_viewForwardAction, IPCore::EventCategories::viewNavigationCategory, m_viewForwardAction->toolTip()},
+                                     {m_viewMenuAction, IPCore::EventCategories::viewNavigationCategory, m_viewMenuAction->toolTip()},
                                      {m_fullScreenAction, IPCore::EventCategories::fullscreenModeCategory, m_fullScreenAction->toolTip()},
                                      {m_frameAction, IPCore::EventCategories::viewmodeCategory, m_frameAction->toolTip()},
                                      {m_bgMenuAction, IPCore::EventCategories::backgroundStyleCategory, m_bgMenuAction->toolTip()},

--- a/src/lib/ip/IPCore/IPCore/Session.h
+++ b/src/lib/ip/IPCore/IPCore/Session.h
@@ -74,6 +74,7 @@ namespace IPCore
         inline constexpr std::string_view screeningroomCategory = "screeningroom_category";
         inline constexpr std::string_view unclassifiedCategory = "unclassified_category";
         inline constexpr std::string_view viewmodeCategory = "viewmode_category";
+        inline constexpr std::string_view viewNavigationCategory = "view_navigation_category";
         inline constexpr std::string_view fullscreenModeCategory = "fullscreenMode_category";
         inline constexpr std::string_view backgroundStyleCategory = "backgroundStyle_category";
         inline constexpr std::string_view wipesCategory = "wipes_category";
@@ -84,7 +85,7 @@ namespace IPCore
             // Explicitly specify template parameters for MSVC compatibility.
             // CTAD (Class Template Argument Deduction) works on GCC/Clang but
             // fails on Windows MSVC, so we specify the number of categories explicitly.
-            return std::array<std::string_view, 34>{annotateCategory,
+            return std::array<std::string_view, 35>{annotateCategory,
                                                     annotateAirbrushCategory,
                                                     annotateBurnCategory,
                                                     annotateCloneCategory,
@@ -104,6 +105,7 @@ namespace IPCore
                                                     infoCategory,
                                                     markCategory,
                                                     mediaCategory,
+                                                    panzoomCategory,
                                                     playcontrolCategory,
                                                     playControlClickCategory,
                                                     playmodeLoopCategory,
@@ -116,8 +118,8 @@ namespace IPCore
                                                     screeningroomCategory,
                                                     unclassifiedCategory,
                                                     viewmodeCategory,
-                                                    wipesCategory,
-                                                    panzoomCategory};
+                                                    viewNavigationCategory,
+                                                    wipesCategory};
         }
     } // namespace EventCategories
 


### PR DESCRIPTION
### SG-41718 - Add a specific category for the view control in the top bar

### Linked issues
n/a

### Summarize your change.
Added a new category for the following buttons and select box in the top toolbar:
<img width="459" height="41" alt="Screenshot 2026-01-19 at 4 12 10 PM" src="https://github.com/user-attachments/assets/b05c8d97-6369-4891-b45a-eb98a695e7b3" />


### Describe the reason for the change.
The Live review plugin need granular control over those buttons and select box.

### Describe what you have tested and on which operating system.
MacOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.