### PR TITLE
build: Fix various with the debug build on Windows

### DIFF
--- a/cmake/dependencies/pyimgui.cmake
+++ b/cmake/dependencies/pyimgui.cmake
@@ -108,3 +108,16 @@ RV_STAGE_DEPENDENCY_LIBS(
   OUTPUTS
   ${_pybindings_location}/${_libname}
 )
+
+# Windows only. Debug Python on Windows searches for modules with *_d suffix, but pyimgui does not create a pyimgui_d.pyd.
+IF(RV_TARGET_WINDOWS
+   AND CMAKE_BUILD_TYPE MATCHES "^Debug$"
+)
+  ADD_CUSTOM_COMMAND(
+    TARGET ${_target}
+    POST_BUILD
+    COMMENT "Copying pyimgui.pyd to pyimgui_d.pyd in '${_pybindings_location}' for Python debug compatibility."
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${_pybindings_location}
+    COMMAND ${CMAKE_COMMAND} -E copy ${_libpath} ${_pybindings_location}/pyimgui_d.pyd
+  )
+ENDIF()

--- a/cmake/dependencies/pyimplot.cmake
+++ b/cmake/dependencies/pyimplot.cmake
@@ -104,3 +104,16 @@ RV_STAGE_DEPENDENCY_LIBS(
   OUTPUTS
   ${_pybindings_location}/${_libname}
 )
+
+# Windows only. Debug Python on Windows searches for modules with *_d suffix, but pyimplot does not create a pyimplot_d.pyd.
+IF(RV_TARGET_WINDOWS
+   AND CMAKE_BUILD_TYPE MATCHES "^Debug$"
+)
+  ADD_CUSTOM_COMMAND(
+    TARGET ${_target}
+    POST_BUILD
+    COMMENT "Copying pyimplot.pyd to pyimplot_d.pyd in '${_pybindings_location}' for Python debug compatibility."
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${_pybindings_location}
+    COMMAND ${CMAKE_COMMAND} -E copy ${_libpath} ${_pybindings_location}/pyimplot_d.pyd
+  )
+ENDIF()

--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -562,21 +562,31 @@ SET_PROPERTY(
   PROPERTY IMPORTED_SONAME ${_python3_lib_name}
 )
 IF(RV_TARGET_WINDOWS)
-  # Set per-config import libs so multi-config generators (VS) pick the right one.
-  # Without this, IMPORTED_IMPLIB would be fixed to whichever CMAKE_BUILD_TYPE was
-  # set at configure time, causing LNK1104 when building a different configuration.
+  # Set per-config import libs so multi-config generators (VS) pick the right one. Without this, IMPORTED_IMPLIB would be fixed to whichever CMAKE_BUILD_TYPE
+  # was set at configure time, causing LNK1104 when building a different configuration.
   SET(_python_debug_implib
       ${_lib_dir}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_d${CMAKE_IMPORT_LIBRARY_SUFFIX}
   )
   SET(_python_release_implib
       ${_lib_dir}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}${CMAKE_IMPORT_LIBRARY_SUFFIX}
   )
-  SET_PROPERTY(TARGET Python::Python PROPERTY IMPORTED_IMPLIB_DEBUG ${_python_debug_implib})
-  SET_PROPERTY(TARGET Python::Python PROPERTY IMPORTED_IMPLIB_RELEASE ${_python_release_implib})
-  SET_PROPERTY(TARGET Python::Python PROPERTY IMPORTED_IMPLIB_RELWITHDEBINFO ${_python_release_implib})
-  SET_PROPERTY(TARGET Python::Python PROPERTY IMPORTED_IMPLIB_MINSIZEREL ${_python_release_implib})
-  # Also expose the libs dir so #pragma comment(lib, "python311.lib") in Python
-  # headers can be resolved by the linker for non-debug configurations.
+  SET_PROPERTY(
+    TARGET Python::Python
+    PROPERTY IMPORTED_IMPLIB_DEBUG ${_python_debug_implib}
+  )
+  SET_PROPERTY(
+    TARGET Python::Python
+    PROPERTY IMPORTED_IMPLIB_RELEASE ${_python_release_implib}
+  )
+  SET_PROPERTY(
+    TARGET Python::Python
+    PROPERTY IMPORTED_IMPLIB_RELWITHDEBINFO ${_python_release_implib}
+  )
+  SET_PROPERTY(
+    TARGET Python::Python
+    PROPERTY IMPORTED_IMPLIB_MINSIZEREL ${_python_release_implib}
+  )
+  # Also expose the libs dir so #pragma comment(lib, "python311.lib") in Python headers can be resolved by the linker for non-debug configurations.
   TARGET_LINK_DIRECTORIES(Python::Python INTERFACE ${_lib_dir})
 ENDIF()
 FILE(MAKE_DIRECTORY ${_include_dir})

