### PR TITLE
feat: SG-27382: Add 12G SDI single-link support for the AJA Kona 5 card

### DIFF
--- a/src/plugins/output/AJADevices/AJADevices/KonaVideoDevice.h
+++ b/src/plugins/output/AJADevices/AJADevices/KonaVideoDevice.h
@@ -69,9 +69,11 @@ namespace AJADevices
         ThreeG = 1 << 3,
         LegalRangeY = 1 << 4,
         FullRangeY = 1 << 5,
+        TwelveG = 1 << 6,
 
         RGB_3G = RGB444 | P2P | ThreeG,
         RGB_DualLink = RGB444 | P2P | DualLink,
+        YUV_6G = P2P | TwelveG,
     };
 
     struct KonaDataFormat
@@ -418,6 +420,7 @@ namespace AJADevices
         void routeQuadRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeStereoRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeMonoRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
+        void route12GSingleLinkYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeQuadYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeStereoYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeMonoYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
@@ -448,7 +451,7 @@ namespace AJADevices
         size_t m_deviceNumVideoOutputs{0};
         size_t m_deviceNumVideoChannels{};
         bool m_deviceHasDualLink{false};
-        bool m_deviceHas3G{false};
+        bool m_deviceHas12G{false};
         ULWord m_deviceHDMIVersion{0};
         bool m_deviceHasHDMIStereo{false};
         bool m_deviceHas4KDownConverter{false};
@@ -467,6 +470,7 @@ namespace AJADevices
         bool m_3G{false};
         bool m_3GB{false};
         bool m_dualLink{false};
+        bool m_12G{false};
         bool m_yuvInternalFormat{false};
         bool m_allowSegmentedTransfer{false};
         bool m_simpleRouting{false};

--- a/src/plugins/output/AJADevices/AJADevices/KonaVideoDevice.h
+++ b/src/plugins/output/AJADevices/AJADevices/KonaVideoDevice.h
@@ -74,6 +74,7 @@ namespace AJADevices
         RGB_3G = RGB444 | P2P | ThreeG,
         RGB_DualLink = RGB444 | P2P | DualLink,
         YUV_12G = P2P | TwelveG,
+        RGB_12G = RGB444 | P2P | TwelveG,
     };
 
     struct KonaDataFormat
@@ -421,6 +422,7 @@ namespace AJADevices
         void routeStereoRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeMonoRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void route12GSingleLinkYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
+        void route12GSingleLinkRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeQuadYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeStereoYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);
         void routeMonoYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d);

--- a/src/plugins/output/AJADevices/AJADevices/KonaVideoDevice.h
+++ b/src/plugins/output/AJADevices/AJADevices/KonaVideoDevice.h
@@ -73,7 +73,7 @@ namespace AJADevices
 
         RGB_3G = RGB444 | P2P | ThreeG,
         RGB_DualLink = RGB444 | P2P | DualLink,
-        YUV_6G = P2P | TwelveG,
+        YUV_12G = P2P | TwelveG,
     };
 
     struct KonaDataFormat

--- a/src/plugins/output/AJADevices/KonaVideoDevice.cpp
+++ b/src/plugins/output/AJADevices/KonaVideoDevice.cpp
@@ -270,6 +270,9 @@ namespace AJADevices
             {"10 Bit Dual Link RGB", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, RGB_DualLink},
             {"12 Bit Dual Link RGB", NTV2_FBF_48BIT_RGB, VideoDevice::RGB16, RGB_DualLink},
 
+            // 6G Single-link YCbCr formats (12G-capable port on SDI Out 3)
+            {"10 Bit 6G Single-Link YCrCb 4:2:2 (SDI Out 3)", NTV2_FBF_10BIT_YCBCR, VideoDevice::YCrCb_AJA_10_422, YUV_6G},
+
             // Stereo
             // {"Stereo Dual 10 Bit YCrCb 4:2:2 (8 bit internal)",
             // NTV2_FBF_24BIT_RGB, VideoDevice::RGB8, P2P},
@@ -580,7 +583,9 @@ namespace AJADevices
             m_deviceNumVideoOutputs = NTV2DeviceGetNumVideoOutputs(m_deviceID);
             m_deviceNumVideoChannels = NTV2DeviceGetNumVideoChannels(m_deviceID);
             m_deviceHasDualLink = NTV2DeviceCanDoDualLink(m_deviceID);
-            m_deviceHas3G = NTV2DeviceCanDo3GOut(m_deviceID, 0);
+            m_deviceHas12G = m_card->features().CanDoWidget(
+                NTV2WidgetType_SDIOut12G, 2); // Kona 5 only supports 12G SDI single-link on port 3 with the retail firmware, to be
+                                              // refactored later when the ports to use will be configurable
             m_deviceHDMIVersion = NTV2DeviceGetHDMIVersion(m_deviceID);
             m_deviceHasHDMIStereo = NTV2DeviceCanDoHDMIOutStereo(m_deviceID);
             m_deviceHasCSC = NTV2DeviceCanDoWidget(m_deviceID, NTV2_WgtCSC1);
@@ -608,10 +613,13 @@ namespace AJADevices
                         bool stereoFormat = p->desc.find("Stereo") != string::npos;
                         bool dualLink = p->flags & DualLink;
                         bool rgb = p->flags & RGB444;
+                        bool twelveG = p->flags & TwelveG;
 
                         if (stereoFormat && !stereo)
                             continue;
                         if (dualLink && !m_deviceHasDualLink)
+                            continue;
+                        if (twelveG && !m_deviceHas12G)
                             continue;
                         if (!rgb && !m_deviceHasCSC)
                             continue;
@@ -1041,6 +1049,7 @@ namespace AJADevices
             m_3G = (d.flags & ThreeG) || NTV2_IS_3G_FORMAT(f.value);
             m_3GB = (m_3GA ? false : ((d.flags & ThreeG) || IsVideoFormatB(f.value)) && !IsVideoFormatA(f.value));
             m_dualLink = d.flags & DualLink;
+            m_12G = d.flags & TwelveG;
             m_channels = channelsFromFormat(d.value);
             m_quad = NTV2_IS_QUAD_FRAME_FORMAT(f.value);
             m_quadQuad = NTV2_IS_QUAD_QUAD_FORMAT(f.value);
@@ -1056,6 +1065,7 @@ namespace AJADevices
                 cout << "INFO: KONA enable 3GA = " << (int)m_3GA << endl;
                 cout << "INFO: KONA enable 3G = " << (int)m_3G << endl;
                 cout << "INFO: KONA enable 3GB = " << (int)m_3GB << endl;
+                cout << "INFO: KONA enable 12G = " << (int)m_12G << endl;
             }
 
             NTV2VideoLimiting limiting = rgb ? NTV2_VIDEOLIMITING_LEGALSDI : NTV2_VIDEOLIMITING_LEGALBROADCAST;
@@ -1187,7 +1197,19 @@ namespace AJADevices
                 if (numFrameStores >= 2)
                     m_card->EnableChannel(NTV2_CHANNEL2);
 
-                if (tsiEnabled())
+                if (m_12G)
+                {
+                    // 12G single-link always uses TSI regardless of the 4K transport setting.
+                    // YUV needs CH3+CH4 and RGB needs CH1+CH2 (already enabled above).
+                    if (!rgb)
+                    {
+                        m_card->DisableChannel(NTV2_CHANNEL1);
+                        m_card->DisableChannel(NTV2_CHANNEL2);
+                        m_card->EnableChannel(NTV2_CHANNEL3);
+                        m_card->EnableChannel(NTV2_CHANNEL4);
+                    }
+                }
+                else if (tsiEnabled())
                 {
                     if (numFrameStores >= 3)
                         m_card->DisableChannel(NTV2_CHANNEL3);
@@ -1209,25 +1231,52 @@ namespace AJADevices
 
                 AJA_CHECK(m_card->SetVideoFormat(f.value));
 
-                AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL1, d.value));
-                AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL2, d.value));
-
-                if (m_quad || m_quadQuad)
+                if (m_12G)
                 {
-                    AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL3, d.value));
-                    AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL4, d.value));
+                    // YUV 6G: framestores 3+4 (feeds TSI Mux 3+4 → SDIOut3 via 6G link grouping)
+                    // RGB 12G: framestores 1+2 (feeds TSI Mux 1+2 → DLOut → SDIOut3 via 12G link grouping)
+                    if (rgb)
+                    {
+                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL1, d.value));
+                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL2, d.value));
+                    }
+                    else
+                    {
+                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL3, d.value));
+                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL4, d.value));
+                    }
+                }
+                else
+                {
+                    AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL1, d.value));
+                    AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL2, d.value));
+
+                    if (m_quad || m_quadQuad)
+                    {
+                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL3, d.value));
+                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL4, d.value));
+                    }
                 }
 
