### PR TITLE
feat: SG-42131 - Migrate to OpenImageIO 3.x and build it with OpenColorIO

### DIFF
--- a/cmake/defaults/CYCOMMON.cmake
+++ b/cmake/defaults/CYCOMMON.cmake
@@ -176,10 +176,10 @@ SET(RV_DEPS_JPEGTURBO_VERSION_LIB
 
 # oiio https://github.com/AcademySoftwareFoundation/OpenImageIO
 SET(RV_DEPS_OIIO_VERSION
-    "2.5.19.1"
+    "3.1.11.0"
 )
 SET(RV_DEPS_OIIO_DOWNLOAD_HASH
-    "5af6de5a73c6d234eed8e2874a5aed62"
+    "29665fc3ef38a4ddb07f5c2833c9c9f8"
 )
 
 # openjpeg https://github.com/uclouvain/openjpeg

--- a/cmake/defaults/cxx_msvc_defaults.cmake
+++ b/cmake/defaults/cxx_msvc_defaults.cmake
@@ -54,6 +54,7 @@ ADD_COMPILE_OPTIONS(
   -Gy
   -nologo
   -Qfast_transcendentals
+  -utf-8
   -Zc:forScope
   -Zc:sizedDealloc-
   -Zi

--- a/cmake/dependencies/ocio.cmake
+++ b/cmake/dependencies/ocio.cmake
@@ -145,6 +145,9 @@ LIST(APPEND _configure_options "-DZLIB_ROOT=${RV_DEPS_ZLIB_ROOT_DIR}")
 
 # OCIO apps are not needed.
 LIST(APPEND _configure_options "-DOCIO_BUILD_APPS=OFF")
+# Use MISSING so OCIO vendors its own third-party deps when not already provided by RV_DEPS (vs NONE/default), pinning versions and avoiding ABI/licensing drift
+# with system libs; typical CI pulls in Imath/OpenEXR components, yaml-cpp, pystring, expat, lcms2, zlib, and related OCIO external packages.
+LIST(APPEND _configure_options "-DOCIO_INSTALL_EXT_PACKAGES=MISSING")
 
 IF(NOT RV_TARGET_WINDOWS)
   EXTERNALPROJECT_ADD(

--- a/cmake/dependencies/oiio.cmake
+++ b/cmake/dependencies/oiio.cmake
@@ -48,7 +48,8 @@ LIST(APPEND _byproducts ${_byprojects_copy})
 # The '_configure_options' list gets reset and initialized in 'RV_CREATE_STANDARD_DEPS_VARIABLES'
 LIST(APPEND _configure_options "-DBUILD_TESTING=OFF")
 LIST(APPEND _configure_options "-DUSE_PYTHON=0") # this on would requireextra pybind11 package
-LIST(APPEND _configure_options "-DUSE_OCIO=0")
+LIST(APPEND _configure_options "-DUSE_OCIO=ON")
+LIST(APPEND _configure_options "-DOpenColorIO_ROOT=${RV_DEPS_OCIO_ROOT_DIR}")
 LIST(APPEND _configure_options "-DUSE_FREETYPE=0")
 LIST(APPEND _configure_options "-DUSE_GIF=OFF")
 
@@ -87,6 +88,7 @@ LIST(APPEND _configure_options "-DJPEGTURBO_LIBRARY=${_jpegturbo_library}")
 LIST(APPEND _configure_options "-DJPEGTURBO_INCLUDE_DIR=${_jpegturbo_include_dir}")
 
 LIST(APPEND _configure_options "-DOpenJPEG_ROOT=${RV_DEPS_OPENJPEG_ROOT_DIR}")
+LIST(APPEND _configure_options "-DOPENJPEG_VERSION=${RV_DEPS_OPENJPEG_VERSION}")
 GET_TARGET_PROPERTY(_openjpeg_library OpenJpeg::OpenJpeg IMPORTED_LOCATION)
 GET_TARGET_PROPERTY(_openjpeg_include_dir OpenJpeg::OpenJpeg INTERFACE_INCLUDE_DIRECTORIES)
 LIST(APPEND _configure_options "-DOPENJPEG_OPENJP2_LIBRARY=${_openjpeg_library}")
@@ -126,6 +128,7 @@ LIST(APPEND _configure_options "-DOIIO_BUILD_TOOLS=OFF" "-DOIIO_BUILD_TESTS=OFF"
 
 IF(RV_TARGET_WINDOWS)
   LIST(PREPEND _configure_options "-G ${CMAKE_GENERATOR}")
+  LIST(APPEND _configure_options "-DCMAKE_CXX_FLAGS=/utf-8")
 ENDIF()
 
 IF(NOT RV_TARGET_WINDOWS)
@@ -153,6 +156,7 @@ IF(NOT RV_TARGET_WINDOWS)
             WebP::webp
             LibRaw::raw
             ZLIB::ZLIB
+            OpenColorIO::OpenColorIO
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options}
     BUILD_COMMAND ${_cmake_build_command}
     INSTALL_COMMAND ${_cmake_install_command}
@@ -207,6 +211,7 @@ ELSE()
             WebP::webp
             LibRaw::raw
             ZLIB::ZLIB
+            OpenColorIO::OpenColorIO
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options}
     BUILD_COMMAND ${CMAKE_COMMAND} ${_oiio_build_options}
     INSTALL_COMMAND ${CMAKE_COMMAND} ${_oiio_install_options}

--- a/src/lib/image/IOoiio/IOoiio.cpp
+++ b/src/lib/image/IOoiio/IOoiio.cpp
@@ -19,7 +19,7 @@ namespace TwkFB
 {
     using namespace std;
     using namespace TwkUtil;
-    using namespace OpenImageIO_v2_5;
+    using namespace OpenImageIO;
 
     IOoiio::IOoiio()
         : FrameBufferIO("IOoiio", "n") // OIIO after any defaults of ours
@@ -348,7 +348,7 @@ namespace TwkFB
         }
         else
         {
-            TWK_THROW_STREAM(IOException, "OIIO: Unable to open file \"" << filename << "\" for reading. " << OpenImageIO_v2_5::geterror());
+            TWK_THROW_STREAM(IOException, "OIIO: Unable to open file \"" << filename << "\" for reading. " << OpenImageIO::geterror());
         }
     }
 
@@ -439,7 +439,7 @@ namespace TwkFB
 
             fb.restructure(spec.width, spec.height, spec.depth, spec.nchannels, dtype, NULL, &spec.channelnames, orientation, true);
 
-            in->read_image(informat, fb.pixels<void>());
+            in->read_image(subimage, 0, 0, spec.nchannels, informat, fb.pixels<void>());
 
             readAttrs(fb, spec);
 
@@ -464,7 +464,7 @@ namespace TwkFB
         }
         else
         {
-            TWK_THROW_STREAM(IOException, "OIIO: Unable to open file \"" << filename << "\" for reading. " << OpenImageIO_v2_5::geterror());
+            TWK_THROW_STREAM(IOException, "OIIO: Unable to open file \"" << filename << "\" for reading. " << OpenImageIO::geterror());
         }
     }
 


### PR DESCRIPTION
OIIO development has moved to v3.  Also adding ocio support with oiio.

<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->
fixes #893 
### Summarize your change.
Upgrade OIIO to v3 and build with OCIO

### Describe the reason for the change.
OIIO v2 is considered obsolete: https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/tag/v2.5.19.1

```Note that this is a patch release for the obsolete 2.5 branch that merely repairs its ability to build under new versions of some dependencies. You need not upgrade if you are not encountering build problems. Except for legacy constraints, everybody should currently be using OIIO 3.0 and testing the beta for 3.1 which will become the new supported branch very soon.```

### Describe what you have tested and on which operating system.
built locally and tested on macos for 2024 and 2025. Need the Academy's CICD to build for other configs

### Add a list of changes, and note any that might need special attention during the review.
It appears OIIO implementation is pretty minimal so I think we should be good but testing on other distros to validate would be appreciated.  

### If possible, provide screenshots.