### PR TITLE
Add copilot-instructions.md for code review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+# General Code Review Standards
+
+## Purpose
+
+These instructions guide GitHub Copilot code review across all files in this repository.
+
+## About Open RV
+
+Open RV is an open-source, hardware-accelerated image and video sequence viewer built for visual effects (VFX) and animation production pipelines. It is maintained under the Academy Software Foundation (ASWF). It runs on macOS, Windows, and RHEL-based Linux distributions. The build targets the VFX Reference Platform specification for dependency compatibility across studios.
+
+## Code Standards Reference
+
+All code must follow the project's configuration files:
+
+- **C++ formatting**: `.clang-format`
+- **C++ linting**: `.clang-tidy`
+- **Python formatting and linting**: `ruff.toml`
+- **CMake formatting**: `cmake-format.json`
+- **Pre-commit hooks**: `.pre-commit-config.yaml`
+
+Review code against these standards and flag violations.
+
+## Review Behavior
+
+### Confidence Threshold
+
+- **Only comment when you have 80% confidence** the issue is real and valid
+- If uncertain about severity or whether it's actually a problem, don't comment
+- If you notice a pattern that MIGHT be an issue but aren't certain, don't comment
+- Do not speculate about hypothetical issues without clear evidence
+
+### What to Review
+
+- Security vulnerabilities
+- Bugs and logic errors
+- Breaking changes or API changes
+- Performance issues
+- Build system issues
+- Missing error handling
+- Changes made in the pull request


### PR DESCRIPTION
### Add copilot-instructions.md for code review

### Summarize your change.

Add a basic set of instructions to give some guidelines to GitHub Copilot code review.

### Describe the reason for the change.

This is a first pass at trying to give more context to Copilot when performing code reviews on pull requests to get more meaningful comments from it. Since the format of the comments made by Copilot can't be modified, these instructions only focus on targeting specific issues to report on when the confidence level is high to prevent getting too much noise on the PRs.