### PR TITLE
feat: SG-43401: rvbuild-withbrew command to build openrv with homebrew packages

### DIFF
--- a/cmake/dependencies/aja.cmake
+++ b/cmake/dependencies/aja.cmake
@@ -50,6 +50,48 @@ SET(_mbedcrypto_lib
     ${_mbedtls_lib_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}mbedcrypto${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(PkgConfig)
+  PKG_CHECK_MODULES(PC_mbedtls mbedtls mbedx509 mbedcrypto)
+  IF(PC_mbedtls_FOUND)
+    MESSAGE(STATUS "Using Homebrew mbedtls")
+    # Use direct paths from pkg-config
+    FIND_LIBRARY(
+      BREW_MBEDTLS_LIB
+      NAMES mbedtls
+      HINTS ${PC_mbedtls_LIBDIR}
+    )
+    FIND_LIBRARY(
+      BREW_MBEDX509_LIB
+      NAMES mbedx509
+      HINTS ${PC_mbedtls_LIBDIR}
+    )
+    FIND_LIBRARY(
+      BREW_MBEDCRYPTO_LIB
+      NAMES mbedcrypto
+      HINTS ${PC_mbedtls_LIBDIR}
+    )
+
+    IF(BREW_MBEDTLS_LIB
+       AND BREW_MBEDX509_LIB
+       AND BREW_MBEDCRYPTO_LIB
+    )
+      SET(_mbedtls_lib
+          "${BREW_MBEDTLS_LIB}"
+      )
+      SET(_mbedx509_lib
+          "${BREW_MBEDX509_LIB}"
+      )
+      SET(_mbedcrypto_lib
+          "${BREW_MBEDCRYPTO_LIB}"
+      )
+      SET(_use_brew_mbedtls
+          TRUE
+      )
+    ENDIF()
+  ENDIF()
+ENDIF()
+
 LIST(APPEND _byproducts ${_mbedtls_lib} ${_mbedx509_lib} ${_mbedcrypto_lib})
 
 # There is an issue with the recent AJA SDK : the OS specific header files are no longer copied to _aja_ntv2_include_dir Adding custom paths here to work around
@@ -85,6 +127,19 @@ IF(RV_TARGET_WINDOWS
   LIST(APPEND _configure_options "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug")
 ENDIF()
 
+IF(_use_brew_mbedtls)
+  LIST(APPEND _configure_options "-DAJANTV2_DISABLE_MBEDTLS=ON")
+  # In AJA SDK, AJANTV2_DISABLE_PLUGIN_LOAD=ON also disables internal mbedtls
+  LIST(APPEND _configure_options "-DAJANTV2_DISABLE_PLUGIN_LOAD=ON")
+  SET(_aja_install_command
+      ${_cmake_install_command}
+  )
+ELSE()
+  SET(_aja_install_command
+      ${_cmake_install_command} && ${CMAKE_COMMAND} -E copy_directory ${_mbedtls_lib_dir} ${_lib_dir}
+  )
+ENDIF()
+
 EXTERNALPROJECT_ADD(
   ${_target}
   URL ${_download_url}
@@ -97,7 +152,7 @@ EXTERNALPROJECT_ADD(
   INSTALL_DIR ${_install_dir}
   CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options}
   BUILD_COMMAND ${_cmake_build_command}
-  INSTALL_COMMAND ${_cmake_install_command} && ${CMAKE_COMMAND} -E copy_directory ${_mbedtls_lib_dir} ${_lib_dir}
+  INSTALL_COMMAND ${_aja_install_command}
   BUILD_IN_SOURCE FALSE
   BUILD_ALWAYS FALSE
   BUILD_BYPRODUCTS ${_byproducts}

--- a/cmake/dependencies/boost.cmake
+++ b/cmake/dependencies/boost.cmake
@@ -207,37 +207,41 @@ FOREACH(
   _boost_lib
   ${_boost_libs}
 )
-  ADD_LIBRARY(Boost::${_boost_lib} SHARED IMPORTED GLOBAL)
-  ADD_DEPENDENCIES(Boost::${_boost_lib} ${_target})
-  SET_PROPERTY(
-    TARGET Boost::${_boost_lib}
-    PROPERTY IMPORTED_LOCATION ${_boost_${_boost_lib}_lib}
-  )
-  SET_PROPERTY(
-    TARGET Boost::${_boost_lib}
-    PROPERTY IMPORTED_SONAME ${_boost_${_boost_lib}_lib_name}
-  )
-
-  IF(RV_TARGET_WINDOWS)
+  IF(NOT TARGET Boost::${_boost_lib})
+    ADD_LIBRARY(Boost::${_boost_lib} SHARED IMPORTED GLOBAL)
+    ADD_DEPENDENCIES(Boost::${_boost_lib} ${_target})
     SET_PROPERTY(
       TARGET Boost::${_boost_lib}
-      PROPERTY IMPORTED_IMPLIB ${_boost_${_boost_lib}_implib}
+      PROPERTY IMPORTED_LOCATION ${_boost_${_boost_lib}_lib}
     )
-  ENDIF()
-  TARGET_INCLUDE_DIRECTORIES(
-    Boost::${_boost_lib}
-    INTERFACE ${_include_dir}
-  )
+    SET_PROPERTY(
+      TARGET Boost::${_boost_lib}
+      PROPERTY IMPORTED_SONAME ${_boost_${_boost_lib}_lib_name}
+    )
 
-  LIST(APPEND RV_DEPS_LIST Boost::${_boost_lib})
-  LIST(APPEND _boost_stage_output ${RV_STAGE_LIB_DIR}/${_boost_${_boost_lib}_lib_name})
+    IF(RV_TARGET_WINDOWS)
+      SET_PROPERTY(
+        TARGET Boost::${_boost_lib}
+        PROPERTY IMPORTED_IMPLIB ${_boost_${_boost_lib}_implib}
+      )
+    ENDIF()
+    TARGET_INCLUDE_DIRECTORIES(
+      Boost::${_boost_lib}
+      INTERFACE ${_include_dir}
+    )
+
+    LIST(APPEND RV_DEPS_LIST Boost::${_boost_lib})
+    LIST(APPEND _boost_stage_output ${RV_STAGE_LIB_DIR}/${_boost_${_boost_lib}_lib_name})
+  ENDIF()
 ENDFOREACH()
 
-ADD_LIBRARY(Boost::headers INTERFACE IMPORTED GLOBAL)
-SET_TARGET_PROPERTIES(
-  Boost::headers
-  PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_include_dir}"
-)
+IF(NOT TARGET Boost::headers)
+  ADD_LIBRARY(Boost::headers INTERFACE IMPORTED GLOBAL)
+  SET_TARGET_PROPERTIES(
+    Boost::headers
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_include_dir}"
+  )
+ENDIF()
 
 # Note: On Windows, Boost's b2 puts both .lib and .dll in lib/, so we copy _lib_dir to both RV_STAGE_LIB_DIR and RV_STAGE_BIN_DIR.
 IF(RV_TARGET_WINDOWS)

--- a/cmake/dependencies/dav1d.cmake
+++ b/cmake/dependencies/dav1d.cmake
@@ -4,6 +4,62 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(PkgConfig)
+  PKG_CHECK_MODULES(PC_dav1d dav1d)
+  IF(PC_dav1d_FOUND)
+    MESSAGE(STATUS "Using Homebrew dav1d: ${PC_dav1d_VERSION}")
+
+    IF(NOT TARGET dav1d::dav1d)
+      ADD_LIBRARY(dav1d::dav1d UNKNOWN IMPORTED GLOBAL)
+      FIND_LIBRARY(
+        dav1d_LIBRARY
+        NAMES dav1d
+        HINTS ${PC_dav1d_LIBDIR}
+      )
+      SET_PROPERTY(
+        TARGET dav1d::dav1d
+        PROPERTY IMPORTED_LOCATION "${dav1d_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        dav1d::dav1d
+        INTERFACE "${PC_dav1d_INCLUDE_DIRS}"
+      )
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST dav1d::dav1d)
+    GET_TARGET_PROPERTY(_dav1d_loc dav1d::dav1d LOCATION)
+    GET_FILENAME_COMPONENT(_dav1d_lib_dir "${_dav1d_loc}" DIRECTORY)
+    SET(RV_DEPS_DAVID_LIB_DIR
+        "${_dav1d_lib_dir}"
+        CACHE INTERNAL ""
+    )
+
+    # FFmpeg customization adding dav1d codec support to FFmpeg
+    SET_PROPERTY(
+      GLOBAL APPEND
+      PROPERTY "RV_FFMPEG_EXTRA_C_OPTIONS" "--extra-cflags=-I${PC_dav1d_INCLUDE_DIRS}"
+    )
+    IF(RV_TARGET_WINDOWS)
+      SET_PROPERTY(
+        GLOBAL APPEND
+        PROPERTY "RV_FFMPEG_EXTRA_LIBPATH_OPTIONS" "--extra-ldflags=-LIBPATH:${_dav1d_lib_dir}"
+      )
+    ELSE()
+      SET_PROPERTY(
+        GLOBAL APPEND
+        PROPERTY "RV_FFMPEG_EXTRA_LIBPATH_OPTIONS" "--extra-ldflags=-L${_dav1d_lib_dir}"
+      )
+    ENDIF()
+    SET_PROPERTY(
+      GLOBAL APPEND
+      PROPERTY "RV_FFMPEG_EXTERNAL_LIBS" "--enable-libdav1d"
+    )
+
+    RETURN()
+  ENDIF()
+ENDIF()
+
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_DAV1D" "${RV_DEPS_DAV1D_VERSION}" "ninja" "meson")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 

--- a/cmake/dependencies/expat.cmake
+++ b/cmake/dependencies/expat.cmake
@@ -11,6 +11,33 @@
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_EXPAT" "${RV_DEPS_EXPAT_VERSION}" "" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(EXPAT)
+  IF(EXPAT_FOUND)
+    MESSAGE(STATUS "Using Homebrew EXPAT: ${EXPAT_VERSION_STRING}")
+    IF(NOT TARGET EXPAT::EXPAT)
+      ADD_LIBRARY(EXPAT::EXPAT UNKNOWN IMPORTED GLOBAL)
+      SET_PROPERTY(
+        TARGET EXPAT::EXPAT
+        PROPERTY IMPORTED_LOCATION "${EXPAT_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        EXPAT::EXPAT
+        INTERFACE "${EXPAT_INCLUDE_DIRS}"
+      )
+    ENDIF()
+    LIST(APPEND RV_DEPS_LIST EXPAT::EXPAT)
+    # Some other deps might need EXPAT root dir
+    GET_FILENAME_COMPONENT(_expat_include_dir "${EXPAT_INCLUDE_DIRS}" ABSOLUTE)
+    GET_FILENAME_COMPONENT(_expat_root_dir "${_expat_include_dir}/.." ABSOLUTE)
+    SET(RV_DEPS_EXPAT_ROOT_DIR
+        "${_expat_root_dir}"
+        CACHE INTERNAL "" FORCE
+    )
+    RETURN()
+  ENDIF()
+ENDIF()
+
 STRING(REPLACE "." "_" _version_underscored ${_version})
 SET(_download_url
     "https://github.com/libexpat/libexpat/archive/refs/tags/R_${_version_underscored}.tar.gz"

--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -16,6 +16,66 @@
 # cmake-format: on
 # ------------------------------------------------------------------------------
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(PkgConfig)
+  SET(_ffmpeg_found_all
+      TRUE
+  )
+  FOREACH(
+    _comp
+    avutil swresample swscale avcodec avformat
+  )
+    PKG_CHECK_MODULES(PC_${_comp} lib${_comp})
+    IF(PC_${_comp}_FOUND)
+      IF(NOT TARGET ffmpeg::${_comp})
+        ADD_LIBRARY(ffmpeg::${_comp} UNKNOWN IMPORTED GLOBAL)
+        FIND_LIBRARY(
+          LIB_${_comp}
+          NAMES ${_comp}
+          HINTS ${PC_${_comp}_LIBDIR}
+        )
+        SET_PROPERTY(
+          TARGET ffmpeg::${_comp}
+          PROPERTY IMPORTED_LOCATION "${LIB_${_comp}}"
+        )
+        TARGET_INCLUDE_DIRECTORIES(
+          ffmpeg::${_comp}
+          INTERFACE "${PC_${_comp}_INCLUDE_DIRS}"
+        )
+        LIST(APPEND RV_DEPS_LIST ffmpeg::${_comp})
+
+        # Need to link dependencies
+        IF("${_comp}" STREQUAL "swresample"
+           OR "${_comp}" STREQUAL "swscale"
+        )
+          TARGET_LINK_LIBRARIES(
+            ffmpeg::${_comp}
+            INTERFACE ffmpeg::avutil
+          )
+        ELSEIF("${_comp}" STREQUAL "avcodec")
+          TARGET_LINK_LIBRARIES(
+            ffmpeg::${_comp}
+            INTERFACE ffmpeg::swresample
+          )
+        ELSEIF("${_comp}" STREQUAL "avformat")
+          TARGET_LINK_LIBRARIES(
+            ffmpeg::${_comp}
+            INTERFACE ffmpeg::avcodec
+          )
+        ENDIF()
+      ENDIF()
+    ELSE()
+      MESSAGE(WARNING "Homebrew FFmpeg component lib${_comp} not found")
+      SET(_ffmpeg_found_all
+          FALSE
+      )
+    ENDIF()
+  ENDFOREACH()
+
+  IF(_ffmpeg_found_all)
+    RETURN()
+  ENDIF()
+ENDIF()
 SET(_target
     "RV_DEPS_FFMPEG"
 )

--- a/cmake/dependencies/gc.cmake
+++ b/cmake/dependencies/gc.cmake
@@ -6,6 +6,32 @@
 
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_GC" "${RV_DEPS_GC_VERSION}" "" "")
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(PkgConfig)
+  PKG_CHECK_MODULES(PC_GC bdw-gc)
+  IF(PC_GC_FOUND)
+    MESSAGE(STATUS "Using Homebrew GC")
+    IF(NOT TARGET BDWGC::Gc)
+      ADD_LIBRARY(BDWGC::Gc UNKNOWN IMPORTED GLOBAL)
+      FIND_LIBRARY(
+        GC_LIBRARY
+        NAMES gc
+        HINTS ${PC_GC_LIBDIR}
+      )
+      SET_PROPERTY(
+        TARGET BDWGC::Gc
+        PROPERTY IMPORTED_LOCATION "${GC_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        BDWGC::Gc
+        INTERFACE "${PC_GC_INCLUDE_DIRS}"
+      )
+    ENDIF()
+    LIST(APPEND RV_DEPS_LIST BDWGC::Gc)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/ivmai/bdwgc/archive/refs/tags/v${_version}.zip"
 )

--- a/cmake/dependencies/glew.cmake
+++ b/cmake/dependencies/glew.cmake
@@ -6,6 +6,33 @@
 
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_GLEW" "${RV_DEPS_GLEW_VERSION}" "make" "")
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(GLEW)
+  IF(GLEW_FOUND)
+    MESSAGE(STATUS "Using Homebrew GLEW: ${GLEW_VERSION}")
+    IF(NOT TARGET GLEW::GLEW)
+      ADD_LIBRARY(GLEW::GLEW UNKNOWN IMPORTED GLOBAL)
+      IF(GLEW_SHARED_LIBRARY)
+        SET_PROPERTY(
+          TARGET GLEW::GLEW
+          PROPERTY IMPORTED_LOCATION "${GLEW_SHARED_LIBRARY}"
+        )
+      ELSE()
+        SET_PROPERTY(
+          TARGET GLEW::GLEW
+          PROPERTY IMPORTED_LOCATION "${GLEW_LIBRARIES}"
+        )
+      ENDIF()
+      TARGET_INCLUDE_DIRECTORIES(
+        GLEW::GLEW
+        INTERFACE "${GLEW_INCLUDE_DIRS}"
+      )
+    ENDIF()
+    LIST(APPEND RV_DEPS_LIST GLEW::GLEW)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/nigels-com/glew/archive/refs/tags/glew-${_version}.tar.gz"
 )