-                if (m_quad || m_quadQuad)
+                if (m_12G)
+                    m_channelVector.resize(1);
+                else if (m_quad || m_quadQuad)
                     m_channelVector.resize(4);
                 else if (m_stereo)
                     m_channelVector.resize(2);
                 else
                     m_channelVector.resize(1);
 
-                for (unsigned int i = 0; i < m_channelVector.size(); i++)
+                if (m_12G)
                 {
-                    m_channelVector[i] = (NTV2Channel)(i + NTV2_CHANNEL1);
+                    m_channelVector[0] = rgb ? NTV2_CHANNEL1 : NTV2_CHANNEL3;
+                }
+                else
+                {
+                    for (unsigned int i = 0; i < m_channelVector.size(); i++)
+                    {
+                        m_channelVector[i] = (NTV2Channel)(i + NTV2_CHANNEL1);
+                    }
                 }
 
                 AJA_CHECK(m_card->SetReference(NTV2_REFERENCE_FREERUN));
@@ -1256,13 +1305,16 @@ namespace AJADevices
                     }
                 }
 
-                m_card->SetSDITransmitEnable(NTV2_CHANNEL1, true);
-                m_card->SetSDITransmitEnable(NTV2_CHANNEL2, true);
-
-                if (m_quad || m_quadQuad)
+                if (!m_12G)
                 {
-                    m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
-                    m_card->SetSDITransmitEnable(NTV2_CHANNEL4, true);
+                    m_card->SetSDITransmitEnable(NTV2_CHANNEL1, true);
+                    m_card->SetSDITransmitEnable(NTV2_CHANNEL2, true);
+
+                    if (m_quad || m_quadQuad)
+                    {
+                        m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
+                        m_card->SetSDITransmitEnable(NTV2_CHANNEL4, true);
+                    }
                 }
 
                 const bool needRGBLevelAConversion = (rgb & m_3GA);
@@ -1330,6 +1382,10 @@ namespace AJADevices
                         routeMonoRGB(standard, f, d);
                     }
                 }
+                else if (m_12G)
+                {
+                    route12GSingleLinkYUV(standard, f, d);
+                }
                 else if (m_quad || m_quadQuad)
                 {
                     routeQuadYUV(standard, f, d);
@@ -1361,7 +1417,7 @@ namespace AJADevices
                     AJA_CHECK(m_card->SetColorSpaceMatrixSelect(m, NTV2_CHANNEL1));
                     AJA_CHECK(m_card->SetColorSpaceMatrixSelect(m, NTV2_CHANNEL2));
 
-                    if (m_quad || m_quadQuad)
+                    if (m_quad || m_quadQuad || m_12G)
                     {
                         AJA_CHECK(m_card->SetColorSpaceMatrixSelect(m, NTV2_CHANNEL3));
                         AJA_CHECK(m_card->SetColorSpaceMatrixSelect(m, NTV2_CHANNEL4));
@@ -1380,7 +1436,7 @@ namespace AJADevices
                     AJA_CHECK(m_card->SetColorSpaceRGBBlackRange(range, NTV2_CHANNEL1));
                     AJA_CHECK(m_card->SetColorSpaceRGBBlackRange(range, NTV2_CHANNEL2));
 
-                    if (m_quad || m_quadQuad)
+                    if (m_quad || m_quadQuad || m_12G)
                     {
                         AJA_CHECK(m_card->SetColorSpaceRGBBlackRange(range, NTV2_CHANNEL3));
                         AJA_CHECK(m_card->SetColorSpaceRGBBlackRange(range, NTV2_CHANNEL4));
@@ -1551,11 +1607,25 @@ namespace AJADevices
             }
             if (ok)
             {
-                AJA_CHECK(m_card->AutoCirculateFlush(NTV2_CHANNEL1));
+                if (m_12G)
+                {
+                    AJA_CHECK(m_card->AutoCirculateFlush(m_videoChannels[0]->channel));
+                }
+                else
+                {
+                    AJA_CHECK(m_card->AutoCirculateFlush(NTV2_CHANNEL1));
+                }
 
                 if (m_stereo)
                 {
-                    AJA_CHECK(m_card->AutoCirculateFlush(NTV2_CHANNEL2));
+                    if (m_12G)
+                    {
+                        AJA_CHECK(m_card->AutoCirculateFlush(m_videoChannels[1]->channel));
+                    }
+                    else
+                    {
+                        AJA_CHECK(m_card->AutoCirculateFlush(NTV2_CHANNEL2));
+                    }
                 }
             }
         }
@@ -1878,6 +1948,58 @@ namespace AJADevices
             m_card->Connect(NTV2_XptSDIOut5Input, NTV2_XptDuallinkOut1);
             m_card->Connect(NTV2_XptSDIOut5InputDS2, NTV2_XptDuallinkOut1DS2);
         }
+    }
+
+    void KonaVideoDevice::route12GSingleLinkYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
+    {
+        if (m_infoFeedback)
+            cout << "INFO: KONA 6G single-link YCbCr format (port 3)" << endl;
+
+        //
+        //  6G single-link YCbCr output on Kona 5 port 3 (NTV2_CHANNEL3) with the retail firmware.
+        //
+        //  Two framestores feed a TSI mux which interleaves their samples into
+        //  a single 4K YCbCr stream output over the 12G-capable SDIOut3 port at 6G:
+        //
+        //      FB3(YUV) + FB4(YUV) -> TSI Mux 3+4 -> SDIOut3 (6G, DS1+DS2)
+        //
+
+        ULWord vpidA;
+        CNTV2VPID::SetVPIDData(vpidA, f.value, d.value, false, false, VPIDChannel_3);
+
+        // Disable 6G/12G on SDIOut3 before configuring
+        m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, false);
+        m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, false);
+
+        m_card->SetSDITransmitEnable(NTV2_CHANNEL1, false);
+        m_card->SetSDITransmitEnable(NTV2_CHANNEL2, false);
+        m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
+        m_card->SetSDITransmitEnable(NTV2_CHANNEL4, false);
+
+        m_card->SetSDIOutputStandard(NTV2_CHANNEL3, standard);
+        m_card->SetMode(NTV2_CHANNEL3, NTV2_MODE_DISPLAY);
+        m_card->SetMode(NTV2_CHANNEL4, NTV2_MODE_DISPLAY);
+
+        m_card->SetTsiFrameEnable(true, NTV2_CHANNEL3);
+
+        m_card->SubscribeOutputVerticalEvent(NTV2_CHANNEL3);
+
+        m_card->SetSDIOutVPID(vpidA, 0, NTV2_CHANNEL3);
+
+        // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4
+        m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3YUV);
+        m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2YUV);
+        m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4YUV);
+        m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2YUV);
+
+        // TSI Mux 3 + TSI Mux 4 -> SDIOut3
+        m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux3AYUV);
+        m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_Xpt425Mux3BYUV);
+        m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4AYUV);
+        m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_Xpt425Mux4BYUV);
+
+        // Re-enable 6G after routing is configured
+        m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, true);
     }
 
     void KonaVideoDevice::routeQuadYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
