### PR TITLE
fix: SG-43399: 1181 fix colorspace changes when session clear and fix memory leak with orphaned sessions

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -313,6 +313,9 @@ namespace TwkMovie
                 av_frame_free(&videoFrame);
             av_frame_free(&inPicture);
             av_frame_free(&outPicture);
+
+            if (hardwareContext.deviceContext)
+                av_buffer_unref(&hardwareContext.deviceContext);
         };
 
         VideoTrack& initFrom(const VideoTrack* t)
@@ -5649,7 +5652,6 @@ namespace TwkMovie
         {
             VideoTrack* track = m_videoTracks[i];
             avcodec_free_context(&track->avCodecContext);
-            av_buffer_unref(&track->hardwareContext.deviceContext);
             delete track;
         }
         if (m_audioSamples)

--- a/src/plugins/rv-packages/ocio_source_setup/ocio_source_setup.py
+++ b/src/plugins/rv-packages/ocio_source_setup/ocio_source_setup.py
@@ -519,6 +519,11 @@ class OCIOSourceSetupMode(rvtypes.MinorMode):
         except Exception as inst:
             print((str(inst), node))
 
+    def afterClearSession(self, event):
+        event.reject()
+        self.usingOCIOForDisplay.clear()
+        commands.defineModeMenu("OCIO Source Setup", self.buildOCIOMenu(), True)
+
     def maybeUpdateViews(self, event):
         event.reject()
         if event.contents().endswith("ocio_display.display"):
@@ -728,6 +733,7 @@ class OCIOSourceSetupMode(rvtypes.MinorMode):
                 ("before-session-read", self.beforeSessionRead, ""),
                 ("after-session-read", self.afterSessionRead, ""),
                 ("graph-new-node", self.checkForDisplayGroup, ""),
+                ("after-clear-session", self.afterClearSession, ""),
                 ("graph-node-inputs-changed", self.checkForDisplayGroup, ""),
                 ("graph-state-change", self.maybeUpdateViews, ""),
             ],

--- a/src/plugins/rv-packages/source_setup/source_setup.py
+++ b/src/plugins/rv-packages/source_setup/source_setup.py
@@ -505,6 +505,10 @@ class SourceSetupMode(rvtypes.MinorMode):
         if commands.nodeType(event.contents()) == "RVDisplayGroup":
             self._haveNewDisplayGroups = True
 
+    def afterClearSession(self, event):
+        event.reject()
+        self._haveNewDisplayGroups = True
+
     def __init__(self):
         self._readingSession = False
         self._haveNewDisplayGroups = True
@@ -523,6 +527,7 @@ class SourceSetupMode(rvtypes.MinorMode):
                     "Color and Geometry Management",
                 ),
                 ("graph-new-node", self.checkForDisplayGroup, ""),
+                ("after-clear-session", self.afterClearSession, ""),
             ],
             None,
             "source_setup",


### PR DESCRIPTION
`source_setup.py` and `ocio_source_setup.py` scripts track whether a new Display Group has been created using a variable named _haveNewDisplayGroups. When you open OpenRV normally, this is configured correctly, and properties like sRGB output on the `#RVDisplayColor` node get activated. However, when you run `File -> Clear`, the C++ `Session::clear()` function destroys and immediately recreates the `Display Group`. The python scripts were failing to track this recreation because of missing event listeners.

When I loaded an MP4 file immediately after clearing the session, the C++ code successfully identified the MP4 as sRGB and enabled the `RVLinearize` step (darkening the image), but the python scripts skipped setting up the `#RVDisplayColor` node. Because `#RVDisplayColor` remained off, the linear image was never lifted back into display color space, rendering it way too dark.

I fixed this by adding an explicit listener for the `after-clear-session` event in both `source_setup.py` and `ocio_source_setup.py`. Now, immediately following a session clear, the internal Python flags are properly reset ensuring that the display color setup happens properly when the next file is loaded. 

Also included a fix for a hardware memory leak.  Every time you open an MP4 and then `File -> Clear`, OpenRV leaks a VideoToolbox hardware decoding session in macOS. Once you hit the macOS limit for concurrent hardware decoder sessions, FFmpeg will silently fail to allocate a new hardware decoder and fall back to the much slower software decoder (libx264).  This fix frees up hardware decoding sessions so they can be available again.

Fixes #1181 
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.