### PR TITLE
feat: SG-42879: Improve realtime playback performance especially with prores

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -673,7 +673,10 @@ namespace TwkMovie
                                                        "wmv3image"sv,
                                                        "xith"sv,
                                                        "xvid"sv,
-                                                       "libdav1d"sv
+                                                       "libdav1d"sv,
+                                                       "prores_aw"sv,
+                                                       "prores_ks"sv,
+                                                       "prores_raw"sv
 #if defined(RV_FFMPEG_USE_VIDEOTOOLBOX)
                                                        ,
                                                        "prores"sv
@@ -1435,6 +1438,7 @@ namespace TwkMovie
 
         // Open the codec
         (*avCodecContext)->thread_count = m_io->codecThreads();
+        (*avCodecContext)->thread_type = FF_THREAD_SLICE;
         if (avcodec_open2(*avCodecContext, avCodec, nullptr) < 0)
         {
             std::cerr << "ERROR: MovieFFMpeg: Failed to open codec '" << avCodec->name << "' for " << m_filename << '\n';


### PR DESCRIPTION
Fixes #1187 

Unable to playback prores files due to a buffer that is unable to keep up.  This PR fixes that so Prores files playback in realtime by adding the filetypes to slowRandomAccessCodecs

Also noticed that FFMpeg buffers internal frames and RV expects to decode one frame synchronously.  FF_THREAD_SLICE exploits multi-core systems and should bring performance improvements.

**Before**
https://github.com/user-attachments/assets/48703ec6-6816-4d4c-aa7c-b6ce420d39af

**After**
https://github.com/user-attachments/assets/2362cff2-35c0-4be9-812b-c097bb59576b

