### PR TITLE
Fix return value in rmsImageDiff main

### DIFF
--- a/src/bin/imgtools/rmsImageDiff/main.cpp
+++ b/src/bin/imgtools/rmsImageDiff/main.cpp
@@ -406,5 +406,5 @@ int utf8Main(int argc, char* argv[])
     TwkMovie::GenericIO::shutdown(); // Shutdown TwkMovie::GenericIO plugins
     TwkFB::GenericIO::shutdown();    // Shutdown TwkFB::GenericIO plugins
 
-    return 0;
+    return status;
 }


### PR DESCRIPTION
### Fix return value in rmsImageDiff main

### Summarize your change.

Return the status value instead of always returning 0 when doing images comparison with -cmp

### Describe the reason for the change.

0 was always return instead of the status value returned by `computeRMS`.