### PR TITLE
chore: update glew to 2.3.1 from 2.2.0 custom hash with patch

### DIFF
--- a/cmake/defaults/CYCOMMON.cmake
+++ b/cmake/defaults/CYCOMMON.cmake
@@ -132,13 +132,13 @@ SET(RV_DEPS_GC_DOWNLOAD_HASH
 
 # glew https://github.com/nigels-com/glew
 SET(RV_DEPS_GLEW_VERSION
-    "e1a80a9f12d7def202d394f46e44cfced1104bfb"
+    "2.3.1"
 )
 SET(RV_DEPS_GLEW_DOWNLOAD_HASH
-    "9bfc689dabeb4e305ce80b5b6f28bcf9"
+    "e795affc12dda3226e9ae3afcc80ceb9"
 )
 SET(RV_DEPS_GLEW_VERSION_LIB
-    "2.2.0"
+    "2.3.1"
 )
 
 # imgui https://github.com/pthom/imgui

--- a/cmake/dependencies/glew.cmake
+++ b/cmake/dependencies/glew.cmake
@@ -10,7 +10,7 @@ PROCESSORCOUNT(_cpu_count)
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_GLEW" "${RV_DEPS_GLEW_VERSION}" "make" "")
 
 SET(_download_url
-    "https://github.com/nigels-com/glew/archive/${_version}.zip"
+    "https://github.com/nigels-com/glew/archive/refs/tags/glew-${_version}.tar.gz"
 )
 
 SET(_download_hash
@@ -50,14 +50,8 @@ EXTERNALPROJECT_ADD(
   INSTALL_DIR ${_install_dir}
   URL ${_download_url}
   URL_MD5 ${_download_hash}
-  DOWNLOAD_NAME ${_target}_${_version}.zip
+  DOWNLOAD_NAME glew-glew-${_version}.tar.gz
   DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
-  # Patch to fix the build issue with OpenGL-Registry Pinning the OpenGL-Registry version to a specific commit https://github.com/nigels-com/glew/issues/449
-  # Also clone the required glfixes repository
-  PATCH_COMMAND
-    cd auto && git clone https://github.com/KhronosGroup/OpenGL-Registry.git || true && cd OpenGL-Registry && git checkout
-    a77f5b6ffd0b0b74904f755ae977fa278eac4e95 && cd .. && git clone --depth=1 --branch glew https://github.com/nigels-com/glfixes glfixes || true && touch
-    OpenGL-Registry/.dummy && cd ..
   CONFIGURE_COMMAND cd auto && ${_make_command} && cd .. && ${_make_command}
   BUILD_COMMAND ${_make_command} -j${_cpu_count} GLEW_DEST=${_install_dir}
   INSTALL_COMMAND ${_make_command} install LIBDIR=${_lib_dir} GLEW_DEST=${_install_dir}


### PR DESCRIPTION
Signed-off-by: Michael Oliver <mcoliver@gmail.com>

GLEW was pulling a non release commit hash and then applying a patch.  The fix has been rolled into an official release 2.3.1 along with other fixes and improvements.  


<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.