### PR TITLE
fix: SG-43270: Fix QMainWindow Resize Crash in Qt6

### DIFF
--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -1283,10 +1283,13 @@ namespace Rv
             m_glView->setContentSize(int(w), int(h));
             m_glView->setMinimumContentSize(int(w), int(h));
             m_glView->updateGeometry();
+
+            // Note: We don't call this the first time,
+            // as it will reset the image size to its
+            // previous scale.
+            m_resetPolicyTimer->start();
         }
         DB("resizeToFit final resulting size w " << m_glView->width() << " h " << m_glView->height());
-
-        m_resetPolicyTimer->start();
 
         if (placement)
         {


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->
Fixes #1063

### Summarize your change.
On the GLView's first paintGL routine, the Rv Window's resizeToFit function is now called from inside a singleShot. This causes it to run after the first paintGL completes, which avoids the state that previously caused the crash.

### Describe the reason for the change.
OpenRV, when built with the VFX2024 option which includes Qt6 6.5.3, had a crash regression. The crash would occur when resizing the main window after the preference "Fit Window to First Media Loaded" executed.

### Describe what you have tested and on which operating system.
Tested on Linux RHEL 9.6. Made sure the steps below no longer resulted in a crash:

1. Build OpenRV with Qt 6.5.3 and the rvcfg flag `-DRV_VFX_CY2024=1`
2. Make sure `RV > Preferences > Fit Window to First Media Loaded` is active
3. From command line open RV with: `rv colorchart,start=1,end=2,width=1920,height=804,fps=24.movieproc`
4. After image loads, attempt to resize RV window. RV previously would crash, but should now should behave as expected.
5. In RV, activate menu option `View > Lock Pixel Scale During Resize`.
6. Close RV, then reopen with same command as in step 3. Image should load and resize to 1:1 scale.