### PR TITLE
SG-41220: Add -update option to rvpkg command line tool

### DIFF
--- a/src/lib/app/RvPackage/RvPackage/PackageManager.h
+++ b/src/lib/app/RvPackage/RvPackage/PackageManager.h
@@ -220,6 +220,8 @@ namespace Rv
 
         void setNoConfirmation(bool force = true) { m_force = force; }
 
+        void setSkipDependencyCheck(bool skip = true) { m_skipDependencyCheck = skip; }
+
         static void setIgnorePrefs(bool b) { m_ignorePrefs = b; }
 
         static bool ignoringPrefs() { return m_ignorePrefs; }
@@ -237,7 +239,8 @@ namespace Rv
         PackageMap m_packageMap;
         QStringList m_doNotLoadPackages;
         QStringList m_optLoadPackages;
-        bool m_force;
+        bool m_force{false};
+        bool m_skipDependencyCheck{false};
 
         static bool m_ignorePrefs;
     };


### PR DESCRIPTION
### SG-41220: Add -update option to rvpkg command line tool

### Linked issues
NA

### Summarize your change.

This commit adds the "-update" option to rvpkg command line tool.
Update = Uninstall(currently installed pkg)  + Remove(currently installed pkg) + Install(new pkg)
Works for both single .rvpkg and also bundles (.rvpkgs)

Also in this commit: I have added a new option to the RV's PackageManager to be able to skip the dependency checking duing the uninstallation of a package. This option is used required by the -update rvpkg option so that it can uninstall an existing package freely without being forced to unnecessarily uninstall all the packages that depend on it (since it will be soon after reinstalled with the new updated version) 

**Examples:**
Single package (.rvpkg):
`./RV.app/Contents/MacOS/rvpkg -update ./live_review-2.5.rvpkg`
Bundle of packages (.rvpkgs):
`./RV.app/Contents/MacOS/rvpkg -update ./live_review-2.5.rvpkgs`


### Describe the reason for the change.
Functionality required for the new single click Live Review package update (which is broken without it).

### Describe what you have tested and on which operating system.
Successfully tested on macOS.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.