### PR TITLE
fix: SG-42703: Fix timecode rate detection for MOV-MXF

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -1512,9 +1512,14 @@ namespace TwkMovie
     {
         AVRational tcRate = {tsStream->time_base.den, tsStream->time_base.num};
 
-        if (isMOVformat(formatContext))
+        bool isMxf = formatContext && formatContext->iformat && formatContext->iformat->name
+                     && strstr(formatContext->iformat->name, "mxf") != nullptr;
+        if (isMOVformat(formatContext) || isMxf)
         {
-            tcRate = tsStream->avg_frame_rate;
+            if (tsStream->avg_frame_rate.num > 0 && tsStream->avg_frame_rate.den > 0)
+            {
+                tcRate = tsStream->avg_frame_rate;
+            }
         }
 
         return tcRate;
@@ -1581,7 +1586,11 @@ namespace TwkMovie
                 for (unsigned int s = 0; s < m_avFormatContext->nb_streams; ++s)
                 {
                     AVStream* tsStream = m_avFormatContext->streams[s];
-                    tcRate = getTimecodeRate(tsStream, m_avFormatContext);
+                    if (tsStream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+                    {
+                        tcRate = getTimecodeRate(tsStream, m_avFormatContext);
+                        break;
+                    }
                 }
                 AVTimecode avTimecode;
                 av_timecode_init_from_string(&avTimecode, tcRate, fmtTcEntry->value, m_avFormatContext);


### PR DESCRIPTION
RV was parsing the 48000 Hz Alexa audio tracks as the MXF's master video framerate resulting in bloated frame numbers and what appeared to be frozen/missing frames.  

MovieFFMpegReader::getFirstFrame() attempts to fallback to the format's metadata timecode to calculate the starting frame. To do this, it needs the video framerate (e.g. 23.976), so it loops through all the .mxf track streams sequentially, overwriting the tcRate value each time. Because the alexa MXF metadata places the PCM audio streams at the end (streams 1 through 5 in this case), the fallback logic loops past the video stream and selects the 48000 Hz time-base from the final audio stream.

RV then feeds 48000 into av_timecode_init_from_string(), which throws a framerate warning in my terminal inflated the starting frame that RV requests from the decoder when seeking.

Fixes #1189 

**Before**

https://github.com/user-attachments/assets/7f2cfe00-f988-48ee-b0de-d4c36da1d2b5


**After**

https://github.com/user-attachments/assets/6a94bbda-09fe-49ff-9653-381697bdf821

