### PR TITLE
chore: SG-43402: python requirements updated to latest versions

### DIFF
--- a/rvcmds.sh
+++ b/rvcmds.sh
@@ -61,7 +61,15 @@ if [[ "$OSTYPE" == "linux"* ]]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
   RV_TOOLCHAIN=""
-  export PATH="/opt/homebrew/opt/python@3.11/libexec/bin:$PATH" 
+  if [[ "$RV_VFX_PLATFORM" == "CY2026" ]]; then
+    export PATH="/opt/homebrew/opt/python@3.13/libexec/bin:$PATH"
+  elif [[ "$RV_VFX_PLATFORM" == "CY2024" ]] || [[ "$RV_VFX_PLATFORM" == "CY2025" ]]; then
+    export PATH="/opt/homebrew/opt/python@3.11/libexec/bin:$PATH"
+  elif [[ "$RV_VFX_PLATFORM" == "CY2023" ]]; then
+    export PATH="/opt/homebrew/opt/python@3.10/libexec/bin:$PATH"
+  else
+    export PATH="/opt/homebrew/opt/python3/libexec/bin:$PATH"
+  fi
 
 # Windows
 elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then

--- a/src/build/requirements.txt.in
+++ b/src/build/requirements.txt.in
@@ -6,19 +6,19 @@
 #       Pure Python packages and build tools safe to install from wheels are listed in RV_PYTHON_WHEEL_SAFE in python3.cmake.
 #       This approach ensures safety by default: new packages will be built from source unless explicitly marked as wheel-safe.
 
-pip==24.0               # License: MIT License (MIT)
-setuptools==69.5.1      # License: MIT License
-wheel==0.43.0           # License: MIT License (MIT)
-numpy==@_numpy_version@ # License: BSD License (BSD-3-Clause) - Required by PySide6
-opentimelineio==@_opentimelineio_version@ # License: Other/Proprietary License (Modified Apache 2.0 License)
-PyOpenGL==3.1.7         # License: BSD License (BSD)
-PyOpenGL_accelerate==3.1.10 # License: BSD License (BSD) - v3.1.10 includes Python 3 fix for Cython compatibility
+numpy==@_numpy_version@                     # License: BSD License (BSD-3-Clause) - Required by PySide6
+opentimelineio==@_opentimelineio_version@   # License: Other/Proprietary License (Modified Apache 2.0 License)
+pip==26.0.1                                 # License: MIT License (MIT)
+PyOpenGL_accelerate~=3.1.10                 # License: BSD License (BSD) - v3.1.10 includes Python 3 fix for Cython compatibility
+PyOpenGL~=3.1.10                            # License: BSD License (BSD)
+setuptools==82.0.1                          # License: MIT License
+wheel==0.46.3                               # License: MIT License (MIT)
 
 # Additional packages required by RV and for testing the Python distribution
 
-certifi==2024.2.2       # License: Mozilla Public License 2.0 (MPL 2.0) (MPL-2.0)
-six==1.16.0             # License: MIT License (MIT)
-packaging==24.0         # License: Apache Software License, BSD License
-requests==2.31.0        # License: Apache Software License (Apache 2.0)
-cryptography==42.0.5    # License: Apache Software License, BSD License ((Apache-2.0 OR BSD-3-Clause) AND PSF-2.0)
-pydantic==2.7.1         # License: MIT License (MIT)
+certifi==2026.2.25          # License: Mozilla Public License 2.0 (MPL 2.0) (MPL-2.0)
+cryptography==46.0.5        # License: Apache Software License, BSD License ((Apache-2.0 OR BSD-3-Clause) AND PSF-2.0)
+packaging==26.0             # License: Apache Software License, BSD License
+pydantic==2.12.5            # License: MIT License (MIT)
+requests==2.32.5            # License: Apache Software License (Apache 2.0)
+six==1.17.0                 # License: MIT License (MIT)


### PR DESCRIPTION
### Summarize your change.
the `requirements.txt.in` file which installs packages during python builds had specific versions pinned that were in many cases over two years old.  Things like certifi, requests, pip, cryptography, etc.. can and in some cases should  be latest. Additionally PyOpenGL was a different version than the PyOpenGL_accelerate so that was synced.

I also took this moment to place them in alphabetical order

### Describe the reason for the change.
Many of those pinned packages lacked support for newer version of Python (eg python 3.14) and have received numerous security, features, and performance improvements in the last couple years. 

### Describe what you have tested and on which operating system.
macOS 26.  Builds on 2024 and 2025

### Add a list of changes, and note any that might need special attention during the review.
I considered not setting a version at all (always latest) or setting minimum versions rather than pinning a specific version, but opted to conform to the existing format.  

If you feel differently for certain packages let me know and I'll make the changes. eg `certifi>=2026.2.25` or just `certifi` probably make sense along with a few others.