--- a/cmake/dependencies/imath.cmake
+++ b/cmake/dependencies/imath.cmake
@@ -6,6 +6,61 @@
 
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_IMATH" "${RV_DEPS_IMATH_VERSION}" "" "")
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(Imath CONFIG)
+  IF(Imath_FOUND)
+    MESSAGE(STATUS "Using Homebrew Imath: ${Imath_VERSION}")
+
+    # Helper macro to promote target to global
+    MACRO(PROMOTE_TO_GLOBAL target)
+      IF(TARGET ${target})
+        GET_TARGET_PROPERTY(_is_imported ${target} IMPORTED)
+        IF(_is_imported)
+          SET_TARGET_PROPERTIES(
+            ${target}
+            PROPERTIES IMPORTED_GLOBAL TRUE
+          )
+        ENDIF()
+      ENDIF()
+    ENDMACRO()
+
+    IF(TARGET Imath::Imath)
+      PROMOTE_TO_GLOBAL(Imath::Imath)
+      LIST(APPEND RV_DEPS_LIST Imath::Imath)
+    ELSEIF(TARGET Imath::imath)
+      PROMOTE_TO_GLOBAL(Imath::imath)
+      ADD_LIBRARY(Imath::Imath ALIAS Imath::imath)
+      LIST(APPEND RV_DEPS_LIST Imath::Imath)
+    ELSE()
+      # Fallback using variables
+      ADD_LIBRARY(Imath::Imath UNKNOWN IMPORTED GLOBAL)
+      SET_PROPERTY(
+        TARGET Imath::Imath
+        PROPERTY IMPORTED_LOCATION "${Imath_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        Imath::Imath
+        INTERFACE "${Imath_INCLUDE_DIR}"
+      )
+      LIST(APPEND RV_DEPS_LIST Imath::Imath)
+    ENDIF()
+
+    SET(RV_DEPS_IMATH_VERSION
+        "${Imath_VERSION}"
+        CACHE INTERNAL "" FORCE
+    )
+    SET(RV_DEPS_IMATH_ROOT_DIR
+        "${Imath_DIR}/../.."
+        CACHE INTERNAL "" FORCE
+    )
+    SET(RV_DEPS_IMATH_CMAKE_DIR
+        "${Imath_DIR}"
+        CACHE STRING "" FORCE
+    )
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v${_version}.zip"
 )

