### PR TITLE
fix: Revert fix: Fix crashes when calling sourcesAtFrame when clearing

### DIFF
--- a/src/lib/ip/IPCore/IPCore/Session.h
+++ b/src/lib/ip/IPCore/IPCore/Session.h
@@ -1090,8 +1090,6 @@ namespace IPCore
 
         bool beingDeleted() { return m_beingDeleted; }
 
-        bool beingCleared() { return m_beingCleared; }
-
         void physicalDeviceChanged(const VideoDevice*);
 
     protected:
@@ -1258,7 +1256,6 @@ namespace IPCore
         bool m_audioUnavailble;
         static float m_audioDrift;
         bool m_beingDeleted;
-        bool m_beingCleared{false};
         CacheStats m_cacheStats;
         Time m_syncOffset;
         SyncTimes m_syncTimes;

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -52,7 +52,6 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <boost/scope_exit.hpp>
 #include <iterator>
 
 #ifndef PLATFORM_WINDOWS
@@ -1696,9 +1695,6 @@ namespace IPCore
 
     void Session::clear()
     {
-        m_beingCleared = true;
-        BOOST_SCOPE_EXIT_ALL(&) { m_beingCleared = false; };
-
         if (!m_beingDeleted)
         {
             userGenericEvent("before-clear-session", "");

--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -75,7 +75,6 @@
 #include <half.h>
 #include <iostream>
 #include <iterator>
-#include <optional>
 #include <sstream>
 #include <stl_ext/string_algo.h>
 #include <unordered_set>
@@ -94,27 +93,6 @@ namespace IPMu
 
     typedef Session::PropertyVector PropertyVector;
     typedef TwkApp::EventType::EventInstance Event;
-
-    //----------------------------------------------------------------------
-    //
-    //  Helper function to check if node graph access is safe during
-    //  session clearing/deletion. Returns the provided default value
-    //  if access is unsafe, otherwise returns std::nullopt.
-    //
-    //  Usage:
-    //      if (auto val = returnIfGraphUnsafe(s, Pointer(0))) {
-    //          NODE_RETURN(*val);
-    //      }
-    //      // Continue with normal graph access...
-    //
-    template <typename T> std::optional<T> returnIfGraphUnsafe(Session* session, T defaultValue)
-    {
-        if (session->beingCleared() || session->beingDeleted())
-        {
-            return defaultValue;
-        }
-        return std::nullopt;
-    }
 
     //----------------------------------------------------------------------
 
@@ -581,12 +559,6 @@ namespace IPMu
         StringType::String* leaf = NODE_ARG_OBJECT(2, StringType::String);
         const bool unique = NODE_ARG(3, bool);
 
-        if (auto val = returnIfGraphUnsafe(s, array))
-        {
-            (*val)->resize(0);
-            NODE_RETURN(*val);
-        }
-
         IPNode::MetaEvalInfoVector infos;
         IPNode* rootNode = s->graph().viewNode();
 
@@ -682,12 +654,6 @@ namespace IPMu
         StringType::String* root = NODE_ARG_OBJECT(2, StringType::String);
         const bool unique = NODE_ARG(3, bool);
 
-        if (auto val = returnIfGraphUnsafe(s, array))
-        {
-            (*val)->resize(0);
-            NODE_RETURN(*val);
-        }
-
         IPNode* rootNode = s->graph().root();
 
         if (root)
@@ -762,13 +728,6 @@ namespace IPMu
         int depth = NODE_ARG(1, int);
         StringType::String* root = NODE_ARG_OBJECT(2, StringType::String);
         const Class* atype = static_cast<const Class*>(c->arrayType(c->intType(), 1, 0));
-        DynamicArray* array = new DynamicArray(atype, 1);
-
-        if (auto val = returnIfGraphUnsafe(s, array))
-        {
-            (*val)->resize(0);
-            NODE_RETURN(*val);
-        }
 
         IPNode* rootNode = s->graph().root();
 
@@ -809,6 +768,8 @@ namespace IPMu
         for (size_t i = 0; i < frames.size(); i++)
             frameSet.insert(frames[i]);
 
+        DynamicArray* array = new DynamicArray(atype, 1);
+
         array->resize(frameSet.size());
         size_t count = 0;
 
@@ -831,12 +792,6 @@ namespace IPMu
         StringType::String* root = NODE_ARG_OBJECT(1, StringType::String);
         int depth = NODE_ARG(2, int);
         const StringType* stype = c->stringType();
-
-        if (auto val = returnIfGraphUnsafe(s, array))
-        {
-            (*val)->resize(0);
-            NODE_RETURN(*val);
-        }
 
         IPNode* rootNode = s->graph().root();
 
@@ -1269,16 +1224,9 @@ namespace IPMu
         if (!tname)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil tname");
 
-        DynamicArray* array = new DynamicArray(atype, 1);
-
-        if (auto val = returnIfGraphUnsafe(s, array))
-        {
-            (*val)->resize(0);
-            NODE_RETURN(*val);
-        }
-
         Session::NodeVector nodes;
         s->findCurrentNodesByTypeName(nodes, tname->c_str());
+        DynamicArray* array = new DynamicArray(atype, 1);
         array->resize(nodes.size());
 
         for (int i = 0; i < nodes.size(); i++)
@@ -1301,16 +1249,9 @@ namespace IPMu
         if (!tname)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil tname");
 
-        DynamicArray* array = new DynamicArray(atype, 1);
-
-        if (auto val = returnIfGraphUnsafe(s, array))
-        {
-            (*val)->resize(0);
-            NODE_RETURN(*val);
-        }
-
         Session::NodeVector nodes;
         s->findNodesByTypeName(nodes, tname->c_str());
+        DynamicArray* array = new DynamicArray(atype, 1);
         array->resize(nodes.size());
 
         for (int i = 0; i < nodes.size(); i++)
@@ -1999,12 +1940,6 @@ namespace IPMu
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         const int frame = NODE_ARG(0, int);
         DynamicArray* array = new DynamicArray(atype, 1);
-
-        if (auto val = returnIfGraphUnsafe(s, array))
-        {
-            (*val)->resize(0);
-            NODE_RETURN(*val);
-        }
 
         IPNode::MetaEvalInfoVector infos;
         IPNode::MetaEvalInfoCollectorByType<SourceIPNode> collector(infos);
@@ -3864,12 +3799,6 @@ namespace IPMu
         DynamicArray* array = new DynamicArray(type, 1);
         const StringType* stype = c->stringType();
 
-        if (auto val = returnIfGraphUnsafe(s, array))
-        {
-            (*val)->resize(0);
-            NODE_RETURN(*val);
-        }
-
         const IPGraph::NodeMap& map = s->graph().nodeMap();
 
         array->resize(map.size());
@@ -3894,11 +3823,6 @@ namespace IPMu
 
         if (!node)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil node name");
-
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
-        }
 
         if (IPNode* n = s->graph().findNode(node->c_str()))
         {
@@ -4127,11 +4051,6 @@ namespace IPMu
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "no node name specified");
         }
 
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
-        }
-
         if (IPNode* node = s->graph().findNode(name->c_str()))
         {
             IPNode::IPNodes nodeIns = node->inputs();
@@ -4233,11 +4152,6 @@ namespace IPMu
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "no node name specified");
         }
 
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
-        }
-
         if (IPNode* node = s->graph().findNode(name->c_str()))
         {
             if (GroupIPNode* group = dynamic_cast<GroupIPNode*>(node))
@@ -4295,11 +4209,6 @@ namespace IPMu
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "no node name specified");
         }
 
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
-        }
-
         if (IPNode* node = s->graph().findNode(name->c_str()))
         {
             if (GroupIPNode* group = node->group())
@@ -4322,11 +4231,6 @@ namespace IPMu
         if (!name)
         {
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "no node name specified");
-        }
-
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
         }
 
         if (IPNode* node = s->graph().findNode(name->c_str()))
