### PR TITLE
build: Fix namespace for OIIO 2.5 and VFX2023

### DIFF
--- a/cmake/dependencies/oiio.cmake
+++ b/cmake/dependencies/oiio.cmake
@@ -136,6 +136,8 @@ LIST(APPEND _configure_options "-DZLIB_ROOT=${RV_DEPS_ZLIB_ROOT_DIR}")
 # OIIO tools are not needed.
 LIST(APPEND _configure_options "-DOIIO_BUILD_TOOLS=OFF" "-DOIIO_BUILD_TESTS=OFF")
 
+LIST(APPEND _configure_options "-DCMAKE_CXX_STANDARD=${RV_CPP_STANDARD}")
+
 IF(RV_TARGET_WINDOWS)
   LIST(PREPEND _configure_options "-G ${CMAKE_GENERATOR}")
   LIST(APPEND _configure_options "-DCMAKE_CXX_FLAGS=/utf-8")

--- a/src/lib/image/IOoiio/IOoiio.cpp
+++ b/src/lib/image/IOoiio/IOoiio.cpp
@@ -19,7 +19,11 @@ namespace TwkFB
 {
     using namespace std;
     using namespace TwkUtil;
+#ifdef RV_VFX_CY2023
+    using namespace OpenImageIO_v2_5;
+#else
     using namespace OpenImageIO;
+#endif
 
     IOoiio::IOoiio()
         : FrameBufferIO("IOoiio", "n") // OIIO after any defaults of ours


### PR DESCRIPTION
Fix namespace for OIIO 2.5 and VFX2023

### Linked issues
none

### Summarize your change.
Fixing namespace used by IOoiio to what it was in CY2023 (before OIIO 3).

### Describe the reason for the change.
CY2023 build were failing because OIIO 2.5

### Describe what you have tested and on which operating system.
CI 
