### PR TITLE
build: SG-42137: disable x11 features on macos

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -179,7 +179,7 @@ IF(RV_TARGET_WINDOWS)
   LIST(APPEND RV_FFMPEG_COMMON_CONFIG_OPTIONS "--toolchain=msvc")
 ENDIF()
 
-# Disable x11 on macos to prevent distribution binary errors related to missing X11 headers
+# Disable x11 on macOS to avoid linking against Homebrew's X11 libraries, ensuring binary portability
 IF(RV_TARGET_DARWIN
    OR RV_TARGET_APPLE_ARM64
 )


### PR DESCRIPTION


<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
Fixes #1115 
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.
disabled x11 features in ffmpeg.cmake for macos

### Describe the reason for the change.
we don't use them and building openrv's ffmpeg on a machine that has libx11 installed via homebrew results in a rvinst package that is not portable.

### Describe what you have tested and on which operating system.
macos 26.2 building 2024 and 2025.  ran otool on the RV.app built by rvinst and did not find any links to x11.  
```
for i in `find RV.app -name "*.dylib"`; do otool -L $i; done >> /tmp/rv-libs-otool.log;
grep -i x11 /tmp/rv-libs-otool.log;
```
### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.