### PR TITLE
fix: SG-42902: Fix seg fault on Linux when displays are stacked in the system settings

### DIFF
--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -779,19 +779,6 @@ namespace Rv
             return totalGeometry != primaryScreen->geometry();
         };
 
-        auto getScreenFromPoint = [&screens](const QPoint& point) -> int
-        {
-            for (int i = 0; i < screens.size(); ++i)
-            {
-                if (screens[i]->geometry().contains(point))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        };
-
         //
         //  Allow command line placement
         //
@@ -818,16 +805,31 @@ namespace Rv
             }
         }
 
+        auto getScreenFromPoint = [&screens](const QPoint& point) -> int
+        {
+            for (int i = 0; i < screens.size(); ++i)
+            {
+                if (screens[i]->geometry().contains(point))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        };
+
         int screen = getScreenFromPoint(QCursor::pos());
         if (opts.screen != -1)
+        {
             screen = opts.screen;
+        }
 
         int oldX = doc->pos().x();
         int oldY = doc->pos().y();
 
         int oldScreen = getScreenFromPoint(QPoint(oldX, oldY));
 
-        if (screen != -1 && isVirtualDesktop() && screen != oldScreen)
+        if (screen != -1 && oldScreen != -1 && isVirtualDesktop() && screen != oldScreen)
         //
         //  The application is going to come up on the wrong screen, so figure
         //  out our our relative position on the current screen, and move to the


### PR DESCRIPTION
### [SG-42902](https://jira.autodesk.com/browse/SG-42902): Fix seg fault on Linux when displays are stacked in the system settings

### Summarize your change.

Prevent accessing the screen index of a secondary monitor if it invalid (i.e. -1).

### Describe the reason for the change.

Open RV would crash when trying to launch on Linux if a secondary monitor was stacked under the primary monitor in the system settings on Linux. The issue was introduced by the upgrade to Qt6 where `screenNumber()` and `screenGeometry()` were now deprecated and respectively replaced with the lambda function `getScreenFromPoint()` and the Qt function `geometry()`. With the previous implementation, Qt was falling back to using index 0 (i.e. the primary screen) if the index of the screen was invalid. However, I believe we are better by simply not computing any calculation if the screen index is -1 as comparing the values between the same screen wouldn't do anything.

Note that I also moved `getScreenFromPoint()` closer to where it was actually used to make the code a little bit more readable.

### Describe what you have tested and on which operating system.

Tested different configuration of arranging displays in the System Settings was tested on Linux, macOS and Windows.