@@ -2604,7 +2726,7 @@ namespace AJADevices
 
                     if (rcount >= m_highwater && !m_autocirculateRunning)
                     {
-                        AJA_CHECK(m_card->AutoCirculateStart(NTV2_CHANNEL1));
+                        AJA_CHECK(m_card->AutoCirculateStart((m_12G && m_yuvInternalFormat) ? NTV2_CHANNEL3 : NTV2_CHANNEL1));
 
                         if (doingStereo)
                         {
@@ -2833,7 +2955,7 @@ namespace AJADevices
 
             if (!wrote)
             {
-                AJA_CHECK(m_card->WaitForOutputVerticalInterrupt(NTV2_CHANNEL1)); // XXX best guess
+                AJA_CHECK(m_card->WaitForOutputVerticalInterrupt((m_12G && m_yuvInternalFormat) ? NTV2_CHANNEL3 : NTV2_CHANNEL1));
                 vi--;
             }
         }

--- a/src/plugins/output/AJADevices/KonaVideoDevice.cpp
+++ b/src/plugins/output/AJADevices/KonaVideoDevice.cpp
@@ -271,7 +271,7 @@ namespace AJADevices
             {"12 Bit Dual Link RGB", NTV2_FBF_48BIT_RGB, VideoDevice::RGB16, RGB_DualLink},
 
             // 6G/12G Single-link YCbCr formats
-            {"10 Bit 12G Single-Link YCrCb 4:2:2 (SDI Out 3)", NTV2_FBF_10BIT_YCBCR, VideoDevice::YCrCb_AJA_10_422, YUV_12G},
+            {"10 Bit 12G Single-Link YCrCb 4:2:2 (SDI Out 3)", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, YUV_12G},
 
             // 12G Single-link RGB formats
             {"10 Bit 12G Single-Link RGB (SDI Out 3)", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, RGB_12G},
@@ -1971,14 +1971,12 @@ namespace AJADevices
         //
         //  Single-link YCbCr output on Kona 5 port 3 (NTV2_CHANNEL3) with the retail firmware.
         //
-        //  Two framestores feed a TSI mux which interleaves their samples into
-        //  a single 4K YCbCr stream on the 12G-capable SDIOut3 port:
         //
-        //  6G (non-HFR, <=30fps):
-        //      FB3(YUV) + FB4(YUV) -> TSI Mux 3+4 -> SDIOut3 DS1+DS2 / SDIOut4 DS1+DS2 (6G)
+        //  6G:
+        //      FB3 + FB4 -> TSI Mux 3 + TSI Mux 4 -> CSC3 + CSC4 -> SDIOut3 + SDIOut4
         //
-        //  12G (HFR, >=47.95fps):
-        //      FB3(YUV) + FB4(YUV) -> TSI Mux 3+4 -> SDIOut1+2+3+4 (12G link group)
+        //  12G:
+        //      FB3 + FB4 -> TSI Mux 3 + TSI Mux 4 -> CSC31 + CSC2 + CSC3 + CSC4 -> SDIOut1 + SDIOut2 + SDIOut3 + SDIOut4
         //
 
         if (m_infoFeedback)
@@ -2002,64 +2000,32 @@ namespace AJADevices
         m_card->SetSDIOutVPID(vpidA, 0, NTV2_CHANNEL3);
 
         // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4
-        if (m_yuvInternalFormat)
-        {
-            m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3YUV);
-            m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2YUV);
-            m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4YUV);
-            m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2YUV);
-        }
-        else
-        {
-            // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4 -> CSC3 + CSC4
-            m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3RGB);
-            m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2RGB);
-            m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4RGB);
-            m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2RGB);
+        m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3RGB);
+        m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2RGB);
+        m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4RGB);
+        m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2RGB);
 
-            m_card->Connect(NTV2_XptCSC1VidInput, NTV2_Xpt425Mux3ARGB);
-            m_card->Connect(NTV2_XptCSC2VidInput, NTV2_Xpt425Mux3BRGB);
-            m_card->Connect(NTV2_XptCSC3VidInput, NTV2_Xpt425Mux4ARGB);
-            m_card->Connect(NTV2_XptCSC4VidInput, NTV2_Xpt425Mux4BRGB);
-        }
+        // TSI Mux 3 + TSI Mux 4 -> CSC1 + CSC2 + CSC3 + CSC4
+        m_card->Connect(NTV2_XptCSC1VidInput, NTV2_Xpt425Mux3ARGB);
+        m_card->Connect(NTV2_XptCSC2VidInput, NTV2_Xpt425Mux3BRGB);
+        m_card->Connect(NTV2_XptCSC3VidInput, NTV2_Xpt425Mux4ARGB);
+        m_card->Connect(NTV2_XptCSC4VidInput, NTV2_Xpt425Mux4BRGB);
 
         if (NTV2_IS_4K_HFR_VIDEO_FORMAT(f.value))
         {
-            // 12G: TSI Mux 3 + TSI Mux 4 -> SDIOut1 + SDIOut2 + SDIOut3 + SDIOut4
-            if (m_yuvInternalFormat)
-            {
-                m_card->Connect(NTV2_XptSDIOut1Input, NTV2_Xpt425Mux3AYUV);
-                m_card->Connect(NTV2_XptSDIOut2Input, NTV2_Xpt425Mux3BYUV);
-                m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux4AYUV);
-                m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4BYUV);
-            }
-            else
-            {
-                m_card->Connect(NTV2_XptSDIOut1Input, NTV2_XptCSC1VidYUV);
-                m_card->Connect(NTV2_XptSDIOut2Input, NTV2_XptCSC2VidYUV);
-                m_card->Connect(NTV2_XptSDIOut3Input, NTV2_XptCSC3VidYUV);
-                m_card->Connect(NTV2_XptSDIOut4Input, NTV2_XptCSC4VidYUV);
-            }
+            m_card->Connect(NTV2_XptSDIOut1Input, NTV2_XptCSC1VidYUV);
+            m_card->Connect(NTV2_XptSDIOut2Input, NTV2_XptCSC2VidYUV);
+            m_card->Connect(NTV2_XptSDIOut3Input, NTV2_XptCSC3VidYUV);
+            m_card->Connect(NTV2_XptSDIOut4Input, NTV2_XptCSC4VidYUV);
 
             m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, true);
         }
         else
         {
-            // 6G: TSI Mux 3 + TSI Mux 4 -> SDIOut3 + SDIOut4
-            if (m_yuvInternalFormat)
-            {
-                m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux3AYUV);
-                m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_Xpt425Mux3BYUV);
-                m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4AYUV);
-                m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_Xpt425Mux4BYUV);
-            }
-            else
-            {
-                m_card->Connect(NTV2_XptSDIOut3Input, NTV2_XptCSC1VidYUV);
-                m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_XptCSC2VidYUV);
-                m_card->Connect(NTV2_XptSDIOut4Input, NTV2_XptCSC3VidYUV);
-                m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_XptCSC4VidYUV);
-            }
+            m_card->Connect(NTV2_XptSDIOut3Input, NTV2_XptCSC1VidYUV);
+            m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_XptCSC2VidYUV);
+            m_card->Connect(NTV2_XptSDIOut4Input, NTV2_XptCSC3VidYUV);
+            m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_XptCSC4VidYUV);
 
             m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, true);
         }
@@ -2072,11 +2038,8 @@ namespace AJADevices
         //
         //  Single-link RGB output on Kona 5 port 3 (NTV2_CHANNEL3) with the retail firmware.
         //
-        //  RGB requires DualLink encoding (the 12G transmitter multiplexes two DL streams onto
-        //  a single 12G cable). This saturates 12G bandwidth at non-HFR rates, so HFR is not
-        //  supported for this path.
         //
-        //  FB1(RGB) + FB2(RGB) -> TSI Mux 1+2 -> DLOut 1-4 -> SDIOut 1-4 -> 12G link group (SDIOut3)
+        //  FB1(RGB) + FB2(RGB) -> TSI Mux 1 + TSI Mux 2 -> DLOut1 + DLOut2 + DLOut3 + DLOut4 -> SDIOut1 + SDIOut2 + SDIOut3 + SDIOut4
         //
 
         if (m_infoFeedback)
@@ -2099,39 +2062,18 @@ namespace AJADevices
 
         m_card->SetSDIOutVPID(vpidA, 0, NTV2_CHANNEL3);
 
