### PR TITLE
SG-42039 Revert recent mmr fix

### DIFF
--- a/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep.py
+++ b/src/plugins/rv-packages/multiple_source_media_rep/multiple_source_media_rep.py
@@ -543,7 +543,6 @@ class MultipleSourceMediaRepMode(rvtypes.MinorMode):
                 ("before-source-delete", self._before_source_delete, ""),
                 ("source-group-complete", self._update_media_info, ""),
                 ("frame-changed", self._update_media_info, ""),
-                ("graph-node-inputs-changed", self._update_media_info, ""),
                 ("session-clear-everything", self._update_media_info, ""),
                 ("source-media-set", self._on_force_update_media_info, ""),
                 ("source-modified", self._on_force_update_media_info, ""),


### PR DESCRIPTION
### SG-42039 Revert recent mmr fix

### Linked issues
NA

### Summarize your change.
Reverting this recent multiple media representation fix since it might be causing crashes during a clearSession() (because sourcesAtFrame() might be evaluated during this clearSession()).

The multiple media representation fix was cosmetic anyhow in a Live Review RV-RV with Screening Room scenario:
after loading a new version via Screening Room, the participants' multiple media representation UI at the bottom right
of the RV player was not being updated because this event was not taken into consideration.

### Describe the reason for the change.

Random crashes occured in OTIO RV Automated tests 

### Describe what you have tested and on which operating system.
successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.