### PR TITLE
Add safety check in base64Encode

### DIFF
--- a/src/lib/base/TwkUtil/Base64.cpp
+++ b/src/lib/base/TwkUtil/Base64.cpp
@@ -20,6 +20,11 @@ namespace TwkUtil
 
     string base64Encode(const char* data, size_t size)
     {
+        if ((data == nullptr) || size == 0)
+        {
+            return "";
+        }
+
         namespace bai = boost::archive::iterators;
         stringstream os;
 


### PR DESCRIPTION
### Add safety check in base64Encode

### Summarize your change.

Add an early return in `base64Encode` there is no data to compute.

### Describe the reason for the change.

`base64Encode` was not validating the input before encoding it in base 64.