-        // FS1 + FS2 -> TSI Mux 1+2 -> DLOut 1-4
-        // When the internal format is YUV, a CSC converts YUV -> RGB before the DLOut.
-        if (m_yuvInternalFormat)
-        {
-            m_card->Connect(NTV2_Xpt425Mux1AInput, NTV2_XptFrameBuffer1YUV);
-            m_card->Connect(NTV2_Xpt425Mux1BInput, NTV2_XptFrameBuffer1_DS2YUV);
-            m_card->Connect(NTV2_Xpt425Mux2AInput, NTV2_XptFrameBuffer2YUV);
-            m_card->Connect(NTV2_Xpt425Mux2BInput, NTV2_XptFrameBuffer2_DS2YUV);
+        // FS1 + FS2 -> TSI Mux 1 + TSI Mux 2 -> DLOut1 + DLOut2 + DLOut3 + DLOut4
+        m_card->Connect(NTV2_Xpt425Mux1AInput, NTV2_XptFrameBuffer1RGB);
+        m_card->Connect(NTV2_Xpt425Mux1BInput, NTV2_XptFrameBuffer1_DS2RGB);
+        m_card->Connect(NTV2_Xpt425Mux2AInput, NTV2_XptFrameBuffer2RGB);
+        m_card->Connect(NTV2_Xpt425Mux2BInput, NTV2_XptFrameBuffer2_DS2RGB);
 
-            m_card->Connect(NTV2_XptCSC1VidInput, NTV2_Xpt425Mux1AYUV);
-            m_card->Connect(NTV2_XptCSC2VidInput, NTV2_Xpt425Mux1BYUV);
-            m_card->Connect(NTV2_XptCSC3VidInput, NTV2_Xpt425Mux2AYUV);
-            m_card->Connect(NTV2_XptCSC4VidInput, NTV2_Xpt425Mux2BYUV);
+        m_card->Connect(NTV2_XptDualLinkOut1Input, NTV2_Xpt425Mux1ARGB);
+        m_card->Connect(NTV2_XptDualLinkOut2Input, NTV2_Xpt425Mux1BRGB);
+        m_card->Connect(NTV2_XptDualLinkOut3Input, NTV2_Xpt425Mux2ARGB);
+        m_card->Connect(NTV2_XptDualLinkOut4Input, NTV2_Xpt425Mux2BRGB);
 
-            m_card->Connect(NTV2_XptDualLinkOut1Input, NTV2_XptCSC1VidRGB);
-            m_card->Connect(NTV2_XptDualLinkOut2Input, NTV2_XptCSC2VidRGB);
-            m_card->Connect(NTV2_XptDualLinkOut3Input, NTV2_XptCSC3VidRGB);
-            m_card->Connect(NTV2_XptDualLinkOut4Input, NTV2_XptCSC4VidRGB);
-        }
-        else
-        {
-            m_card->Connect(NTV2_Xpt425Mux1AInput, NTV2_XptFrameBuffer1RGB);
-            m_card->Connect(NTV2_Xpt425Mux1BInput, NTV2_XptFrameBuffer1_DS2RGB);
-            m_card->Connect(NTV2_Xpt425Mux2AInput, NTV2_XptFrameBuffer2RGB);
-            m_card->Connect(NTV2_Xpt425Mux2BInput, NTV2_XptFrameBuffer2_DS2RGB);
-
-            m_card->Connect(NTV2_XptDualLinkOut1Input, NTV2_Xpt425Mux1ARGB);
-            m_card->Connect(NTV2_XptDualLinkOut2Input, NTV2_Xpt425Mux1BRGB);
-            m_card->Connect(NTV2_XptDualLinkOut3Input, NTV2_Xpt425Mux2ARGB);
-            m_card->Connect(NTV2_XptDualLinkOut4Input, NTV2_Xpt425Mux2BRGB);
-        }
-
-        // DLOut 1-4 -> SDIOut 1-4 (12G link group sub-links)
+        // DLOut1 + DLOut2 + DLOut3 + DLOut4 -> SDIOut1 + SDIOut2 + SDIOut3 + SDIOut4
         m_card->Connect(NTV2_XptSDIOut1Input, NTV2_XptDuallinkOut1);
         m_card->Connect(NTV2_XptSDIOut1InputDS2, NTV2_XptDuallinkOut1DS2);
         m_card->Connect(NTV2_XptSDIOut2Input, NTV2_XptDuallinkOut2);
@@ -2873,7 +2815,7 @@ namespace AJADevices
 
                     if (rcount >= m_highwater && !m_autocirculateRunning)
                     {
-                        AJA_CHECK(m_card->AutoCirculateStart((m_12G && m_yuvInternalFormat) ? NTV2_CHANNEL3 : NTV2_CHANNEL1));
+                        AJA_CHECK(m_card->AutoCirculateStart(m_12G ? m_channelVector[0] : NTV2_CHANNEL1));
 
                         if (doingStereo)
                         {
@@ -3102,7 +3044,7 @@ namespace AJADevices
 
             if (!wrote)
             {
-                AJA_CHECK(m_card->WaitForOutputVerticalInterrupt((m_12G && m_yuvInternalFormat) ? NTV2_CHANNEL3 : NTV2_CHANNEL1));
+                AJA_CHECK(m_card->WaitForOutputVerticalInterrupt(m_12G ? m_channelVector[0] : NTV2_CHANNEL1));
                 vi--;
             }
         }

--- a/src/plugins/output/AJADevices/KonaVideoDevice.cpp
+++ b/src/plugins/output/AJADevices/KonaVideoDevice.cpp
@@ -271,11 +271,11 @@ namespace AJADevices
             {"12 Bit Dual Link RGB", NTV2_FBF_48BIT_RGB, VideoDevice::RGB16, RGB_DualLink},
 
             // 6G/12G Single-link YCbCr formats
-            {"10 Bit 12G Single-Link YCrCb 4:2:2 (SDI Out 3)", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, YUV_12G},
+            {"10 Bit 12G Single-link YCrCb 4:2:2 (SDI Out 3)", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, YUV_12G},
 
             // 12G Single-link RGB formats
-            {"10 Bit 12G Single-Link RGB (SDI Out 3)", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, RGB_12G},
-            {"12 Bit 12G Single-Link RGB (SDI Out 3)", NTV2_FBF_48BIT_RGB, VideoDevice::RGB16, RGB_12G},
+            {"10 Bit 12G Single-link RGB (SDI Out 3)", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, RGB_12G},
+            {"12 Bit 12G Single-link RGB (SDI Out 3)", NTV2_FBF_48BIT_RGB, VideoDevice::RGB16, RGB_12G},
 
             // Stereo
             // {"Stereo Dual 10 Bit YCrCb 4:2:2 (8 bit internal)",
@@ -1201,19 +1201,7 @@ namespace AJADevices
                 if (numFrameStores >= 2)
                     m_card->EnableChannel(NTV2_CHANNEL2);
 
-                if (m_12G)
-                {
-                    // 12G single-link always uses TSI regardless of the 4K transport setting.
-                    // YUV needs CH3+CH4 and RGB needs CH1+CH2 (already enabled above).
-                    if (!rgb)
-                    {
-                        m_card->DisableChannel(NTV2_CHANNEL1);
-                        m_card->DisableChannel(NTV2_CHANNEL2);
-                        m_card->EnableChannel(NTV2_CHANNEL3);
-                        m_card->EnableChannel(NTV2_CHANNEL4);
-                    }
-                }
-                else if (tsiEnabled())
+                if (tsiEnabled() || m_12G)
                 {
                     if (numFrameStores >= 3)
                         m_card->DisableChannel(NTV2_CHANNEL3);
@@ -1237,18 +1225,8 @@ namespace AJADevices
 
                 if (m_12G)
                 {
-                    // YUV 6G: framestores 3+4 (feeds TSI Mux 3+4 → SDIOut3 via 6G link grouping)
-                    // RGB 12G: framestores 1+2 (feeds TSI Mux 1+2 → DLOut → SDIOut3 via 12G link grouping)
-                    if (rgb)
-                    {
-                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL1, d.value));
-                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL2, d.value));
-                    }
-                    else
-                    {
-                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL3, d.value));
-                        AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL4, d.value));
-                    }
+                    AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL1, d.value));
+                    AJA_CHECK(m_card->SetFrameBufferFormat(NTV2_CHANNEL2, d.value));
                 }
                 else
                 {
@@ -1271,16 +1249,9 @@ namespace AJADevices
                 else
                     m_channelVector.resize(1);
 
-                if (m_12G)
+                for (unsigned int i = 0; i < m_channelVector.size(); i++)
                 {
-                    m_channelVector[0] = rgb ? NTV2_CHANNEL1 : NTV2_CHANNEL3;
-                }
-                else
-                {
-                    for (unsigned int i = 0; i < m_channelVector.size(); i++)
-                    {
-                        m_channelVector[i] = (NTV2Channel)(i + NTV2_CHANNEL1);
-                    }
+                    m_channelVector[i] = (NTV2Channel)(i + NTV2_CHANNEL1);
                 }
 
                 AJA_CHECK(m_card->SetReference(NTV2_REFERENCE_FREERUN));
@@ -1506,11 +1477,6 @@ namespace AJADevices
             if (m_textureType == GL_UNSIGNED_INT_10_10_10_2)
                 m_textureType = GL_UNSIGNED_INT_2_10_10_10_REV;
 
-            for (VideoChannel* vc : m_videoChannels)
-            {
-                m_card->DisableChannel(vc->channel);
-            }
-
             m_videoChannels.clear();
 
             m_videoChannels.push_back(
@@ -1623,25 +1589,11 @@ namespace AJADevices
             }
             if (ok)
             {
-                if (m_12G)
-                {
-                    AJA_CHECK(m_card->AutoCirculateFlush(m_videoChannels[0]->channel));
-                }
-                else
-                {
-                    AJA_CHECK(m_card->AutoCirculateFlush(NTV2_CHANNEL1));
-                }
+                AJA_CHECK(m_card->AutoCirculateFlush(NTV2_CHANNEL1));
 
                 if (m_stereo)
                 {
-                    if (m_12G)
-                    {
-                        AJA_CHECK(m_card->AutoCirculateFlush(m_videoChannels[1]->channel));
-                    }
-                    else
-                    {
-                        AJA_CHECK(m_card->AutoCirculateFlush(NTV2_CHANNEL2));
-                    }
+                    AJA_CHECK(m_card->AutoCirculateFlush(NTV2_CHANNEL2));
                 }
             }
         }
