### PR TITLE
chore: Prevent new workflow from running on fork

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,7 +13,7 @@ jobs:
   release-pr:
     runs-on: ubuntu-latest
     # Skip if this push is the merge of a release PR
-    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    if: github.repository_owner == 'AcademySoftwareFoundation' && !startsWith(github.event.head_commit.message, 'chore(release):')
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'autorelease')
+    if: github.repository_owner == 'AcademySoftwareFoundation' && github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'autorelease')
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   semantic:
+    if: github.repository_owner == 'AcademySoftwareFoundation'
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50


### PR DESCRIPTION
### Prevent new workflow from running on fork

### Linked issues
none

### Summarize your change.
Prevent these workflow from running in forks.

### Describe the reason for the change.
Change log and release workflow are running in forks.

### Describe what you have tested and on which operating system.
CI