### PR TITLE
SG-41889: add waitForProgressiveLoading() RV Command

### DIFF
--- a/src/lib/app/mu_rvui/commands.mud
+++ b/src/lib/app/mu_rvui/commands.mud
@@ -745,6 +745,22 @@ For example a single stereo source might look like string[]
 {"[", "left.mov", "right.mov", "+rs", "1001", "]" }
 """
 
+waitForProgressiveLoading """
+Blocks execution until all progressive source loading has completed. This 
+command waits for the 'after-progressive-loading' event to be triggered, 
+which occurs when all media from previously called addSource() or addSources() 
+has finished loading.
+
+This is particularly useful when:
+- You need to ensure all sources are fully loaded before performing operations
+- Scripting workflows that depend on complete media availability
+
+The command processes Qt events while waiting to keep the UI responsive, but 
+excludes user input events to prevent interference during the loading process.
+
+For reference: addSource(), addSources(), before-progressive-loading, 
+after-progressive-loading events
+"""
 
 startPreloadingMedia """
 When called with a media name (eg: a movie filename or url for mp4 media), 

--- a/src/lib/app/py_rvui/rv_commands_setup.py
+++ b/src/lib/app/py_rvui/rv_commands_setup.py
@@ -315,6 +315,7 @@ all_mu_commands = [
     "sourceMediaRepSourceNode",
     "sourceMediaRepsAndNodes",
     "devicePixelRatio",
+    "waitForProgressiveLoading",
 ]
 
 

--- a/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep.py
+++ b/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep.py
@@ -543,6 +543,7 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
                 ("before-source-delete", self._before_source_delete, ""),
                 ("source-group-complete", self._update_media_info, ""),
                 ("frame-changed", self._update_media_info, ""),
+                ("graph-node-inputs-changed", self._update_media_info, ""),
                 ("session-clear-everything", self._update_media_info, ""),
                 ("source-media-set", self._on_force_update_media_info, ""),
                 ("source-modified", self._on_force_update_media_info, ""),


### PR DESCRIPTION
### SG-41889: add waitForProgressiveLoading() RV Command

### Linked issues
NA

### Summarize your change.

This commit adds a new RV command : waitForProgressiveLoading()
It blocks execution until all progressive source loading has completed. This command waits for the 'after-progressive-loading' event to be triggered, which occurs when all media from previously called addSource() or addSources() has finished loading.

Also in this commit: Added the graph-node-inputs-changed event to the list of events that triggers an update of the multiple media representation UI. This issue was discovered when fixing a Live Review Screening Room issue: after loading a new version via Screening Room, the participants' multiple media representation UI at the bottom right of the RV player was not being updated because this event was not taken into consideration.

### Describe the reason for the change.

To fix an issue with the RV Screening Room when used in a Live Review session, we needed a way to synchronize execution of the multiple participants for commands that are executed during the after-progressive-loading event.

### Describe what you have tested and on which operating system.

Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.