@@ -1969,48 +1921,41 @@ namespace AJADevices
     void KonaVideoDevice::route12GSingleLinkYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
     {
         //
-        //  Single-link YCbCr output on Kona 5 port 3 (NTV2_CHANNEL3) with the retail firmware.
+        //  Single-link YCbCr output on Kona 5 port 3 with the retail firmware.
         //
         //
-        //  6G:
-        //      FB3 + FB4 -> TSI Mux 3 + TSI Mux 4 -> CSC3 + CSC4 -> SDIOut3 + SDIOut4
-        //
-        //  12G:
-        //      FB3 + FB4 -> TSI Mux 3 + TSI Mux 4 -> CSC31 + CSC2 + CSC3 + CSC4 -> SDIOut1 + SDIOut2 + SDIOut3 + SDIOut4
+        //  FB 1 + FB 2 -> TSI Mux 1 + TSI Mux 2 -> CSC 1 + CSC 2 + CSC 3 + CSC 4 -> SDI Out 1 + SDI Out 2 + SDI Out 3 + SDI Out 4
         //
 
         if (m_infoFeedback)
-            cout << "INFO: KONA 6G/12G single-link YCbCr format" << endl;
+            std::cout << "INFO: KONA 6G/12G single-link YCbCr format\n";
 
         ULWord vpidA;
         CNTV2VPID::SetVPIDData(vpidA, f.value, d.value, false, false, VPIDChannel_3);
 
-        // Disable 6G/12G on SDIOut3 before configuring
-        m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, false);
-        m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, false);
-
         m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
 
         m_card->SetSDIOutputStandard(NTV2_CHANNEL3, standard);
-        m_card->SetMode(NTV2_CHANNEL3, NTV2_MODE_DISPLAY);
-        m_card->SetMode(NTV2_CHANNEL4, NTV2_MODE_DISPLAY);
+        m_card->SetMode(NTV2_CHANNEL1, NTV2_MODE_DISPLAY);
+        m_card->SetMode(NTV2_CHANNEL2, NTV2_MODE_DISPLAY);
 
-        m_card->SubscribeOutputVerticalEvent(NTV2_CHANNEL3);
+        m_card->SubscribeOutputVerticalEvent(NTV2_CHANNEL1);
 
         m_card->SetSDIOutVPID(vpidA, 0, NTV2_CHANNEL3);
 
-        // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4
-        m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3RGB);
-        m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2RGB);
-        m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4RGB);
-        m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2RGB);
+        // FB 1 + FB 2 -> TSI Mux 1 + TSI Mux 2
+        m_card->Connect(NTV2_Xpt425Mux1AInput, NTV2_XptFrameBuffer1RGB);
+        m_card->Connect(NTV2_Xpt425Mux1BInput, NTV2_XptFrameBuffer1_DS2RGB);
+        m_card->Connect(NTV2_Xpt425Mux2AInput, NTV2_XptFrameBuffer2RGB);
+        m_card->Connect(NTV2_Xpt425Mux2BInput, NTV2_XptFrameBuffer2_DS2RGB);
 
-        // TSI Mux 3 + TSI Mux 4 -> CSC1 + CSC2 + CSC3 + CSC4
-        m_card->Connect(NTV2_XptCSC1VidInput, NTV2_Xpt425Mux3ARGB);
-        m_card->Connect(NTV2_XptCSC2VidInput, NTV2_Xpt425Mux3BRGB);
-        m_card->Connect(NTV2_XptCSC3VidInput, NTV2_Xpt425Mux4ARGB);
-        m_card->Connect(NTV2_XptCSC4VidInput, NTV2_Xpt425Mux4BRGB);
+        // TSI Mux 1 + TSI Mux 2 -> CSC 1 + CSC 2 + CSC 3 + CSC 4
+        m_card->Connect(NTV2_XptCSC1VidInput, NTV2_Xpt425Mux1ARGB);
+        m_card->Connect(NTV2_XptCSC2VidInput, NTV2_Xpt425Mux1BRGB);
+        m_card->Connect(NTV2_XptCSC3VidInput, NTV2_Xpt425Mux2ARGB);
+        m_card->Connect(NTV2_XptCSC4VidInput, NTV2_Xpt425Mux2BRGB);
 
+        // CSC 1 + CSC 2 + CSC 3 + CSC 4 -> SDI Out 1 + SDI Out 2 + SDI Out 3 + SDI Out 4
         if (NTV2_IS_4K_HFR_VIDEO_FORMAT(f.value))
         {
             m_card->Connect(NTV2_XptSDIOut1Input, NTV2_XptCSC1VidYUV);
@@ -2030,27 +1975,24 @@ namespace AJADevices
             m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, true);
         }
 
-        m_card->SetTsiFrameEnable(true, NTV2_CHANNEL3);
+        m_card->SetTsiFrameEnable(true, NTV2_CHANNEL1);
     }
 
     void KonaVideoDevice::route12GSingleLinkRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
     {
         //
-        //  Single-link RGB output on Kona 5 port 3 (NTV2_CHANNEL3) with the retail firmware.
+        //  Single-link RGB output on Kona 5 port 3 with the retail firmware.
         //
         //
-        //  FB1(RGB) + FB2(RGB) -> TSI Mux 1 + TSI Mux 2 -> DLOut1 + DLOut2 + DLOut3 + DLOut4 -> SDIOut1 + SDIOut2 + SDIOut3 + SDIOut4
+        //  FB 1 + FB 2 -> TSI Mux 1 + TSI Mux 2 -> DL Out 1 + DL Out 2 + DL Out 3 + DL Out 4 -> SDI Out 1 + SDI Out 2 + SDI Out 3 +
+        //  SDI Out 4
         //
 
         if (m_infoFeedback)
-            cout << "INFO: KONA 12G single-link RGB format" << endl;
+            std::cout << "INFO: KONA 12G single-link RGB format\n";
 
         ULWord vpidA;
         CNTV2VPID::SetVPIDData(vpidA, f.value, d.value, false, false, VPIDChannel_3);
-
-        // Disable 6G/12G on SDIOut3 before configuring
-        m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, false);
-        m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, false);
 
         m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
 
@@ -2062,18 +2004,19 @@ namespace AJADevices
 
         m_card->SetSDIOutVPID(vpidA, 0, NTV2_CHANNEL3);
 
-        // FS1 + FS2 -> TSI Mux 1 + TSI Mux 2 -> DLOut1 + DLOut2 + DLOut3 + DLOut4
+        // FB 1 + FB 2 -> TSI Mux 1 + TSI Mux 2
         m_card->Connect(NTV2_Xpt425Mux1AInput, NTV2_XptFrameBuffer1RGB);
         m_card->Connect(NTV2_Xpt425Mux1BInput, NTV2_XptFrameBuffer1_DS2RGB);
         m_card->Connect(NTV2_Xpt425Mux2AInput, NTV2_XptFrameBuffer2RGB);
         m_card->Connect(NTV2_Xpt425Mux2BInput, NTV2_XptFrameBuffer2_DS2RGB);
 
+        // TSI Mux 1 + TSI Mux 2 -> DL Out 1 + DL Out 2 + DL Out 3 + DL Out 4
         m_card->Connect(NTV2_XptDualLinkOut1Input, NTV2_Xpt425Mux1ARGB);
         m_card->Connect(NTV2_XptDualLinkOut2Input, NTV2_Xpt425Mux1BRGB);
         m_card->Connect(NTV2_XptDualLinkOut3Input, NTV2_Xpt425Mux2ARGB);
         m_card->Connect(NTV2_XptDualLinkOut4Input, NTV2_Xpt425Mux2BRGB);
 
