### PR TITLE
SG-41979: Add hotkey and env var for no seq formation during drag and drop

### DIFF
--- a/src/lib/app/RvApp/RvSession.cpp
+++ b/src/lib/app/RvApp/RvSession.cpp
@@ -674,6 +674,8 @@ namespace Rv
 
         int nexisting = sources().size();
 
+        bool noSeq = (tag == "drop-no-sequence") || m_noSequences;
+
         //
         //  NOTE: the exception is created but will not be used unless an
         //  error occurs. Each round of reading results in another line of
@@ -691,7 +693,7 @@ namespace Rv
             {
                 if (m_loadState)
                     cerr << "ERROR: already have load state!\n" << endl;
-                m_loadState = new LoadState(this, insources, m_noSequences,
+                m_loadState = new LoadState(this, insources, noSeq,
                                             doProcessOpts, merge, tag);
 
                 if (m_loadState->loadTotal() > 1)
@@ -719,8 +721,8 @@ namespace Rv
                 Options::SourceArgs& sargs = insources[q];
                 const Options::Files& files = sargs.files;
                 SequenceNameList inputPatterns = sequencesInFileList(
-                    files, m_noSequences ? FalseSequencePredicate
-                                         : GlobalExtensionPredicate);
+                    files,
+                    noSeq ? FalseSequencePredicate : GlobalExtensionPredicate);
 
                 for (int i = 0; i < inputPatterns.size(); i++)
                 {

--- a/src/lib/app/RvCommon/QTTranslator.cpp
+++ b/src/lib/app/RvCommon/QTTranslator.cpp
@@ -944,6 +944,9 @@ namespace Rv
         }
 #endif
 
+            Qt::KeyboardModifiers dropEventModifiers =
+                devent->keyboardModifiers();
+
             if (devent->mimeData()->hasUrls())
             {
                 QList<QUrl> urls = devent->mimeData()->urls();
@@ -988,12 +991,19 @@ namespace Rv
                     seqs = files;
                 }
                 else
-                    seqs = sequencesInFileList(files, GlobalExtensionPredicate);
+                {
+                    SequencePredicate pred =
+                        (dropEventModifiers & Qt::AltModifier)
+                            ? FalseSequencePredicate
+                            : GlobalExtensionPredicate;
+                    seqs = sequencesInFileList(files, pred);
+                }
 
+                unsigned int dropMods = modifiers(dropEventModifiers);
                 for (int i = 0; i < seqs.size(); i++)
                 {
                     DragDropEvent e(ename, m_node, type, DragDropEvent::File,
-                                    seqs[i], 0, devent->pos().x(),
+                                    seqs[i], dropMods, devent->pos().x(),
                                     h - devent->pos().y() - 1, w, h);
 
                     sendEvent(e);
@@ -1004,7 +1014,7 @@ namespace Rv
                 for (int i = 0; i < nonfiles.size(); i++)
                 {
                     DragDropEvent e(ename, m_node, type, DragDropEvent::URL,
-                                    nonfiles[i], 0, devent->pos().x(),
+                                    nonfiles[i], dropMods, devent->pos().x(),
                                     h - devent->pos().y() - 1, w, h);
 
                     sendEvent(e);
@@ -1016,8 +1026,9 @@ namespace Rv
             {
                 DragDropEvent e(ename, m_node, type, DragDropEvent::Text,
                                 devent->mimeData()->text().toUtf8().constData(),
-                                0, devent->pos().x(), h - devent->pos().y() - 1,
-                                w, h);
+                                modifiers(dropEventModifiers),
+                                devent->pos().x(), h - devent->pos().y() - 1, w,
+                                h);
 
                 sendEvent(e);
                 if (e.handled)

--- a/src/lib/app/mu_rvui/rvtypes.mu
+++ b/src/lib/app/mu_rvui/rvtypes.mu
@@ -658,6 +658,7 @@ class: State
     bool            ddProgressiveDrop;
     string[]        ddDropFiles;
     object          ddDropTimer;
+    bool            ddNoSequence;
 
     float           lastPixelBlockTime;
 

--- a/src/lib/app/mu_rvui/rvui.mu
+++ b/src/lib/app/mu_rvui/rvui.mu
@@ -3236,9 +3236,11 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
 {
     State state = data();
     state.dragDropOccuring = false;
+    state.ddNoSequence = (event.modifiers() & Event.Alt) != 0;
     recordPixelInfo(event);
 
     let kind = event.contentType(),
+        tag = if state.ddNoSequence then "drop-no-sequence" else "drop",
         F    = if state.ddDropFunc eq nil 
                     then ddNoop(0,)
                     else state.ddDropFunc(state.ddRegion,);
@@ -3248,7 +3250,7 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
         let root = string.split(file, "/").back(),
             ext  = string.split(root, ".").back(),
             f    = frameEnd(),
-            F    = if Fin eq nil then (\: (void; string s) { addSources(string[] {s},"drop"); }) else Fin;
+            F    = if Fin eq nil then (\: (void; string s) { addSources(string[] {s}, tag); }) else Fin;
 
         try
         {
@@ -3280,7 +3282,7 @@ global let enterFrame = startTextEntryMode(\: (string;) {"Go To Frame: ";}, goto
             qt.QTimer dt = state.ddDropTimer;
             dt.start();
         }
-        else loadFile(filepath, F);
+        else loadFile(filepath, if state.ddRegion == 1 then (\: (void; string s) { addSources(string[] {s}, tag); }) else F);
     }
     else if (kind == Event.URLObject ||
              kind == Event.TextObject)  //  Chrome URL drops come accross as "Text"
@@ -6974,7 +6976,8 @@ global bool debugGC = false;
     state.ddDropFiles.clear();
     state.ddProgressiveDrop = false;
 
-    addSources(myFiles, "drop");
+    let tag = if state.ddNoSequence then "drop-no-sequence" else "drop";
+    addSources(myFiles, tag);
 }
 
 
@@ -7085,6 +7088,7 @@ global bool debugGC = false;
 
     s.ddDropFiles = string[]();
     s.ddProgressiveDrop = false;
+    s.ddNoSequence = false;
 
     s.quitConfirmMessages = (string,string)[]();
     s.savedInOut = int[]();

--- a/src/lib/base/TwkUtil/CMakeLists.txt
+++ b/src/lib/base/TwkUtil/CMakeLists.txt
@@ -88,6 +88,13 @@ IF(RV_TARGET_LINUX)
   )
 ENDIF()
 
+IF(RV_TARGET_IS_RHEL8)
+  TARGET_LINK_LIBRARIES(
+    ${_target}
+    PRIVATE stdc++fs
+  )
+ENDIF()
+
 IF(RV_TARGET_WINDOWS)
   TARGET_LINK_LIBRARIES(
     ${_target}

--- a/src/lib/base/TwkUtil/FrameUtils.cpp
+++ b/src/lib/base/TwkUtil/FrameUtils.cpp
@@ -9,10 +9,12 @@
 #include <TwkUtil/TwkRegEx.h>
 #include <TwkUtil/File.h>
 #include <TwkUtil/PathConform.h>
+#include <filesystem>
 #include <stl_ext/string_algo.h>
 #include <limits.h>
 #include <stdio.h>
 #include <list>
+#include <memory>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -274,6 +276,8 @@ struct LexinumericCompare
     }
 
     static int defaultMinSequenceSize = -2;
+    static string cachedNoSequencePattern;
+    static unique_ptr<RegEx> noSequencePatternRe;
 
     SequenceNameList sequencesInFileList(const FileNameList& infiles,
                                          SequencePredicate P,
@@ -299,6 +303,31 @@ struct LexinumericCompare
         }
         if (minSequenceSize == -1)
             minSequenceSize = defaultMinSequenceSize;
+
+        const char* envVar = getenv("RV_NO_SEQUENCE_PATTERN");
+        if (envVar && *envVar)
+        {
+            if (cachedNoSequencePattern != envVar)
+            {
+                cachedNoSequencePattern = envVar;
+                try
+                {
+                    noSequencePatternRe = make_unique<RegEx>(envVar);
+                }
+                catch (const RegEx::Exception& e)
+                {
+                    cerr
+                        << "Warning: Invalid regex for RV_NO_SEQUENCE_PATTERN: "
+                        << e.what() << '\n';
+                    noSequencePatternRe.reset();
+                }
+            }
+        }
+        else
+        {
+            cachedNoSequencePattern.clear();
+            noSequencePatternRe.reset();
+        }
 
         //
         //  NOTE: this function needs to maintain as much order as
@@ -328,6 +357,22 @@ struct LexinumericCompare
                 frameSequences.push_back(f);
                 allfiles.pop_front();
                 continue;
+            }
+
+            // Apply pattern to basename only,
+            // so names like ^thumbnail or ^\. match the file name, not the
+            // path.
+            if (noSequencePatternRe)
+            {
+                const string nameForPattern =
+                    filesystem::path(f).filename().string();
+
+                if (noSequencePatternRe->matches(nameForPattern))
+                {
+                    frameSequences.push_back(f);
+                    allfiles.pop_front();
+                    continue;
+                }
             }
 
             //


### PR DESCRIPTION
Note: This is a cherry pick from the main branch

### **[SG-41979](https://jira.autodesk.com/browse/SG-41979): [RV] Add alt/option hotkey and env var with a pattern to prevent RV from loading images as an image sequence**

### Summarize your change.

Added an Alt/Option hotkey for drag-and-drop: holding Alt while dropping files prevents sequence formation so each file is added as its own source. Modifier is read in QTTranslator, the Mu layer passes a "drop-no-sequence" tag into addSources, RvSession uses that tag so LoadState and the non-delayed path do not re-group.

Added RV_NO_SEQUENCE_PATTERN that can be set using export RV_NO_SEQUENCE_PATTERN="wanted_pattern". When set to a regex, matching file names are not grouped into sequences.

### Describe the reason for the change.

The previous env substring (RV_NO_SEQUENCE_SUBSTRING) did not meet the client’s needs. They wanted a hotkey so they can have more control over sequence formation.

The client wanted something more powerful than the previous substring approach and suggested using RegEx instead.

### Describe what you have tested and on which operating system.

The hotkey was tested on macOS by holding down the Option key and verifying that no sequence would form during a drag and drop of files.

https://github.com/user-attachments/assets/edb60953-b6b6-4a65-a687-e2d4357600ef

The RegEx was tested on macOS by setting the environment variable by using export RV_NO_SEQUENCE_PATTERN="_[vV][0-9]+\.jpg$"

https://github.com/user-attachments/assets/c81ecac9-82c0-453d-8931-e068e36d3ed6