--- a/cmake/dependencies/jpegturbo.cmake
+++ b/cmake/dependencies/jpegturbo.cmake
@@ -6,6 +6,53 @@
 
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_JPEGTURBO" "${RV_DEPS_JPEGTURBO_VERSION}" "" "")
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(JPEG)
+  FIND_LIBRARY(
+    TURBOJPEG_LIBRARY
+    NAMES turbojpeg
+  )
+  FIND_PATH(
+    TURBOJPEG_INCLUDE_DIR
+    NAMES turbojpeg.h
+  )
+
+  IF(JPEG_FOUND
+     AND TURBOJPEG_LIBRARY
+     AND TURBOJPEG_INCLUDE_DIR
+  )
+    MESSAGE(STATUS "Using Homebrew JPEGTURBO")
+
+    IF(NOT TARGET libjpeg-turbo::jpeg)
+      ADD_LIBRARY(libjpeg-turbo::jpeg UNKNOWN IMPORTED GLOBAL)
+      SET_PROPERTY(
+        TARGET libjpeg-turbo::jpeg
+        PROPERTY IMPORTED_LOCATION "${JPEG_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        libjpeg-turbo::jpeg
+        INTERFACE "${JPEG_INCLUDE_DIR}"
+      )
+    ENDIF()
+
+    IF(NOT TARGET libjpeg-turbo::turbojpeg)
+      ADD_LIBRARY(libjpeg-turbo::turbojpeg UNKNOWN IMPORTED GLOBAL)
+      SET_PROPERTY(
+        TARGET libjpeg-turbo::turbojpeg
+        PROPERTY IMPORTED_LOCATION "${TURBOJPEG_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        libjpeg-turbo::turbojpeg
+        INTERFACE "${TURBOJPEG_INCLUDE_DIR}"
+      )
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST libjpeg-turbo::jpeg)
+    LIST(APPEND RV_DEPS_LIST libjpeg-turbo::turbojpeg)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/${_version}.tar.gz"
 )

