### PR TITLE
ci: Fix detect change job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       cmake_changed: ${{ steps.filter.outputs.cmake }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
         with:


### PR DESCRIPTION
### ci: Fix detect change job

### Linked issues
none

### Summarize your change.
Add missing actions/checkout step before dorny/paths-filter in the detect-changes job in ci.yml. 

### Describe the reason for the change.
The detect-changes job fails on push, schedule, and workflow_dispatch events with the error:
`fatal: not a git repository (or any of the parent directories): .git`

` dorny/paths-filter` can work without a checkout on pull_request events (using the GitHub API), but on push, schedule, and workflow_dispatch events it requires a local git repository to compare commits. The checkout step was missing, causing the job to fail after merging to main.

### Describe what you have tested and on which operating system.
CI