### PR TITLE
fix: SG-42402: Fix safeguard causing runtime error when clearing loaded media

### DIFF
--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -1696,9 +1696,6 @@ namespace IPCore
 
     void Session::clear()
     {
-        m_beingCleared = true;
-        BOOST_SCOPE_EXIT_ALL(&) { m_beingCleared = false; };
-
         if (!m_beingDeleted)
         {
             userGenericEvent("before-clear-session", "");
@@ -1736,7 +1733,11 @@ namespace IPCore
         graph().setAudioCachingMode(IPGraph::BufferCache);
         graph().flushAudioCache();
         if (!m_beingDeleted)
+        {
+            m_beingCleared = true;
+            BOOST_SCOPE_EXIT_ALL(&) { m_beingCleared = false; };
             graph().reset(App()->videoModules());
+        }
         setFileName("Untitled");
         setInPoint(1);
         setOutPoint(2);
@@ -4574,6 +4575,9 @@ namespace IPCore
     {
         if (m_beingDeleted)
             return EventIgnored;
+
+        if (m_beingCleared)
+            return EventAccept;
 
         //
         //  All events are handled by the init script except for

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -1696,9 +1696,6 @@ namespace IPCore
 
     void Session::clear()
     {
-        m_beingCleared = true;
-        BOOST_SCOPE_EXIT_ALL(&) { m_beingCleared = false; };
-
         if (!m_beingDeleted)
         {
             userGenericEvent("before-clear-session", "");
@@ -1736,7 +1733,11 @@ namespace IPCore
         graph().setAudioCachingMode(IPGraph::BufferCache);
         graph().flushAudioCache();
         if (!m_beingDeleted)
+        {
+            m_beingCleared = true;                                                                                                          
+            BOOST_SCOPE_EXIT_ALL(&) { m_beingCleared = false; };
             graph().reset(App()->videoModules());
+        }
         setFileName("Untitled");
         setInPoint(1);
         setOutPoint(2);
@@ -4574,6 +4575,9 @@ namespace IPCore
     {
         if (m_beingDeleted)
             return EventIgnored;
+
+        if (m_beingCleared)
+            return EventAccept;
 
         //
         //  All events are handled by the init script except for

--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -3895,11 +3895,6 @@ namespace IPMu
         if (!node)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil node name");
 
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
-        }
-
         if (IPNode* n = s->graph().findNode(node->c_str()))
         {
             type = stype->allocate(n->protocol());
@@ -4125,11 +4120,6 @@ namespace IPMu
         if (!name)
         {
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "no node name specified");
-        }
-
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
         }
 
         if (IPNode* node = s->graph().findNode(name->c_str()))

--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -3895,6 +3895,11 @@ namespace IPMu
         if (!node)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil node name");
 
+        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
+        {
+            NODE_RETURN(*val);
+        }
+
         if (IPNode* n = s->graph().findNode(node->c_str()))
         {
             type = stype->allocate(n->protocol());
@@ -4120,6 +4125,11 @@ namespace IPMu
         if (!name)
         {
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "no node name specified");
+        }
+
+        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
+        {
+            NODE_RETURN(*val);
         }
 
         if (IPNode* node = s->graph().findNode(name->c_str()))

--- a/src/plugins/rv-packages/source_setup/source_setup.py
+++ b/src/plugins/rv-packages/source_setup/source_setup.py
@@ -505,6 +505,10 @@ class SourceSetupMode(rvtypes.MinorMode):
         if commands.nodeType(event.contents()) == "RVDisplayGroup":
             self._haveNewDisplayGroups = True
 
+    def afterClearSession(self, event):
+        event.reject()
+        self._haveNewDisplayGroups = True
+
     def __init__(self):
         self._readingSession = False
         self._haveNewDisplayGroups = True
@@ -523,6 +527,7 @@ class SourceSetupMode(rvtypes.MinorMode):
                     "Color and Geometry Management",
                 ),
                 ("graph-new-node", self.checkForDisplayGroup, ""),
+                ("after-clear-session", self.afterClearSession, ""),
             ],
             None,
             "source_setup",


### PR DESCRIPTION
### **[SG-42402](https://jira.autodesk.com/browse/SG-42402): RV: When doing File->Clear, there is a runtime error causing future loaded clips colour to be off**

### Summarize your change.

Narrowed the m_beingCleared scope in Session::clear() to only cover graph().reset(), added an early-return guard in Session::propagateEvent during clearing, and added an afterClearSession handler in source_setup.py to restore the display group detection flag.

### Describe the reason for the change.

Having m_beingCleared set at the very top of Session::clear() caused Mu script handlers bound to before-graph-view-change, after-graph-view-change, and graph-node-inputs-changed to crash with "nil argument to function". These events are fired by setViewNode calls that happen before graph().reset(), so the graph is still intact at that point but the returnIfGraphUnsafe guards cause nodeType to return nil whenever m_beingCleared is true, regardless. Moving the scope of m_beingCleared to only cover graph().reset() fixes this.

The early return in Session::propagateEvent ensures no events are propagated to script handlers during graph().reset(), since those handlers call nodeType which returns nil during that phase.

The afterClearSession handler resets _haveNewDisplayGroups back to True after clearing, since the graph-new-node events that normally set it are suppressed by the early return above. Without this, setDisplayFromProfile() would skip colour setup on the next media load, resulting in incorrect colours.

### Describe what you have tested and on which operating system.

This fix was tested on macOS by loading a media, clearing the session using File->Clear, and reloading the same media to make sure there are no errors and the media looks the same.