--- a/cmake/dependencies/ocio.cmake
+++ b/cmake/dependencies/ocio.cmake
@@ -10,6 +10,33 @@
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_OCIO" "${RV_DEPS_OCIO_VERSION}" "make" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(OpenColorIO CONFIG)
+  IF(OpenColorIO_FOUND)
+    MESSAGE(STATUS "Using Homebrew OpenColorIO: ${OpenColorIO_VERSION}")
+
+    IF(TARGET OpenColorIO::OpenColorIO)
+      GET_TARGET_PROPERTY(_is_imported OpenColorIO::OpenColorIO IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          OpenColorIO::OpenColorIO
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ENDIF()
+
+    IF(NOT TARGET ocio::ocio)
+      ADD_LIBRARY(ocio::ocio INTERFACE IMPORTED GLOBAL)
+      TARGET_LINK_LIBRARIES(
+        ocio::ocio
+        INTERFACE OpenColorIO::OpenColorIO
+      )
+    ENDIF()
+    LIST(APPEND RV_DEPS_LIST OpenColorIO::OpenColorIO)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 # The folder OCIO is building its own dependencies
 SET(RV_DEPS_OCIO_DIST_DIR
     ${_build_dir}/ext/dist

--- a/cmake/dependencies/oiio.cmake
+++ b/cmake/dependencies/oiio.cmake
@@ -15,6 +15,60 @@
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_OIIO" "${RV_DEPS_OIIO_VERSION}" "make" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(OpenImageIO CONFIG)
+  IF(OpenImageIO_FOUND)
+    MESSAGE(STATUS "Using Homebrew OpenImageIO: ${OpenImageIO_VERSION}")
+
+    IF(TARGET OpenImageIO::OpenImageIO)
+      GET_TARGET_PROPERTY(_is_imported OpenImageIO::OpenImageIO IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          OpenImageIO::OpenImageIO
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ENDIF()
+
+    IF(TARGET OpenImageIO::OpenImageIO_Util)
+      GET_TARGET_PROPERTY(_is_imported OpenImageIO::OpenImageIO_Util IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          OpenImageIO::OpenImageIO_Util
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ENDIF()
+
+    IF(NOT TARGET oiio::oiio)
+      ADD_LIBRARY(oiio::oiio INTERFACE IMPORTED GLOBAL)
+      TARGET_LINK_LIBRARIES(
+        oiio::oiio
+        INTERFACE OpenImageIO::OpenImageIO
+      )
+    ENDIF()
+
+    IF(NOT TARGET oiio::utils)
+      IF(TARGET OpenImageIO::OpenImageIO_Util)
+        ADD_LIBRARY(oiio::utils INTERFACE IMPORTED GLOBAL)
+        TARGET_LINK_LIBRARIES(
+          oiio::utils
+          INTERFACE OpenImageIO::OpenImageIO_Util
+        )
+      ELSE()
+        ADD_LIBRARY(oiio::utils INTERFACE IMPORTED GLOBAL)
+        TARGET_LINK_LIBRARIES(
+          oiio::utils
+          INTERFACE OpenImageIO::OpenImageIO
+        )
+      ENDIF()
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST OpenImageIO::OpenImageIO)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v${_version}.tar.gz"
 )

--- a/cmake/dependencies/openexr.cmake
+++ b/cmake/dependencies/openexr.cmake
@@ -6,6 +6,61 @@
 
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_OPENEXR" "${RV_DEPS_OPENEXR_VERSION}" "" "")
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(OpenEXR CONFIG)
+  IF(OpenEXR_FOUND)
+    MESSAGE(STATUS "Using Homebrew OpenEXR: ${OpenEXR_VERSION}")
+
+    # Helper macro to promote target to global
+    MACRO(PROMOTE_TO_GLOBAL target)
+      IF(TARGET ${target})
+        GET_TARGET_PROPERTY(_is_imported ${target} IMPORTED)
+        IF(_is_imported)
+          SET_TARGET_PROPERTIES(
+            ${target}
+            PROPERTIES IMPORTED_GLOBAL TRUE
+          )
+        ENDIF()
+      ENDIF()
+    ENDMACRO()
+
+    # Handle OpenEXR main library
+    IF(TARGET OpenEXR::OpenEXR)
+      PROMOTE_TO_GLOBAL(OpenEXR::OpenEXR)
+      LIST(APPEND RV_DEPS_LIST OpenEXR::OpenEXR)
+    ELSEIF(TARGET OpenEXR::openexr)
+      PROMOTE_TO_GLOBAL(OpenEXR::openexr)
+      ADD_LIBRARY(OpenEXR::OpenEXR ALIAS OpenEXR::openexr)
+      LIST(APPEND RV_DEPS_LIST OpenEXR::OpenEXR)
+    ENDIF()
+
+    # Handle Iex
+    IF(TARGET OpenEXR::Iex)
+      PROMOTE_TO_GLOBAL(OpenEXR::Iex)
+      LIST(APPEND RV_DEPS_LIST OpenEXR::Iex)
+    ELSEIF(TARGET OpenEXR::iex)
+      PROMOTE_TO_GLOBAL(OpenEXR::iex)
+      ADD_LIBRARY(OpenEXR::Iex ALIAS OpenEXR::iex)
+      LIST(APPEND RV_DEPS_LIST OpenEXR::Iex)
+    ENDIF()
+
+    # Handle IlmThread
+    IF(TARGET OpenEXR::IlmThread)
+      PROMOTE_TO_GLOBAL(OpenEXR::IlmThread)
+      LIST(APPEND RV_DEPS_LIST OpenEXR::IlmThread)
+    ELSEIF(TARGET OpenEXR::ilmthread)
+      PROMOTE_TO_GLOBAL(OpenEXR::ilmthread)
+      ADD_LIBRARY(OpenEXR::IlmThread ALIAS OpenEXR::ilmthread)
+      LIST(APPEND RV_DEPS_LIST OpenEXR::IlmThread)
+    ENDIF()
+
+    SET(RV_DEPS_OPENEXR_VERSION
+        "${OpenEXR_VERSION}"
+        CACHE INTERNAL "" FORCE
+    )
+    RETURN()
+  ENDIF()
+ENDIF()
 SET(_make_command
     make
 )

--- a/cmake/dependencies/openjpeg.cmake
+++ b/cmake/dependencies/openjpeg.cmake
@@ -21,6 +21,42 @@ IF(RV_TARGET_LINUX)
 ENDIF()
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PATH(
+    OPENJPEG_INCLUDE_DIR
+    NAMES openjpeg.h
+    PATH_SUFFIXES openjpeg-2.5 openjpeg-2.4 openjpeg-2.3
+  )
+  FIND_LIBRARY(
+    OPENJPEG_LIBRARY
+    NAMES openjp2
+  )
+
+  IF(OPENJPEG_INCLUDE_DIR
+     AND OPENJPEG_LIBRARY
+  )
+    MESSAGE(STATUS "Using Homebrew OpenJPEG")
+    IF(NOT TARGET OpenJpeg::OpenJpeg)
+      ADD_LIBRARY(OpenJpeg::OpenJpeg UNKNOWN IMPORTED GLOBAL)
+      SET_PROPERTY(
+        TARGET OpenJpeg::OpenJpeg
+        PROPERTY IMPORTED_LOCATION "${OPENJPEG_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        OpenJpeg::OpenJpeg
+        INTERFACE "${OPENJPEG_INCLUDE_DIR}"
+      )
+    ENDIF()
+    LIST(APPEND RV_DEPS_LIST OpenJpeg::OpenJpeg)
+    GET_FILENAME_COMPONENT(_openjpeg_root "${OPENJPEG_INCLUDE_DIR}/.." ABSOLUTE)
+    SET(RV_DEPS_OPENJPEG_ROOT_DIR
+        "${_openjpeg_root}"
+        CACHE INTERNAL "" FORCE
+    )
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/uclouvain/openjpeg/archive/refs/tags/v${_version}.tar.gz"
 )

--- a/cmake/dependencies/openjph.cmake
+++ b/cmake/dependencies/openjph.cmake
@@ -10,6 +10,33 @@
 
 # version 2+ requires changes to IOjp2 project
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_OPENJPH" "${RV_DEPS_OPENJPH_VERSION}" "make" "")
+
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(PkgConfig)
+  PKG_CHECK_MODULES(PC_OPENJPH openjph)
+  IF(PC_OPENJPH_FOUND)
+    MESSAGE(STATUS "Using Homebrew OpenJPH")
+    IF(NOT TARGET OpenJph::OpenJph)
+      ADD_LIBRARY(OpenJph::OpenJph UNKNOWN IMPORTED GLOBAL)
+      FIND_LIBRARY(
+        OPENJPH_LIBRARY
+        NAMES openjph
+        HINTS ${PC_OPENJPH_LIBDIR}
+      )
+      SET_PROPERTY(
+        TARGET OpenJph::OpenJph
+        PROPERTY IMPORTED_LOCATION "${OPENJPH_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        OpenJph::OpenJph
+        INTERFACE "${PC_OPENJPH_INCLUDE_DIRS}"
+      )
+    ENDIF()
+    LIST(APPEND RV_DEPS_LIST OpenJph::OpenJph)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 IF(RV_TARGET_LINUX)
   # Overriding _lib_dir created in 'RV_CREATE_STANDARD_DEPS_VARIABLES' since this CMake-based project isn't using lib64
   SET(_lib_dir

--- a/cmake/dependencies/openssl.cmake
+++ b/cmake/dependencies/openssl.cmake
@@ -11,6 +11,75 @@ SET(_version
     ${RV_DEPS_OPENSSL_VERSION}
 )
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(OpenSSL)
+  IF(OpenSSL_FOUND)
+    MESSAGE(STATUS "Using Homebrew OpenSSL: ${OPENSSL_VERSION}")
+
+    IF(TARGET OpenSSL::Crypto)
+      GET_TARGET_PROPERTY(_is_imported OpenSSL::Crypto IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          OpenSSL::Crypto
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ENDIF()
+
+    IF(TARGET OpenSSL::SSL)
+      GET_TARGET_PROPERTY(_is_imported OpenSSL::SSL IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          OpenSSL::SSL
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST OpenSSL::Crypto OpenSSL::SSL)
+
+    GET_FILENAME_COMPONENT(_openssl_include_dir "${OPENSSL_INCLUDE_DIR}" ABSOLUTE)
+    GET_FILENAME_COMPONENT(_openssl_root_dir "${_openssl_include_dir}/.." ABSOLUTE)
+
+    SET(RV_DEPS_OPENSSL_INSTALL_DIR
+        "${_openssl_root_dir}"
+        CACHE INTERNAL "" FORCE
+    )
+    SET(RV_DEPS_OPENSSL_VERSION
+        "${OPENSSL_VERSION}"
+        CACHE INTERNAL "" FORCE
+    )
+
+    SET_PROPERTY(
+      GLOBAL APPEND
+      PROPERTY "RV_FFMPEG_DEPENDS" OpenSSL::Crypto
+    )
+    SET_PROPERTY(
+      GLOBAL APPEND
+      PROPERTY "RV_FFMPEG_EXTRA_C_OPTIONS" "--extra-cflags=-I${OPENSSL_INCLUDE_DIR}"
+    )
+
+    GET_FILENAME_COMPONENT(_openssl_lib_dir "${OPENSSL_CRYPTO_LIBRARY}" DIRECTORY)
+    IF(RV_TARGET_WINDOWS)
+      SET_PROPERTY(
+        GLOBAL APPEND
+        PROPERTY "RV_FFMPEG_EXTRA_LIBPATH_OPTIONS" "--extra-ldflags=-LIBPATH:${_openssl_lib_dir}"
+      )
+    ELSE()
+      SET_PROPERTY(
+        GLOBAL APPEND
+        PROPERTY "RV_FFMPEG_EXTRA_LIBPATH_OPTIONS" "--extra-ldflags=-L${_openssl_lib_dir}"
+      )
+    ENDIF()
+    SET_PROPERTY(
+      GLOBAL APPEND
+      PROPERTY "RV_FFMPEG_EXTERNAL_LIBS" "--enable-openssl"
+    )
+
+    RETURN()
+  ENDIF()
+ENDIF()
+
 IF(RV_TARGET_IS_RHEL8
    AND RV_VFX_PLATFORM STREQUAL CY2023
 )

--- a/cmake/dependencies/pcre2.cmake
+++ b/cmake/dependencies/pcre2.cmake
@@ -7,6 +7,35 @@
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_PCRE2" "pcre2-${RV_DEPS_PCRE2_VERSION}" "make" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(PCRE2 CONFIG)
+  IF(PCRE2_FOUND)
+    MESSAGE(STATUS "Using Homebrew PCRE2")
+    IF(TARGET PCRE2::8bit)
+      IF(NOT TARGET pcre2-8)
+        ADD_LIBRARY(pcre2-8 INTERFACE IMPORTED GLOBAL)
+        TARGET_LINK_LIBRARIES(
+          pcre2-8
+          INTERFACE PCRE2::8bit
+        )
+      ENDIF()
+    ENDIF()
+
+    IF(TARGET PCRE2::posix)
+      IF(NOT TARGET pcre2-posix)
+        ADD_LIBRARY(pcre2-posix INTERFACE IMPORTED GLOBAL)
+        TARGET_LINK_LIBRARIES(
+          pcre2-posix
+          INTERFACE PCRE2::posix
+        )
+      ENDIF()
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST pcre2-8 pcre2-posix)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/PCRE2Project/pcre2/archive/refs/tags/${_version}.zip"
 )

--- a/cmake/dependencies/png.cmake
+++ b/cmake/dependencies/png.cmake
@@ -13,6 +13,43 @@
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_PNG" "${RV_DEPS_PNG_VERSION}" "" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(PNG)
+  IF(PNG_FOUND)
+    MESSAGE(STATUS "Using Homebrew PNG: ${PNG_VERSION_STRING}")
+
+    IF(TARGET PNG::PNG)
+      GET_TARGET_PROPERTY(_is_imported PNG::PNG IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          PNG::PNG
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ELSE()
+      ADD_LIBRARY(PNG::PNG UNKNOWN IMPORTED GLOBAL)
+      SET_PROPERTY(
+        TARGET PNG::PNG
+        PROPERTY IMPORTED_LOCATION "${PNG_LIBRARY}"
+      )
+      IF(PNG_PNG_INCLUDE_DIR)
+        TARGET_INCLUDE_DIRECTORIES(
+          PNG::PNG
+          INTERFACE "${PNG_PNG_INCLUDE_DIR}"
+        )
+      ELSE()
+        TARGET_INCLUDE_DIRECTORIES(
+          PNG::PNG
+          INTERFACE "${PNG_INCLUDE_DIR}"
+        )
+      ENDIF()
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST PNG::PNG)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/glennrp/libpng/archive/refs/tags/v${_version}.tar.gz"
 )

