### PR TITLE
fix: SG-43090: Fix SYNDisplay property regression

### DIFF
--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -162,7 +162,7 @@ namespace IPCore
             }
         }
 
-        updateConfig();
+        updateConfig(true);
     }
 
     OCIOIPNode::~OCIOIPNode()
@@ -174,7 +174,7 @@ namespace IPCore
         delete m_state;
     }
 
-    void OCIOIPNode::updateConfig()
+    void OCIOIPNode::updateConfig(const bool initializing)
     {
         try
         {
@@ -230,7 +230,10 @@ namespace IPCore
         m_state->shaderID = "";
 
         updateContext();
-        updateFunction();
+        if (!initializing)
+        {
+            updateFunction();
+        }
     }
 
     void OCIOIPNode::updateContext()
@@ -352,7 +355,7 @@ namespace IPCore
         boost::hash<string> string_hash;
         string inName = stringProp("ocio.inColorSpace", m_state->linear);
 
-        if (inName.empty())
+        if (inName.empty() && !useRawConfig())
             return;
 
         try

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
@@ -52,7 +52,7 @@ namespace IPCore
         virtual void readCompleted(const std::string&, unsigned int);
         virtual void propertyChanged(const Property*);
 
-        void updateConfig();
+        void updateConfig(const bool initializing = false);
 
         bool useRawConfig() const { return m_useRawConfig; }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
Fixes #1034 
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.
Updated initialization step in OCIOIPNode used by SYNDisplay, so outTransform.url would be checked.

### Describe the reason for the change.
Regression caused SYNDisplay outTransform.url property to be ignored, so we could not set the display colorspace with an icc filepath.

### Describe what you have tested and on which operating system.
Confirmed this update worked on Linux RHEL 9.6. Executed this python code on a single-monitor system to validate the change. The code switches the display group's color pipeline node to a `SYNDisplay` node, and then assigns an icc profile file to the node's `outTransform.url` property.

```
icc_file = '<path-to>/colorspace.icc'
commands.setStringProperty("displayGroup0_colorPipeline.pipeline.nodes", ["SYNDisplay"])
syn_display_node = commands.nodesOfType("SYNDisplay")[0]
commands.setStringProperty(f"{syn_display_node}.outTransform.url", [icc_file])
```