@@ -4366,11 +4270,6 @@ namespace IPMu
 
         if (!name)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil node name");
-
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
-        }
 
         if (IPNode* node = s->graph().findNode(name->c_str()))
         {
@@ -4416,11 +4315,6 @@ namespace IPMu
 
         if (!name)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil node name");
-
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
-        }
 
         if (IPNode* node = s->graph().findNode(name->c_str()))
         {
@@ -5066,11 +4960,6 @@ namespace IPMu
         if (!name)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil source");
         const StringType* stype = static_cast<const StringType*>(name->type());
-
-        if (auto val = returnIfGraphUnsafe(s, Pointer(0)))
-        {
-            NODE_RETURN(*val);
-        }
 
         // for campatibility with rv, scrub the incoming name
         vector<string> tokens;


### PR DESCRIPTION
### Revert fix: Fix crashes when calling sourcesAtFrame when clearing

### Linked issues
NA

### Summarize your change.

Reverted this commit to fix regression:
https://github.com/AcademySoftwareFoundation/OpenRV/commit/02a537b494ba4862f92750a6cea3a69fcb4f10c8

### Describe the reason for the change.

The commit that is being reverted in this commit caused a regression. The following errors when clearing an RV session:
```
ERROR: event = before-graph-view-change
ERROR: function = __lambdac96 (void; Event event)
ERROR: Exception Value: exception: "nil argument to function"
ERROR: event = after-graph-view-change
ERROR: function = __lambdadd8 (void; Event event)
ERROR: Exception Value: exception: "nil argument to function"
ERROR: event = graph-node-inputs-changed
ERROR: function = __lambdadd9 (void; Event event)
ERROR: Exception Value: exception: "nil argument to function"
Traceback (most recent call last):
 File "/private/var/folders/10/sd1gk1s527bfkdmmlbg7352c0000gn/T/AppTranslocation/919C640B-34AC-4B5F-A9AE-D30F60636CDB/d/RV.app/Contents/PlugIns/Python/source_setup.py", line 505, in checkForDisplayGroup
   if commands.nodeType(event.contents()) == "RVDisplayGroup":
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Exception: Exception thrown while calling commands.nodeType -- exception: "nil argument to function"
Traceback (most recent call last):
 File "/private/var/folders/10/sd1gk1s527bfkdmmlbg7352c0000gn/T/AppTranslocation/919C640B-34AC-4B5F-A9AE-D30F60636CDB/d/RV.app/Contents/PlugIns/Python/source_setup.py", line 505, in checkForDisplayGroup
   if commands.nodeType(event.contents()) == "RVDisplayGroup":
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Exception: Exception thrown while calling commands.nodeType -- exception: "nil argument to function"
```

### Describe what you have tested and on which operating system.
Successfully tested on macOS 

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.