--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -4,6 +4,109 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+SET(Python3_FIND_VIRTUALENV
+    FIRST
+)
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(
+    Python3
+    COMPONENTS Interpreter Development
+  )
+  IF(Python3_FOUND)
+    MESSAGE(STATUS "Using Homebrew/System Python3: ${Python3_VERSION}")
+
+    # Satisfy variables used in requirements.txt template etc
+    SET(RV_DEPS_PYTHON_VERSION
+        "${Python3_VERSION}"
+        CACHE INTERNAL "" FORCE
+    )
+    SET(RV_DEPS_PYTHON_VERSION_SHORT
+        "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
+        CACHE INTERNAL "" FORCE
+    )
+    SET(RV_DEPS_PYTHON3_EXECUTABLE
+        "${Python3_EXECUTABLE}"
+        CACHE INTERNAL "" FORCE
+    )
+
+    # Satisfy targets that depend on Python::Python
+    IF(NOT TARGET Python::Python)
+      ADD_LIBRARY(Python::Python INTERFACE IMPORTED GLOBAL)
+      TARGET_LINK_LIBRARIES(
+        Python::Python
+        INTERFACE Python3::Python
+      )
+    ENDIF()
+
+    # Check for PySide if possible
+    IF(RV_VFX_PLATFORM STREQUAL "CY2023")
+      SET(_pyside_pkg
+          "PySide2"
+      )
+    ELSE()
+      SET(_pyside_pkg
+          "PySide6"
+      )
+    ENDIF()
+
+    EXECUTE_PROCESS(
+      COMMAND "${Python3_EXECUTABLE}" -c "import ${_pyside_pkg}; print(${_pyside_pkg}.__version__)"
+      RESULT_VARIABLE _pyside_check_res
+      OUTPUT_VARIABLE _pyside_ver
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    IF(_pyside_check_res EQUAL 0)
+      MESSAGE(STATUS "Using Homebrew/System ${_pyside_pkg}: ${_pyside_ver}")
+      SET(RV_DEPS_PYSIDE_VERSION
+          "${_pyside_ver}"
+          CACHE INTERNAL "" FORCE
+      )
+    ELSE()
+      MESSAGE(WARNING "Homebrew/System ${_pyside_pkg} not found in ${Python3_EXECUTABLE}")
+    ENDIF()
+
+    # Skip everything else in this file
+    LIST(APPEND RV_DEPS_LIST Python::Python)
+
+    # Define flags so later custom commands don't fail on missing dependencies
+    SET(${_python3_target}-requirements-flag
+        "${CMAKE_BINARY_DIR}/python3-brew-requirements-flag"
+        CACHE INTERNAL ""
+    )
+    ADD_CUSTOM_COMMAND(
+      OUTPUT "${${_python3_target}-requirements-flag}"
+      COMMAND ${CMAKE_COMMAND} -E touch "${${_python3_target}-requirements-flag}"
+    )
+
+    SET(${_pyside_target}-build-flag
+        "${CMAKE_BINARY_DIR}/pyside-brew-build-flag"
+        CACHE INTERNAL ""
+    )
+    ADD_CUSTOM_COMMAND(
+      OUTPUT "${${_pyside_target}-build-flag}"
+      COMMAND ${CMAKE_COMMAND} -E touch "${${_pyside_target}-build-flag}"
+    )
+
+    # Create dummy targets for staged dependencies if they don't exist
+    IF(NOT TARGET ${_python3_target}-stage-target)
+      ADD_CUSTOM_TARGET(
+        ${_python3_target}-stage-target
+        DEPENDS "${${_python3_target}-requirements-flag}" "${${_pyside_target}-build-flag}"
+      )
+      ADD_DEPENDENCIES(dependencies ${_python3_target}-stage-target)
+    ENDIF()
+
+    RETURN()
+  ENDIF()
+ENDIF()
+
+FIND_PACKAGE(
+  Python3
+  COMPONENTS Interpreter
+  REQUIRED
+)
+
 SET(_python3_target
     "RV_DEPS_PYTHON3"
 )
@@ -89,7 +192,7 @@ SET(_python3_make_command_script
     "${PROJECT_SOURCE_DIR}/src/build/make_python.py"
 )
 SET(_python3_make_command
-    python3 "${_python3_make_command_script}"
+    ${Python3_EXECUTABLE} "${_python3_make_command_script}"
 )
 LIST(APPEND _python3_make_command "--variant")
 LIST(APPEND _python3_make_command ${CMAKE_BUILD_TYPE})
@@ -117,7 +220,7 @@ IF(RV_VFX_PLATFORM STREQUAL CY2023)
       "${PROJECT_SOURCE_DIR}/src/build/make_pyside.py"
   )
   SET(_pyside_make_command
-      python3 "${_pyside_make_command_script}"
+      ${Python3_EXECUTABLE} "${_pyside_make_command_script}"
   )
 
   LIST(APPEND _pyside_make_command "--variant")