-        // DLOut1 + DLOut2 + DLOut3 + DLOut4 -> SDIOut1 + SDIOut2 + SDIOut3 + SDIOut4
+        // DL Out 1 + DL Out 2 + DL Out 3 + DL Out 4 -> SDI Out 1 + SDI Out 2 + SDI Out 3 + SDI Out
         m_card->Connect(NTV2_XptSDIOut1Input, NTV2_XptDuallinkOut1);
         m_card->Connect(NTV2_XptSDIOut1InputDS2, NTV2_XptDuallinkOut1DS2);
         m_card->Connect(NTV2_XptSDIOut2Input, NTV2_XptDuallinkOut2);
@@ -2815,7 +2758,7 @@ namespace AJADevices
 
                     if (rcount >= m_highwater && !m_autocirculateRunning)
                     {
-                        AJA_CHECK(m_card->AutoCirculateStart(m_12G ? m_channelVector[0] : NTV2_CHANNEL1));
+                        AJA_CHECK(m_card->AutoCirculateStart(NTV2_CHANNEL1));
 
                         if (doingStereo)
                         {
@@ -3044,7 +2987,7 @@ namespace AJADevices
 
             if (!wrote)
             {
-                AJA_CHECK(m_card->WaitForOutputVerticalInterrupt(m_12G ? m_channelVector[0] : NTV2_CHANNEL1));
+                AJA_CHECK(m_card->WaitForOutputVerticalInterrupt(NTV2_CHANNEL1)); // XXX best guess
                 vi--;
             }
         }

--- a/src/plugins/output/AJADevices/KonaVideoDevice.cpp
+++ b/src/plugins/output/AJADevices/KonaVideoDevice.cpp
@@ -273,6 +273,10 @@ namespace AJADevices
             // 6G/12G Single-link YCbCr formats
             {"10 Bit 12G Single-Link YCrCb 4:2:2 (SDI Out 3)", NTV2_FBF_10BIT_YCBCR, VideoDevice::YCrCb_AJA_10_422, YUV_12G},
 
+            // 12G Single-link RGB formats
+            {"10 Bit 12G Single-Link RGB (SDI Out 3)", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, RGB_12G},
+            {"12 Bit 12G Single-Link RGB (SDI Out 3)", NTV2_FBF_48BIT_RGB, VideoDevice::RGB16, RGB_12G},
+
             // Stereo
             // {"Stereo Dual 10 Bit YCrCb 4:2:2 (8 bit internal)",
             // NTV2_FBF_24BIT_RGB, VideoDevice::RGB8, P2P},
@@ -1367,9 +1371,16 @@ namespace AJADevices
                 m_card->SetTsiFrameEnable(false, NTV2_CHANNEL4);
                 m_card->SetTsiFrameEnable(false, NTV2_CHANNEL5);
 
+                m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, false);
+                m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, false);
+
                 if (rgb)
                 {
-                    if (m_quad || m_quadQuad)
+                    if (m_12G)
+                    {
+                        route12GSingleLinkRGB(standard, f, d);
+                    }
+                    else if (m_quad || m_quadQuad)
                     {
                         routeQuadRGB(standard, f, d);
                     }
@@ -1494,6 +1505,11 @@ namespace AJADevices
             m_texturePadding = 0;
             if (m_textureType == GL_UNSIGNED_INT_10_10_10_2)
                 m_textureType = GL_UNSIGNED_INT_2_10_10_10_REV;
+
+            for (VideoChannel* vc : m_videoChannels)
+            {
+                m_card->DisableChannel(vc->channel);
+            }
 
             m_videoChannels.clear();
 
@@ -1985,35 +2001,149 @@ namespace AJADevices
 
         m_card->SetSDIOutVPID(vpidA, 0, NTV2_CHANNEL3);
 
-        // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4 (same for both 6G and 12G)
-        m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3YUV);
-        m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2YUV);
-        m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4YUV);
-        m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2YUV);
+        // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4
+        if (m_yuvInternalFormat)
+        {
+            m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3YUV);
+            m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2YUV);
+            m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4YUV);
+            m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2YUV);
+        }
+        else
+        {
+            // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4 -> CSC3 + CSC4
+            m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3RGB);
+            m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2RGB);
+            m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4RGB);
+            m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2RGB);
+
+            m_card->Connect(NTV2_XptCSC1VidInput, NTV2_Xpt425Mux3ARGB);
+            m_card->Connect(NTV2_XptCSC2VidInput, NTV2_Xpt425Mux3BRGB);
+            m_card->Connect(NTV2_XptCSC3VidInput, NTV2_Xpt425Mux4ARGB);
+            m_card->Connect(NTV2_XptCSC4VidInput, NTV2_Xpt425Mux4BRGB);
+        }
 
         if (NTV2_IS_4K_HFR_VIDEO_FORMAT(f.value))
         {
-            // 12G: TSI Mux 3 + TSI Mux 4 -> SDIOut1/SDIOut2/SDIOut3/SDIOut4
-            // Only CH3 needs to be explicitly transmit-enabled (SetSDIOut12GEnable handles CH4 internally as the sub-link)
-            m_card->Connect(NTV2_XptSDIOut1Input, NTV2_Xpt425Mux3AYUV);
-            m_card->Connect(NTV2_XptSDIOut2Input, NTV2_Xpt425Mux3BYUV);
-            m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux4AYUV);
-            m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4BYUV);
+            // 12G: TSI Mux 3 + TSI Mux 4 -> SDIOut1 + SDIOut2 + SDIOut3 + SDIOut4
+            if (m_yuvInternalFormat)
+            {
+                m_card->Connect(NTV2_XptSDIOut1Input, NTV2_Xpt425Mux3AYUV);
+                m_card->Connect(NTV2_XptSDIOut2Input, NTV2_Xpt425Mux3BYUV);
+                m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux4AYUV);
+                m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4BYUV);
+            }
+            else
+            {
+                m_card->Connect(NTV2_XptSDIOut1Input, NTV2_XptCSC1VidYUV);
+                m_card->Connect(NTV2_XptSDIOut2Input, NTV2_XptCSC2VidYUV);
+                m_card->Connect(NTV2_XptSDIOut3Input, NTV2_XptCSC3VidYUV);
+                m_card->Connect(NTV2_XptSDIOut4Input, NTV2_XptCSC4VidYUV);
+            }
 
             m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, true);
         }
         else
         {
-            // 6G: TSI Mux 3 + TSI Mux 4 -> SDIOut3/SDIOut4
-            m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux3AYUV);
-            m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_Xpt425Mux3BYUV);
-            m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4AYUV);
-            m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_Xpt425Mux4BYUV);
+            // 6G: TSI Mux 3 + TSI Mux 4 -> SDIOut3 + SDIOut4
+            if (m_yuvInternalFormat)
+            {
+                m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux3AYUV);
+                m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_Xpt425Mux3BYUV);
+                m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4AYUV);
+                m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_Xpt425Mux4BYUV);
+            }
+            else
+            {
+                m_card->Connect(NTV2_XptSDIOut3Input, NTV2_XptCSC1VidYUV);
+                m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_XptCSC2VidYUV);
+                m_card->Connect(NTV2_XptSDIOut4Input, NTV2_XptCSC3VidYUV);
+                m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_XptCSC4VidYUV);
+            }
 
             m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, true);
         }
 
         m_card->SetTsiFrameEnable(true, NTV2_CHANNEL3);
