### PR TITLE
Fix QMainWindow Resize Crash in Qt6

### DIFF
--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -363,13 +363,26 @@ namespace Rv
 
         if (!m_postFirstNonEmptyRender && session && session->postFirstNonEmptyRender())
         {
+
             m_postFirstNonEmptyRender = true;
 
             if (!session->isFullScreen())
             {
-                m_doc->resizeToFit(false, false);
-                m_doc->center();
-                TWK_GLDEBUG;
+                // Issue #1063: resizeToFit calls QMainWindow::resize
+                // during this first non-empty render step. In Qt6,
+                // this caused a crash when subsequently resizing the
+                // window again.
+                //
+                // Calling resizeToFit in a singleShot runs after this
+                // paintGL routine completes. This avoids the
+                // condition that was causing the crash.
+                QTimer::singleShot(0, this,
+                                   [this]()
+                                   {
+                                       m_doc->resizeToFit(false, false);
+                                       m_doc->center();
+                                       TWK_GLDEBUG;
+                                   });
             }
         }
 


### PR DESCRIPTION


<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
Fixes #1063 
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.
On the GLView's first paintGL routine, the Rv Window's resizeToFit function is now called from inside a singleShot. This causes it to run after the first paintGL completes, which avoids the state that previously caused the crash.

### Describe the reason for the change.
OpenRV, when built with the VFX2024 option which includes Qt6 6.5.3, had a crash regression. The crash would occur when resizing the main window after the preference "Fit Window to First Media Loaded" executed.

### Describe what you have tested and on which operating system.
Tested on Linux RHEL 9.6. Made sure the steps below no longer resulted in a crash:

1. Build OpenRV with Qt 6.5.3 and the rvcfg flag -DRV_VFX_CY2024=1
2. Make sure `RV > Preferences > Fit Window to First Media Loaded` is active
3. From command line open RV with: `rv colorchart,start=1,end=2,width=1920,height=804,fps=24.movieproc`
4. After image loads, attempt to resize RV window. RV previously should crash, but should now should behave as expected.