@@ -145,7 +248,7 @@ ELSEIF(RV_VFX_PLATFORM STRGREATER_EQUAL CY2024)
       "${PROJECT_SOURCE_DIR}/src/build/make_pyside6.py"
   )
   SET(_pyside_make_command
-      python3 "${_pyside_make_command_script}"
+      ${Python3_EXECUTABLE} "${_pyside_make_command_script}"
   )
 
   LIST(APPEND _pyside_make_command "--variant")
@@ -348,6 +451,7 @@ LIST(
   :all:
   --only-binary
   ${_wheel_safe_packages}
+  ${RV_PYTHON_WHEEL_SAFE}
   -r
   "${_requirements_output_file}"
 )
@@ -436,7 +540,7 @@ SET(_test_python_script
 ADD_CUSTOM_COMMAND(
   COMMENT "Testing Python distribution"
   OUTPUT ${${_python3_target}-test-flag}
-  COMMAND python3 "${_test_python_script}" --python-home "${_install_dir}" --variant "${CMAKE_BUILD_TYPE}"
+  COMMAND ${Python3_EXECUTABLE} "${_test_python_script}" --python-home "${_install_dir}" --variant "${CMAKE_BUILD_TYPE}"
   COMMAND cmake -E touch ${${_python3_target}-test-flag}
   DEPENDS ${${_python3_target}-requirements-flag} ${_test_python_script}
 )

--- a/cmake/dependencies/raw.cmake
+++ b/cmake/dependencies/raw.cmake
@@ -18,6 +18,32 @@ IF(RV_TARGET_LINUX)
 ENDIF()
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(PkgConfig)
+  PKG_CHECK_MODULES(PC_RAW libraw)
+  IF(PC_RAW_FOUND)
+    MESSAGE(STATUS "Using Homebrew LibRaw")
+    IF(NOT TARGET LibRaw::raw)
+      ADD_LIBRARY(LibRaw::raw UNKNOWN IMPORTED GLOBAL)
+      FIND_LIBRARY(
+        RAW_LIBRARY
+        NAMES raw
+        HINTS ${PC_RAW_LIBDIR}
+      )
+      SET_PROPERTY(
+        TARGET LibRaw::raw
+        PROPERTY IMPORTED_LOCATION "${RAW_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        LibRaw::raw
+        INTERFACE "${PC_RAW_INCLUDE_DIRS}"
+      )
+    ENDIF()
+    LIST(APPEND RV_DEPS_LIST LibRaw::raw)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/LibRaw/LibRaw/archive/refs/tags/${_version}.tar.gz"
 )

--- a/cmake/dependencies/spdlog.cmake
+++ b/cmake/dependencies/spdlog.cmake
@@ -6,6 +6,34 @@
 
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_SPDLOG" "${RV_DEPS_SPDLOG_VERSION}" "" "")
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(spdlog CONFIG)
+  IF(spdlog_FOUND)
+    MESSAGE(STATUS "Using Homebrew spdlog: ${spdlog_VERSION}")
+
+    IF(TARGET spdlog::spdlog)
+      GET_TARGET_PROPERTY(_is_imported spdlog::spdlog IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          spdlog::spdlog
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ENDIF()
+
+    IF(NOT TARGET spdlog::spdlog)
+      ADD_LIBRARY(spdlog::spdlog INTERFACE IMPORTED GLOBAL)
+      TARGET_LINK_LIBRARIES(
+        spdlog::spdlog
+        INTERFACE spdlog::spdlog_header_only
+      )
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST spdlog::spdlog)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/gabime/spdlog/archive/refs/tags/v${_version}.zip"
 )