+    }
+
+    void KonaVideoDevice::route12GSingleLinkRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
+    {
+        //
+        //  Single-link RGB output on Kona 5 port 3 (NTV2_CHANNEL3) with the retail firmware.
+        //
+        //  RGB requires DualLink encoding (the 12G transmitter multiplexes two DL streams onto
+        //  a single 12G cable). This saturates 12G bandwidth at non-HFR rates, so HFR is not
+        //  supported for this path.
+        //
+        //  FB1(RGB) + FB2(RGB) -> TSI Mux 1+2 -> DLOut 1-4 -> SDIOut 1-4 -> 12G link group (SDIOut3)
+        //
+
+        if (m_infoFeedback)
+            cout << "INFO: KONA 12G single-link RGB format" << endl;
+
+        ULWord vpidA;
+        CNTV2VPID::SetVPIDData(vpidA, f.value, d.value, false, false, VPIDChannel_3);
+
+        // Disable 6G/12G on SDIOut3 before configuring
+        m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, false);
+        m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, false);
+
+        m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
+
+        m_card->SetSDIOutputStandard(NTV2_CHANNEL3, standard);
+        m_card->SetMode(NTV2_CHANNEL1, NTV2_MODE_DISPLAY);
+        m_card->SetMode(NTV2_CHANNEL2, NTV2_MODE_DISPLAY);
+
+        m_card->SubscribeOutputVerticalEvent(NTV2_CHANNEL1);
+
+        m_card->SetSDIOutVPID(vpidA, 0, NTV2_CHANNEL3);
+
+        // FS1 + FS2 -> TSI Mux 1+2 -> DLOut 1-4
+        // When the internal format is YUV, a CSC converts YUV -> RGB before the DLOut.
+        if (m_yuvInternalFormat)
+        {
+            m_card->Connect(NTV2_Xpt425Mux1AInput, NTV2_XptFrameBuffer1YUV);
+            m_card->Connect(NTV2_Xpt425Mux1BInput, NTV2_XptFrameBuffer1_DS2YUV);
+            m_card->Connect(NTV2_Xpt425Mux2AInput, NTV2_XptFrameBuffer2YUV);
+            m_card->Connect(NTV2_Xpt425Mux2BInput, NTV2_XptFrameBuffer2_DS2YUV);
+
+            m_card->Connect(NTV2_XptCSC1VidInput, NTV2_Xpt425Mux1AYUV);
+            m_card->Connect(NTV2_XptCSC2VidInput, NTV2_Xpt425Mux1BYUV);
+            m_card->Connect(NTV2_XptCSC3VidInput, NTV2_Xpt425Mux2AYUV);
+            m_card->Connect(NTV2_XptCSC4VidInput, NTV2_Xpt425Mux2BYUV);
+
+            m_card->Connect(NTV2_XptDualLinkOut1Input, NTV2_XptCSC1VidRGB);
+            m_card->Connect(NTV2_XptDualLinkOut2Input, NTV2_XptCSC2VidRGB);
+            m_card->Connect(NTV2_XptDualLinkOut3Input, NTV2_XptCSC3VidRGB);
+            m_card->Connect(NTV2_XptDualLinkOut4Input, NTV2_XptCSC4VidRGB);
+        }
+        else
+        {
+            m_card->Connect(NTV2_Xpt425Mux1AInput, NTV2_XptFrameBuffer1RGB);
+            m_card->Connect(NTV2_Xpt425Mux1BInput, NTV2_XptFrameBuffer1_DS2RGB);
+            m_card->Connect(NTV2_Xpt425Mux2AInput, NTV2_XptFrameBuffer2RGB);
+            m_card->Connect(NTV2_Xpt425Mux2BInput, NTV2_XptFrameBuffer2_DS2RGB);
+
+            m_card->Connect(NTV2_XptDualLinkOut1Input, NTV2_Xpt425Mux1ARGB);
+            m_card->Connect(NTV2_XptDualLinkOut2Input, NTV2_Xpt425Mux1BRGB);
+            m_card->Connect(NTV2_XptDualLinkOut3Input, NTV2_Xpt425Mux2ARGB);
+            m_card->Connect(NTV2_XptDualLinkOut4Input, NTV2_Xpt425Mux2BRGB);
+        }
+
+        // DLOut 1-4 -> SDIOut 1-4 (12G link group sub-links)
+        m_card->Connect(NTV2_XptSDIOut1Input, NTV2_XptDuallinkOut1);
+        m_card->Connect(NTV2_XptSDIOut1InputDS2, NTV2_XptDuallinkOut1DS2);
+        m_card->Connect(NTV2_XptSDIOut2Input, NTV2_XptDuallinkOut2);
+        m_card->Connect(NTV2_XptSDIOut2InputDS2, NTV2_XptDuallinkOut2DS2);
+        m_card->Connect(NTV2_XptSDIOut3Input, NTV2_XptDuallinkOut3);
+        m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_XptDuallinkOut3DS2);
+        m_card->Connect(NTV2_XptSDIOut4Input, NTV2_XptDuallinkOut4);
+        m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_XptDuallinkOut4DS2);
+
+        m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, true);
+
+        m_card->SetTsiFrameEnable(true, NTV2_CHANNEL1);
     }
 
     void KonaVideoDevice::routeQuadYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
@@ -2534,6 +2664,9 @@ namespace AJADevices
                 m_card->SetSDIOutRGBLevelAConversion(NTV2_CHANNEL3, false);
                 m_card->SetSDIOutRGBLevelAConversion(NTV2_CHANNEL4, false);
                 m_card->SetSDIOutRGBLevelAConversion(NTV2_CHANNEL5, false);
+
+                m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, false);
+                m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, false);
 
                 m_card->ClearRouting();
             }

--- a/src/plugins/output/AJADevices/KonaVideoDevice.cpp
+++ b/src/plugins/output/AJADevices/KonaVideoDevice.cpp
@@ -1918,7 +1918,7 @@ namespace AJADevices
         }
     }
 
-    void KonaVideoDevice::route12GSingleLinkYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
+    void KonaVideoDevice::route12GSingleLinkYUV(NTV2Standard standard, const KonaVideoFormat& videoFormat, const KonaDataFormat& dataFormat)
     {
         //
         //  Single-link YCbCr output on Kona 5 port 3 with the retail firmware.
@@ -1931,7 +1931,7 @@ namespace AJADevices
             std::cout << "INFO: KONA 6G/12G single-link YCbCr format\n";
 
         ULWord vpidA;
-        CNTV2VPID::SetVPIDData(vpidA, f.value, d.value, false, false, VPIDChannel_3);
+        CNTV2VPID::SetVPIDData(vpidA, videoFormat.value, dataFormat.value, false, false, VPIDChannel_3);
 
         m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
 
@@ -1956,7 +1956,7 @@ namespace AJADevices
         m_card->Connect(NTV2_XptCSC4VidInput, NTV2_Xpt425Mux2BRGB);
 
         // CSC 1 + CSC 2 + CSC 3 + CSC 4 -> SDI Out 1 + SDI Out 2 + SDI Out 3 + SDI Out 4
-        if (NTV2_IS_4K_HFR_VIDEO_FORMAT(f.value))
+        if (NTV2_IS_4K_HFR_VIDEO_FORMAT(videoFormat.value))
         {
             m_card->Connect(NTV2_XptSDIOut1Input, NTV2_XptCSC1VidYUV);
             m_card->Connect(NTV2_XptSDIOut2Input, NTV2_XptCSC2VidYUV);
@@ -1976,9 +1976,11 @@ namespace AJADevices
         }
 
         m_card->SetTsiFrameEnable(true, NTV2_CHANNEL1);
+
+        routeHDMI(standard, dataFormat, true, false);
     }
 
-    void KonaVideoDevice::route12GSingleLinkRGB(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
+    void KonaVideoDevice::route12GSingleLinkRGB(NTV2Standard standard, const KonaVideoFormat& videoFormat, const KonaDataFormat& dataFormat)
     {
         //
         //  Single-link RGB output on Kona 5 port 3 with the retail firmware.
@@ -1992,7 +1994,7 @@ namespace AJADevices
             std::cout << "INFO: KONA 12G single-link RGB format\n";
 
         ULWord vpidA;
-        CNTV2VPID::SetVPIDData(vpidA, f.value, d.value, false, false, VPIDChannel_3);
+        CNTV2VPID::SetVPIDData(vpidA, videoFormat.value, dataFormat.value, false, false, VPIDChannel_3);
 
         m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
 
@@ -2029,6 +2031,8 @@ namespace AJADevices
         m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, true);
 
         m_card->SetTsiFrameEnable(true, NTV2_CHANNEL1);
+
+        routeHDMI(standard, dataFormat, true, true);
     }
 
     void KonaVideoDevice::routeQuadYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)

--- a/src/plugins/output/AJADevices/KonaVideoDevice.cpp
+++ b/src/plugins/output/AJADevices/KonaVideoDevice.cpp
@@ -270,8 +270,8 @@ namespace AJADevices
             {"10 Bit Dual Link RGB", NTV2_FBF_10BIT_RGB, VideoDevice::RGB10X2, RGB_DualLink},
             {"12 Bit Dual Link RGB", NTV2_FBF_48BIT_RGB, VideoDevice::RGB16, RGB_DualLink},
 
