### PR TITLE
SG-41531: Fix warning for non-transcoded media

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -37,7 +37,7 @@ def _get_transform_properties():
                 global_translate_vec = otio.schema.V2d(global_translate[0], global_translate[1])
                 global_scale_vec = otio.schema.V2d(global_scale[0], global_scale[1])
             else:
-                logging.warning(
+                logging.debug(
                     "OTIO global scale and translate properties not found, using aspect ratio from the source"
                 )
                 try:


### PR DESCRIPTION
[SG-41531](https://jira.autodesk.com/browse/SG-41531): Fix warning for non-transcoded media

### Summarize your change.

Replace the logging level from warning to debug when the OTIO global scale and translate properties are not found.

### Describe the reason for the change.

Default projects on test sites contain non-transcoded media causing the OTIO global scale and translate properties to not be found resulting in a spam of warnings. Since this issue is only occurring with this specific type of media, we can lower the logging level since it's shouldn't be treated as a real issue.

### Describe what you have tested and on which operating system.

Joining media from a default projects on a test sites was tested on macOS.