--- a/cmake/dependencies/tiff.cmake
+++ b/cmake/dependencies/tiff.cmake
@@ -17,6 +17,45 @@
 # OpenImageIO required >= 3.9, using latest 4.0
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_TIFF" "${RV_DEPS_TIFF_VERSION}" "" "")
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(TIFF)
+  IF(TIFF_FOUND)
+    MESSAGE(STATUS "Using Homebrew TIFF: ${TIFF_VERSION}")
+
+    # RV build system expects TIFF::TIFF
+    IF(TARGET TIFF::TIFF)
+      GET_TARGET_PROPERTY(_is_imported TIFF::TIFF IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          TIFF::TIFF
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ELSE()
+      ADD_LIBRARY(TIFF::TIFF UNKNOWN IMPORTED GLOBAL)
+      SET_PROPERTY(
+        TARGET TIFF::TIFF
+        PROPERTY IMPORTED_LOCATION "${TIFF_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        TIFF::TIFF
+        INTERFACE "${TIFF_INCLUDE_DIR}"
+      )
+    ENDIF()
+
+    IF(NOT TARGET Tiff::Tiff)
+      ADD_LIBRARY(Tiff::Tiff INTERFACE IMPORTED GLOBAL)
+      TARGET_LINK_LIBRARIES(
+        Tiff::Tiff
+        INTERFACE TIFF::TIFF
+      )
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST TIFF::TIFF)
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://gitlab.com/libtiff/libtiff/-/archive/v${_version}/libtiff-v${_version}.tar.gz"
 )

--- a/cmake/dependencies/webp.cmake
+++ b/cmake/dependencies/webp.cmake
@@ -16,6 +16,45 @@
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_WEBP" "${RV_DEPS_WEBP_VERSION}" "make" "")
 RV_SHOW_STANDARD_DEPS_VARIABLES()
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(WebP CONFIG)
+  IF(WebP_FOUND)
+    MESSAGE(STATUS "Using Homebrew WebP")
+    IF(TARGET WebP::webp)
+      IF(NOT TARGET Webp::Webp)
+        ADD_LIBRARY(Webp::Webp INTERFACE IMPORTED GLOBAL)
+        TARGET_LINK_LIBRARIES(
+          Webp::Webp
+          INTERFACE WebP::webp
+        )
+      ENDIF()
+    ELSE()
+      FIND_LIBRARY(
+        WEBP_LIBRARY
+        NAMES webp
+      )
+      IF(WEBP_LIBRARY)
+        ADD_LIBRARY(Webp::Webp UNKNOWN IMPORTED GLOBAL)
+        SET_PROPERTY(
+          TARGET Webp::Webp
+          PROPERTY IMPORTED_LOCATION "${WEBP_LIBRARY}"
+        )
+        TARGET_INCLUDE_DIRECTORIES(
+          Webp::Webp
+          INTERFACE "${WebP_INCLUDE_DIRS}"
+        )
+      ENDIF()
+    ENDIF()
+    LIST(APPEND RV_DEPS_LIST Webp::Webp)
+    GET_FILENAME_COMPONENT(_webp_root "${WebP_DIR}/../../.." ABSOLUTE)
+    SET(RV_DEPS_WEBP_ROOT_DIR
+        "${_webp_root}"
+        CACHE INTERNAL "" FORCE
+    )
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/webmproject/libwebp/archive/refs/tags/v${_version}.tar.gz"
 )

--- a/cmake/dependencies/yaml-cpp.cmake
+++ b/cmake/dependencies/yaml-cpp.cmake
@@ -9,6 +9,24 @@
 # Expose OCIO's own 'yaml_cpp' target replacing the legacy 'src/pub/yaml_cpp' folder.
 #
 # ##############################################################################################################################################################
+
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(yaml-cpp CONFIG)
+  IF(yaml-cpp_FOUND)
+    MESSAGE(STATUS "Using Homebrew yaml-cpp: ${yaml-cpp_VERSION}")
+    ADD_LIBRARY(yaml_cpp INTERFACE IMPORTED GLOBAL)
+    TARGET_LINK_LIBRARIES(
+      yaml_cpp
+      INTERFACE yaml-cpp
+    )
+    SET(RV_DEPS_YAML_CPP_VERSION
+        "${yaml-cpp_VERSION}"
+        CACHE INTERNAL "" FORCE
+    )
+    RETURN()
+  ENDIF()
+ENDIF()
+
 ADD_LIBRARY(yaml_cpp STATIC IMPORTED GLOBAL)
 ADD_DEPENDENCIES(yaml_cpp RV_DEPS_OCIO)
 IF(CMAKE_BUILD_TYPE MATCHES "^Debug$")

--- a/cmake/dependencies/zlib.cmake
+++ b/cmake/dependencies/zlib.cmake
@@ -6,6 +6,45 @@
 
 RV_CREATE_STANDARD_DEPS_VARIABLES("RV_DEPS_ZLIB" "${RV_DEPS_ZLIB_VERSION}" "" "")
 
+IF(RV_USE_BREW_DEPS)
+  FIND_PACKAGE(ZLIB)
+  IF(ZLIB_FOUND)
+    MESSAGE(STATUS "Using Homebrew ZLIB: ${ZLIB_VERSION_STRING}")
+
+    IF(TARGET ZLIB::ZLIB)
+      GET_TARGET_PROPERTY(_is_imported ZLIB::ZLIB IMPORTED)
+      IF(_is_imported)
+        SET_TARGET_PROPERTIES(
+          ZLIB::ZLIB
+          PROPERTIES IMPORTED_GLOBAL TRUE
+        )
+      ENDIF()
+    ELSE()
+      ADD_LIBRARY(ZLIB::ZLIB UNKNOWN IMPORTED GLOBAL)
+      SET_PROPERTY(
+        TARGET ZLIB::ZLIB
+        PROPERTY IMPORTED_LOCATION "${ZLIB_LIBRARY}"
+      )
+      TARGET_INCLUDE_DIRECTORIES(
+        ZLIB::ZLIB
+        INTERFACE "${ZLIB_INCLUDE_DIRS}"
+      )
+    ENDIF()
+
+    LIST(APPEND RV_DEPS_LIST ZLIB::ZLIB)
+    SET(RV_DEPS_ZLIB_VERSION
+        "${ZLIB_VERSION_STRING}"
+        CACHE INTERNAL "" FORCE
+    )
+    SET(RV_DEPS_ZLIB_INCLUDE_DIR
+        "${ZLIB_INCLUDE_DIRS}"
+        CACHE STRING "Path to installed includes" FORCE
+    )
+
+    RETURN()
+  ENDIF()
+ENDIF()
+
 SET(_download_url
     "https://github.com/madler/zlib/archive/refs/tags/v${_version}.zip"
 )

--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -97,16 +97,30 @@ FUNCTION(rv_stage)
           ${RV_DEPS_LIST}
         )
           IF(TARGET ${dep})
