### PR TITLE
build: Improve resolution of Python for OCIO

### DIFF
--- a/cmake/dependencies/ocio.cmake
+++ b/cmake/dependencies/ocio.cmake
@@ -206,7 +206,11 @@ ELSE() # Windows
     "-DZLIB_INCLUDE_DIR=${_zlib_include_dir}"
     "-Dexpat_ROOT=${RV_DEPS_EXPAT_ROOT_DIR}"
     "-DImath_DIR=${RV_DEPS_IMATH_ROOT_DIR}/lib/cmake/Imath"
-    "-DPython_ROOT=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install"
+    "-DPython_ROOT_DIR=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install"
+    # Force CMake to use our custom Python, not the system/registry Python. Python_FIND_REGISTRY=NEVER prevents Windows registry lookups that find the system
+    # Python from actions/setup-python. Python_FIND_STRATEGY=LOCATION ensures Python_ROOT_DIR is checked before the default search paths.
+    "-DPython_FIND_REGISTRY=NEVER"
+    "-DPython_FIND_STRATEGY=LOCATION"
     # Mandatory param: OCIO CMake code finds Python.
     "-DPython_LIBRARY=${RV_DEPS_BASE_DIR}/RV_DEPS_PYTHON3/install/bin/python${PYTHON_VERSION_SHORT_NO_DOT}.lib" # with this param
     # DRV_Python_LIBRARIES: A Patch RV created for PyOpenColorIO inside OCIO: Hardcode to Release since FindPython.cmake will find the Debug lib, which we don't

--- a/src/build/patch_OCIO/ocio_pyopencolorio_patch.py
+++ b/src/build/patch_OCIO/ocio_pyopencolorio_patch.py
@@ -11,7 +11,7 @@ def patch_execute(filename):
     with open(backup_cmakelist_path, "r") as backup_cmakelist:
         with open(filename, "w") as cmakelist:
             for line in backup_cmakelist:
-                if re.match("^\s*set.*_PublicLibs", line):
+                if re.match(r"^\s*set.*_PublicLibs", line, re.IGNORECASE):
                     new_line = line.replace(
                         "set(_PublicLibs ${Python_LIBRARIES})",
                         "set(_PublicLibs ${RV_Python_LIBRARIES})",


### PR DESCRIPTION
### Improve resolution of Python for OCIO

### Linked issues
None

### Summarize your change.

Fix `Python.h` not found when building PyOpenColorIO (OCIO's Python bindings).

### Describe the reason for the change.
The CI was failing since the merge of OIIO 3 PR because OCIO was having issue finding Python. Altough, I am not 100% certain how that PR caused this.

### Describe what you have tested and on which operating system.
MacOS, CI