### PR TITLE
SG-41837: Improve Clear All Paint

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -1573,7 +1573,7 @@ class: AnnotateMinorMode : MinorMode
             _clearFrameAct.setEnabled(hasCurrentFrameStrokes);
 
             bool hasAnyStrokes = false;
-            for_each(node; nodes())
+            for_each(node; nodesOfType("RVPaint"))
             {
                 let annotatedFrames = findAnnotatedFrames(node);
                 if (!annotatedFrames.empty())
@@ -2052,7 +2052,7 @@ class: AnnotateMinorMode : MinorMode
 
         beginCompoundStateChange();
         
-        for_each(node; nodes())
+        for_each(node; nodesOfType("RVPaint"))
         {
             let annotatedFrames = findAnnotatedFrames(node);
             for_each(frame; annotatedFrames)


### PR DESCRIPTION
### [SG-41837](https://jira.autodesk.com/browse/SG-41837): Improve Clear All Paint

### Summarize your change.

Loop only over the RVPaint node instead of all the nodes to find the annotated frames in `clearAllPaint()` and `undoRedoClearUpdate()`. This is usually fast in a lot of cases, but I had that issue with some media during an OTIO-based Live Review session.

### Describe the reason for the change.

Clear All Frames is taking a long time to clear the timeline

### Describe what you have tested and on which operating system.

Clearing all the frames on the timeline was tested 

### If possible, provide screenshots.

**BEFORE**
https://github.com/user-attachments/assets/99f583f6-8b38-4269-b6c6-191ea6692126

**AFTER**
https://github.com/user-attachments/assets/57fbab0d-7a45-4868-be03-43b00290e0f2