### PR TITLE
fix: SG-42334: Fix random crashes involving SoundTrackIPNode

### DIFF
--- a/src/lib/audio/TwkAudio/AudioCache.cpp
+++ b/src/lib/audio/TwkAudio/AudioCache.cpp
@@ -19,7 +19,7 @@ namespace TwkAudio
     using namespace std;
 
     AudioCache::AudioCache()
-        : m_packetSize(512)
+        : m_packetSize(TWEAK_AUDIO_DEFAULT_PACKET_SIZE)
         , m_packetLayout(TwkAudio::Stereo_2)
         , m_count(0)
         , m_packetRate(0)

--- a/src/lib/audio/TwkAudio/TwkAudio/Audio.h
+++ b/src/lib/audio/TwkAudio/TwkAudio/Audio.h
@@ -24,6 +24,13 @@
 #define TWEAK_AUDIO_MIN_SAMPLE_RATE 8000
 #define TWEAK_AUDIO_DEFAULT_SAMPLE_RATE 48000
 #define TWEAK_AUDIO_MAX_SAMPLE_RATE 352800
+// The audio packet size is the number of audio samples processed per packet
+// (i.e. per call to the audio fill buffer function). It controls the trade-off
+// between latency and CPU overhead: smaller values reduce latency but increase
+// the number of fill-buffer calls per second, while larger values reduce CPU
+// overhead at the cost of higher latency. 2048 samples at 48 kHz yields ~43 ms
+// of audio per packet, which is a standard default for buffered video playback.
+#define TWEAK_AUDIO_DEFAULT_PACKET_SIZE 2048
 
 // #define ENABLE_AUDIOBUFFER_CHECK
 

--- a/src/lib/image/MovieRV/MovieRV.cpp
+++ b/src/lib/image/MovieRV/MovieRV.cpp
@@ -81,7 +81,7 @@ namespace TwkMovie
         , m_session(0)
         , m_audioChannels(TwkAudio::layoutChannels(TwkAudio::Stereo_2))
         , m_audioRate(TWEAK_AUDIO_DEFAULT_SAMPLE_RATE)
-        , m_audioPacketSize(512)
+        , m_audioPacketSize(TWEAK_AUDIO_DEFAULT_PACKET_SIZE)
         , m_audioInit(true)
         , m_thread(pthread_self())
     {

--- a/src/lib/image/MovieRV/MovieRV/MovieRV.h
+++ b/src/lib/image/MovieRV/MovieRV/MovieRV.h
@@ -87,7 +87,7 @@ namespace TwkMovie
         //
 
         void open(Rv::RvSession* session, const TwkMovie::MovieInfo& as, TwkAudio::ChannelsVector audioChannels,
-                  double audioRate = TWEAK_AUDIO_DEFAULT_SAMPLE_RATE, size_t audioPacketSize = 512);
+                  double audioRate = TWEAK_AUDIO_DEFAULT_SAMPLE_RATE, size_t audioPacketSize = TWEAK_AUDIO_DEFAULT_PACKET_SIZE);
 
         //
         //  Movie API

--- a/src/lib/image/MovieRV_FBO/MovieRV_FBO.cpp
+++ b/src/lib/image/MovieRV_FBO/MovieRV_FBO.cpp
@@ -95,7 +95,7 @@ namespace TwkFB
         , m_session(0)
         , m_audioChannels(TwkAudio::layoutChannels(TwkAudio::Stereo_2))
         , m_audioRate(TWEAK_AUDIO_DEFAULT_SAMPLE_RATE)
-        , m_audioPacketSize(512)
+        , m_audioPacketSize(TWEAK_AUDIO_DEFAULT_PACKET_SIZE)
         , m_audioInit(true)
     // m_device(0)
     {

--- a/src/lib/image/MovieRV_FBO/MovieRV_FBO/MovieRV_FBO.h
+++ b/src/lib/image/MovieRV_FBO/MovieRV_FBO/MovieRV_FBO.h
@@ -71,7 +71,7 @@ namespace TwkFB
         virtual void postPreloadOpen(const TwkMovie::MovieInfo& info, const Movie::ReadRequest& request);
 
         void open(Rv::RvSession*, const TwkMovie::MovieInfo& as, TwkAudio::ChannelsVector audioChannels,
-                  double audioRate = TWEAK_AUDIO_DEFAULT_SAMPLE_RATE, size_t audioPacketSize = 512);
+                  double audioRate = TWEAK_AUDIO_DEFAULT_SAMPLE_RATE, size_t audioPacketSize = TWEAK_AUDIO_DEFAULT_PACKET_SIZE);
 
         //
         //  Movie API

