### PR TITLE
SG-41909: Fix Continuous playback annotations

### DIFF
--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -2041,10 +2041,24 @@ class: AnnotateMinorMode : MinorMode
         string[] affectedStrokes;
 
         beginCompoundStateChange();
-        
+
         for_each(node; nodesOfType("RVPaint"))
         {
-            let annotatedFrames = findAnnotatedFrames(node);
+            int[] annotatedFrames;
+            
+            for_each (property; properties(node))
+            {
+                let parts = property.split(".");
+                let propertyName = parts[2];
+                let propertyComponent = parts[1];
+                let ComponentParts = propertyComponent.split(":");
+
+                if (ComponentParts[0] == "frame" && propertyName == "order" && ComponentParts.size() == 2)
+                {
+                    annotatedFrames.push_back(int(ComponentParts[1]));
+                }
+            }
+            
             for_each(frame; annotatedFrames)
             {
                 let orderProperty = frameOrderName(node, frame);


### PR DESCRIPTION
### [SG-41909](https://jira.autodesk.com/browse/SG-41909): Fix continuous playback annotations

### Summarize your change.

- [X] Always keep the _Clear All Frames on Timeline_ button enabled instead of looping over all paint nodes to update its state.
- [X] Directly loop over the properties of the paint nodes instead of calling findAnnotatedFrames() to avoid traversing the graph unnecessary when there is multiple sources loaded.

### Describe the reason for the change.

While fixing the Continuous playback issue with annotations in an OTIO-based Live Review session, the annotation panel was sometimes taking a lot of time to open. The playlist I was using had multiple clips which meant a lot of different RVPaint nodes. Since `undoRedoClearUpdate` is called each time the annotation panel is activated, all the RVPaint nodes were always looped over just for the panel to be shown. Since there is actually no harm in keeping the _Clear All Frames on Timeline_ button enabled, this greatly improved the annotation panel time in Continuous playback. The same kind of loop was also being used in `clearAllPaint`. This was an improvement from looping over all the nodes for a single clip, but it was still taking a long time for a playlist in Continuous playback because of `findAnnotatedFrames()` which was causing a traversal of the graph for each frames.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.