-            GET_PROPERTY(
-              dep_file_path
-              TARGET ${dep}
-              PROPERTY LOCATION
-            )
-            GET_FILENAME_COMPONENT(dep_file_name ${dep_file_path} NAME)
-            ADD_CUSTOM_COMMAND(
-              COMMENT "Fixing ${dep_file_name}'s rpath in ${arg_TARGET}" TARGET ${arg_TARGET} POST_BUILD
-              COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change "${dep_file_path}" "@rpath/${dep_file_name}" "$<TARGET_FILE:${arg_TARGET}>"
-            )
+            GET_TARGET_PROPERTY(dep_type ${dep} TYPE)
+            IF(NOT dep_type STREQUAL "INTERFACE_LIBRARY")
+              GET_PROPERTY(
+                dep_file_path
+                TARGET ${dep}
+                PROPERTY LOCATION
+              )
+              IF(dep_file_path)
+                STRING(REGEX MATCH "^/opt/homebrew" _is_homebrew "${dep_file_path}")
+                STRING(REGEX MATCH "^/usr/local" _is_usr_local "${dep_file_path}")
+                STRING(REGEX MATCH "^/usr/lib" _is_usr_lib "${dep_file_path}")
+
+                IF(NOT _is_homebrew
+                   AND NOT _is_usr_local
+                   AND NOT _is_usr_lib
+                )
+                  GET_FILENAME_COMPONENT(dep_file_name "${dep_file_path}" NAME)
+                  ADD_CUSTOM_COMMAND(
+                    COMMENT "Fixing ${dep_file_name}'s rpath in ${arg_TARGET}" TARGET ${arg_TARGET} POST_BUILD
+                    COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change "${dep_file_path}" "@rpath/${dep_file_name}" "$<TARGET_FILE:${arg_TARGET}>"
+                  )
+                ENDIF()
+              ENDIF()
+            ENDIF()
           ENDIF()
         ENDFOREACH()
       ENDIF()

--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -464,3 +464,77 @@ else
     rvrelease
   fi
 fi
+
+rvbuild-withbrew() {
+  # Define brew dependencies
+  # Format: "cmake_file_prefix:brew_package"
+  local deps=(
+      "dav1d:dav1d"
+      "expat:expat"
+      "ffmpeg:ffmpeg"
+      "gc:bdw-gc"
+      "glew:glew"
+      "imath:imath"
+      "jpegturbo:jpeg-turbo"
+      "mbedtls:mbedtls"
+      "ocio:opencolorio"
+      "oiio:openimageio"
+      "openexr:openexr"
+      "openjpeg:openjpeg"
+      "openjph:openjph"
+      "openssl:openssl@3"
+      "pcre2:pcre2"
+      "png:libpng"
+      "raw:libraw"
+      "spdlog:spdlog"
+      "tiff:libtiff"
+      "webp:webp"
+      "zlib:zlib"
+  )
+
+  local missing_pkgs=()
+  local prefix_paths=""
+  local brew_prefix=$(brew --prefix)
+
+  echo "Checking Homebrew dependencies..."
+  for dep in "${deps[@]}"; do
+      local pkg="${dep#*:}"
+      if ! brew list --versions "$pkg" >/dev/null 2>&1; then
+          missing_pkgs+=("$pkg")
+      else
+          # Get prefix for CMAKE_PREFIX_PATH
+          # Some packages are keg-only (like openssl, curl), so we need their direct path
+          local p="${brew_prefix}/opt/${pkg}"
+          if [ -d "$p" ]; then
+             if [ -z "$prefix_paths" ]; then
+                 prefix_paths="$p"
+             else
+                 prefix_paths="$prefix_paths;$p"
+             fi
+          fi
+      fi
+  done
+
+  if [ ${#missing_pkgs[@]} -gt 0 ]; then
+      echo "Missing Homebrew packages:"
+      printf "  %s\n" "${missing_pkgs[@]}"
+      echo ""
+      echo "Run the following command to install them:"
+      echo "brew install ${missing_pkgs[*]}"
+      return 1
+  fi
+
+  echo "All dependencies found."
+  
+  echo "Configuring with Homebrew dependencies..."
+  # Pass RV_USE_BREW_DEPS=ON and CMAKE_PREFIX_PATH
+  rvcfg -DRV_USE_BREW_DEPS=ON -DCMAKE_PREFIX_PATH="$prefix_paths"
+  
+  if [ $? -eq 0 ]; then
+      echo "Configuration successful. Starting build..."
+      rvbuild
+  else
+      echo "Configuration failed."
+      return 1
+  fi
+}


### PR DESCRIPTION
### Summarize your change.
This branch introduces a new `experimental` build command `rvbuild-withbrew` that allows users on macOS to more quickly install OpenRV with publicly released packages of dependencies.  Users get the latest versions, and build conflicts with already present brew packages are avoided.

Additionally this is a first step towards the ability to easily and quickly install with homebrew eg: `brew install openrv` as homebrew best practice requires formulas to install existing packages rather than build from source.  

It is experimental because the OpenRV project is currently beholden to the https://vfxplatform.com/ which stipulates `max` rather than `min` versions allowed for a given CY year, and public packages like openexr may exceed that.  However this command also presents an opportunity to canary newer versions of dependencies in hopes of highlighting breaking changes to the community.

### Describe the reason for the change.
Currently the build process for OpenRV takes quite a while and can cause conflicts with currently installed packages via `homebrew`.  This is because OpenRV is using a hybrid of brew installed packages and bundled dependencies that are version pinned, pulled and built from source.  During the build process on macOS, OpenRV will download and build all the dependencies, but subsequently during linking will find the homebrew installed packages and fail to build.  

A common issue I have ran into is when having `openexr` installed and linked, the `rvmk` command will download and build the openexr version specified for the CY year, however when it comes time to link (eg when building `OpenImageIO`, it will link back to the homebrew installed version of openexr and imath causing build errors.  Temporarily unlinking openexr via `brew unlink openexr` resolves this, and then after I have to `brew link openexr` to return my system to the way I want it.

There are ways of disabling the Homebrew path for cmake, however this causes issues with dependencies that are not bundled (eg xz or zlib).  We can also be more explicit in each dependency to link only to the paths within the `_build` folder.  There are improvements to be made here.

While building with the latest homebrew packages of various software will break CY Year conformance, the reality is that there are a lot of non-technical people out there who just want to easily build and run RV with the latest dependencies (eg openexr) to take advantage of performance, security, bug and feature improvements.  They don't care about legacy CY Year things.  This PR allows that to happen.

### Describe what you have tested and on which operating system.
macOS 26 on a macbook air m4
```
source rvcmds.sh
rvclean
rvsetup
time (rvbuild-withbrew)
```

**Builds OpenRV in around 6 minutes on a macbook air m4**
```
✓ Build completed successfully!
( rvbuild-withbrew; )  373.42s user 160.58s system 351% cpu 2:31.95 total
```

Biggest time sinks are Boost and ImgGui 

```
lines = open("_build/.ninja_log").readlines()[1:]
data = [l.split() for l in lines]
data = [(int(d[1]) - int(d[0]), d[3]) for d in data]
data.sort(reverse=True)
[print(f"{t/1000.0:>8.2f}s | {n}") for t, n in data[:20]]
```


### Add a list of changes, and note any that might need special attention during the review.
This branch introduces a new build command that sets an env var `RV_USE_BREW_DEPS`.  That env var is checked for inside individual package cmake files so the change is isolated and does not affect anything with the current build config.

This PR is dependent on merging of the following PR's:

- #1176 (because we need to reference the public headers of libTiff

- #1087 (because OpenImageIO is now v3 )

### If possible, provide screenshots.