--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -342,7 +342,8 @@ ENDIF()
 LIST(
   APPEND
   _requirements_install_command
-  "CMAKE_ARGS=-DPYTHON_LIBRARY=${_python3_cmake_library} -DPYTHON_INCLUDE_DIR=${_include_dir} -DPYTHON_EXECUTABLE=${_python3_executable}"
+  # Use old and more recent library name convention to ensure the correct library is used in the build.
+  "CMAKE_ARGS=-DPYTHON_LIBRARY=${_python3_cmake_library} -DPYTHON_INCLUDE_DIR=${_include_dir} -DPYTHON_EXECUTABLE=${_python3_executable} -DPython_INCLUDE_DIR=${_include_dir} -DPython_LIBRARY=${_python3_cmake_library} -DPython_EXECUTABLE=${_python3_executable} -DPython_ROOT_DIR=${_install_dir}"
   "${_python3_executable}"
   -s
   -E
@@ -561,10 +562,22 @@ SET_PROPERTY(
   PROPERTY IMPORTED_SONAME ${_python3_lib_name}
 )
 IF(RV_TARGET_WINDOWS)
-  SET_PROPERTY(
-    TARGET Python::Python
-    PROPERTY IMPORTED_IMPLIB ${_python3_implib}
+  # Set per-config import libs so multi-config generators (VS) pick the right one.
+  # Without this, IMPORTED_IMPLIB would be fixed to whichever CMAKE_BUILD_TYPE was
+  # set at configure time, causing LNK1104 when building a different configuration.
+  SET(_python_debug_implib
+      ${_lib_dir}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_d${CMAKE_IMPORT_LIBRARY_SUFFIX}
   )
+  SET(_python_release_implib
+      ${_lib_dir}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}${CMAKE_IMPORT_LIBRARY_SUFFIX}
+  )
+  SET_PROPERTY(TARGET Python::Python PROPERTY IMPORTED_IMPLIB_DEBUG ${_python_debug_implib})
+  SET_PROPERTY(TARGET Python::Python PROPERTY IMPORTED_IMPLIB_RELEASE ${_python_release_implib})
+  SET_PROPERTY(TARGET Python::Python PROPERTY IMPORTED_IMPLIB_RELWITHDEBINFO ${_python_release_implib})
+  SET_PROPERTY(TARGET Python::Python PROPERTY IMPORTED_IMPLIB_MINSIZEREL ${_python_release_implib})
+  # Also expose the libs dir so #pragma comment(lib, "python311.lib") in Python
+  # headers can be resolved by the linker for non-debug configurations.
+  TARGET_LINK_DIRECTORIES(Python::Python INTERFACE ${_lib_dir})
 ENDIF()
 FILE(MAKE_DIRECTORY ${_include_dir})
 TARGET_INCLUDE_DIRECTORIES(

--- a/src/build/requirements.txt.in
+++ b/src/build/requirements.txt.in
@@ -10,7 +10,9 @@ pip==24.0               # License: MIT License (MIT)
 setuptools==69.5.1      # License: MIT License
 wheel==0.43.0           # License: MIT License (MIT)
 numpy==@_numpy_version@ # License: BSD License (BSD-3-Clause) - Required by PySide6
-opentimelineio==@_opentimelineio_version@ # License: Other/Proprietary License (Modified Apache 2.0 License)
+# Using a fork until the main branch of OTIO merge the PR to fix a crash on windows
+# with a debug build of OpenRV.
+opentimelineio @ git+https://github.com/cedrik-fuoco-adsk/OpenTimelineIO.git@fix-windows-debug-crash # License: Other/Proprietary License (Modified Apache 2.0 License)
 PyOpenGL==3.1.7         # License: BSD License (BSD)
 PyOpenGL_accelerate==3.1.10 # License: BSD License (BSD) - v3.1.10 includes Python 3 fix for Cython compatibility
 


### PR DESCRIPTION
### Fix various with the debug build on Windows

### Linked issues
n/a

### Summarize your change.

  Fix several issues that prevented OpenRV from building and running correctly in Debug configuration on Windows.

### Describe the reason for the change.

- Windows debug Python looks for extension modules with a _d suffix (e.g. pyimgui_d.pyd).
- Additionally, the CMake Python::Python imported target was using a single IMPORTED_IMPLIB that didn't account for multi-config generators (Visual Studio), causing LNK1104 linker errors when switching between Debug and Release. 
- OpenTimelineIO had a crash on Windows debug builds caused by a pybind11 bug.

Temporarily points opentimelineio to a personal fork (cedrik-fuoco-adsk/OpenTimelineIO@fix-windows-debug-crash) to fix a pybind11 crash on Windows debug builds. This should be reverted once the upstream OTIO PR is merged, and use the main branch of OTIO. Once this is merged and OTIO releases a new version, we can go back to using tagged version.

### Describe what you have tested and on which operating system.
 
- Windows 11, Debug build of OpenRV