--- a/src/lib/ip/IPCore/IPCore/SoundTrackIPNode.h
+++ b/src/lib/ip/IPCore/IPCore/SoundTrackIPNode.h
@@ -11,6 +11,7 @@
 #include <TwkMovie/Movie.h>
 #include <TwkAudio/Audio.h>
 #include <algorithm>
+#include <atomic>
 #include <limits>
 
 namespace IPCore
@@ -111,7 +112,7 @@ namespace IPCore
         GraphConfiguration m_graphConfig;
         TwkAudio::SampleTime m_sampleStart;
         TwkAudio::SampleTime m_sampleEnd;
-        TwkAudio::SampleTime m_sampleCurrent;
+        std::atomic<TwkAudio::SampleTime> m_sampleCurrent;
         FrameBuffer* m_fb;
         RangeStatsVector m_stats;
         size_t m_serialNumber;

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -28,6 +28,7 @@
 #include <TwkApp/Event.h>
 #include <TwkApp/VideoDevice.h>
 #include <TwkApp/VideoModule.h>
+#include <TwkAudio/Audio.h>
 #include <TwkAudio/Filters.h>
 #include <TwkAudio/Mix.h>
 #include <TwkMath/Function.h>
@@ -259,15 +260,8 @@ namespace IPCore
         , m_audioThreading(true)
         , m_audioMinCache(3.0)
         , m_audioMaxCache(6.0)
-        ,
-#ifdef WIN32
-        m_audioPacketSize(512)
-        ,
-#else
-        m_audioPacketSize(2048)
-        ,
-#endif
-        m_audioCacheMode(BufferCache)
+        , m_audioPacketSize(TWEAK_AUDIO_DEFAULT_PACKET_SIZE)
+        , m_audioCacheMode(BufferCache)
         , m_audioPendingCacheMode(BufferCache)
         , m_audioConfigured(false)
         , m_audioCacheComplete(false)
@@ -2846,7 +2840,7 @@ IPGraph::findNodesByAbstractPath(int frame,
         if (notify)
             finishAudioThread();
 
-        m_audioPacketSize = Application::optionValue<size_t>("acachesize", 2048);
+        m_audioPacketSize = Application::optionValue<size_t>("acachesize", TWEAK_AUDIO_DEFAULT_PACKET_SIZE);
         m_audioMinCache = Application::optionValue<double>("audioMinCache", m_audioMinCache);
         m_audioMaxCache = Application::optionValue<double>("audioMaxCache", m_audioMaxCache);
 


### PR DESCRIPTION
### fix: SG-42334: Fix random crashes involving SoundTrackIPNode

### Linked issues
NA

### Summarize your change.

  - Fixed race conditions in SoundTrackIPNode that caused random crashes due to unsynchronized access to m_fb across threads.                                             
  - evaluateAudioTexture() now uses a short lock-around-read pattern to safely snapshot m_fb before use, and re-checks it under lock before dereferencing to construct the
   IPImage — guarding against propertyChanged() clearing m_fb on the main thread between the two access points.                                                           
  - propertyChanged() now acquires m_fblock before allocating or restructuring m_fb, preventing data races during waveform texture resize.                                
  - clearFB() now acquires m_fblock for the duration of the pixel clear and stats reset, making it fully thread-safe.

  Root Cause

  m_fb (the waveform framebuffer) was read and written from multiple threads without synchronization. evaluateAudioTexture() ran on the audio/render thread while
  propertyChanged() and clearFB() ran on the main thread. A m_fb pointer that was valid at the check could be freed mid-use, leading to use-after-free crashes.

### Describe the reason for the change.
Random crashes had been reported originating from SoundTrackIPNode.

### Describe what you have tested and on which operating system.
Successfully tested on macOS.

Test Plan

- Enable the Timeline Magnifier via the RV/Tools/Timeline Magnifier menu
- Load media that contains audio
- Play media with audio waveform display enabled and rapidly scrub / resize the timeline — no crash
- Trigger property changes (e.g., resize the waveform panel) during active audio playback — no crash

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.