-            // 6G Single-link YCbCr formats (12G-capable port on SDI Out 3)
-            {"10 Bit 6G Single-Link YCrCb 4:2:2 (SDI Out 3)", NTV2_FBF_10BIT_YCBCR, VideoDevice::YCrCb_AJA_10_422, YUV_6G},
+            // 6G/12G Single-link YCbCr formats
+            {"10 Bit 12G Single-Link YCrCb 4:2:2 (SDI Out 3)", NTV2_FBF_10BIT_YCBCR, VideoDevice::YCrCb_AJA_10_422, YUV_12G},
 
             // Stereo
             // {"Stereo Dual 10 Bit YCrCb 4:2:2 (8 bit internal)",
@@ -1952,17 +1952,21 @@ namespace AJADevices
 
     void KonaVideoDevice::route12GSingleLinkYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)
     {
-        if (m_infoFeedback)
-            cout << "INFO: KONA 6G single-link YCbCr format (port 3)" << endl;
-
         //
-        //  6G single-link YCbCr output on Kona 5 port 3 (NTV2_CHANNEL3) with the retail firmware.
+        //  Single-link YCbCr output on Kona 5 port 3 (NTV2_CHANNEL3) with the retail firmware.
         //
         //  Two framestores feed a TSI mux which interleaves their samples into
-        //  a single 4K YCbCr stream output over the 12G-capable SDIOut3 port at 6G:
+        //  a single 4K YCbCr stream on the 12G-capable SDIOut3 port:
         //
-        //      FB3(YUV) + FB4(YUV) -> TSI Mux 3+4 -> SDIOut3 (6G, DS1+DS2)
+        //  6G (non-HFR, <=30fps):
+        //      FB3(YUV) + FB4(YUV) -> TSI Mux 3+4 -> SDIOut3 DS1+DS2 / SDIOut4 DS1+DS2 (6G)
         //
+        //  12G (HFR, >=47.95fps):
+        //      FB3(YUV) + FB4(YUV) -> TSI Mux 3+4 -> SDIOut1+2+3+4 (12G link group)
+        //
+
+        if (m_infoFeedback)
+            cout << "INFO: KONA 6G/12G single-link YCbCr format" << endl;
 
         ULWord vpidA;
         CNTV2VPID::SetVPIDData(vpidA, f.value, d.value, false, false, VPIDChannel_3);
@@ -1971,35 +1975,45 @@ namespace AJADevices
         m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, false);
         m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, false);
 
-        m_card->SetSDITransmitEnable(NTV2_CHANNEL1, false);
-        m_card->SetSDITransmitEnable(NTV2_CHANNEL2, false);
         m_card->SetSDITransmitEnable(NTV2_CHANNEL3, true);
-        m_card->SetSDITransmitEnable(NTV2_CHANNEL4, false);
 
         m_card->SetSDIOutputStandard(NTV2_CHANNEL3, standard);
         m_card->SetMode(NTV2_CHANNEL3, NTV2_MODE_DISPLAY);
         m_card->SetMode(NTV2_CHANNEL4, NTV2_MODE_DISPLAY);
 
-        m_card->SetTsiFrameEnable(true, NTV2_CHANNEL3);
-
         m_card->SubscribeOutputVerticalEvent(NTV2_CHANNEL3);
 
         m_card->SetSDIOutVPID(vpidA, 0, NTV2_CHANNEL3);
 
-        // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4
+        // FS3 + FS4 -> TSI Mux 3 + TSI Mux 4 (same for both 6G and 12G)
         m_card->Connect(NTV2_Xpt425Mux3AInput, NTV2_XptFrameBuffer3YUV);
         m_card->Connect(NTV2_Xpt425Mux3BInput, NTV2_XptFrameBuffer3_DS2YUV);
         m_card->Connect(NTV2_Xpt425Mux4AInput, NTV2_XptFrameBuffer4YUV);
         m_card->Connect(NTV2_Xpt425Mux4BInput, NTV2_XptFrameBuffer4_DS2YUV);
 
-        // TSI Mux 3 + TSI Mux 4 -> SDIOut3
-        m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux3AYUV);
-        m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_Xpt425Mux3BYUV);
-        m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4AYUV);
-        m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_Xpt425Mux4BYUV);
+        if (NTV2_IS_4K_HFR_VIDEO_FORMAT(f.value))
+        {
+            // 12G: TSI Mux 3 + TSI Mux 4 -> SDIOut1/SDIOut2/SDIOut3/SDIOut4
+            // Only CH3 needs to be explicitly transmit-enabled (SetSDIOut12GEnable handles CH4 internally as the sub-link)
+            m_card->Connect(NTV2_XptSDIOut1Input, NTV2_Xpt425Mux3AYUV);
+            m_card->Connect(NTV2_XptSDIOut2Input, NTV2_Xpt425Mux3BYUV);
+            m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux4AYUV);
+            m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4BYUV);
 
-        // Re-enable 6G after routing is configured
-        m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, true);
+            m_card->SetSDIOut12GEnable(NTV2_CHANNEL3, true);
+        }
+        else
+        {
+            // 6G: TSI Mux 3 + TSI Mux 4 -> SDIOut3/SDIOut4
+            m_card->Connect(NTV2_XptSDIOut3Input, NTV2_Xpt425Mux3AYUV);
+            m_card->Connect(NTV2_XptSDIOut3InputDS2, NTV2_Xpt425Mux3BYUV);
+            m_card->Connect(NTV2_XptSDIOut4Input, NTV2_Xpt425Mux4AYUV);
+            m_card->Connect(NTV2_XptSDIOut4InputDS2, NTV2_Xpt425Mux4BYUV);
+
+            m_card->SetSDIOut6GEnable(NTV2_CHANNEL3, true);
+        }
+
+        m_card->SetTsiFrameEnable(true, NTV2_CHANNEL3);
     }
 
     void KonaVideoDevice::routeQuadYUV(NTV2Standard standard, const KonaVideoFormat& f, const KonaDataFormat& d)


### PR DESCRIPTION
### [SG-27382](https://jira.autodesk.com/browse/SG-27382): Add 12G SDI single-link support for the AJA Kona 5 card

### Linked issues

Fixes #860 

### Summarize your change.

Note that this PR is based on #1192 that is updating the SDK version used to 17.6.0. The only relevant files to review are KonaVideoDevice.cpp and KonaVideoDevice.h.

This PR adds three new possible data formats if the device can support 12G SDI Single-link on its third port (i.e. SDI Out 3):
- 10 Bit 12G Single-link YCrCb 4:2:2 (SDI Out 3)
- 10 Bit 12G Single-link RGB (SDI Out 3)
- 12 Bit 12G Single-link RGB (SDI Out 3)

Note that the first format enables 6G SDI single-link for low frame rates, and 12G for higher frame rates in YUV.

Since the retail firmware of the Kona 5 doesn't have a built-in TSI muxers, the only supported video formats are the quad ones. Therefore, we need to ensure that 12G statements are executed before quad statements. Moreover, the 4K/8K formats options are simply ignored for the 12G single-link case as TSI is the only possible option if we want to wire the frames to one SDI output.

To avoid refactoring too much code that would affect other AJA cards, the idea here is to only support the 12G SDI single-link workflow based on the Kona 5 retail firmware that only handle it on port 3. To do so, two new functions were added: `route12GSingleLinkYUV()` and `route12GSingleLinkRGB` where all the routing is directly handled to go from the frame buffers, to the TSI multiplexers, to the Color spaces converters (if the output format is YUV), to the Dual Link Out (if the output format is RGB), to the third port. To match the rest of the code, we are always using FB 1 and FB 2. The only difference is with the output port.

### Describe the reason for the change.

This is a feature that was requested by multiple people in the last few years for the AJA Kona 5.

### Describe what you have tested and on which operating system.

Tests were performed on macOS 26.3 using a Kona 5 with the retail firmware and a BMD Smartview 4K monitor.
Several YUV and RGB files were tested with the variety of 4K video formats (both UHD and DCI) supported by the card at different resolutions with the 10-bit YUV, 10-bit RGB, and 12-bit RGB data formats that were added specifically to perform 12G SDI Single-link on the third port. Note that the monitor used doesn't support 12G SDI RGB, so only the routing was validated using AJA ntv2watcher tool.