### PR TITLE
feat: SG-42241: RV: Generate thumbnail before filmstrips

### DIFF
--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1824,14 +1824,15 @@ class: SessionManagerMode : MinorMode
             // 10 for ordering. This means any custom plugin of higher priority will be used first.
             // This allows users to override the local plugin with a custom plugin by making sure 
             // the ordering is less than 10 and using event.accept() to prevent the local plugin from running.
-            let filmstripPath = sendInternalEvent("session-manager-get-filmstrip-path", sourceNode);
             let thumbnailPath = sendInternalEvent("session-manager-get-thumbnail-path", sourceNode);
-
-            if (filmstripPath != "" && io.path.exists(filmstripPath))
-                preview.loadStrip(filmstripPath);
-
             if (thumbnailPath != "" && io.path.exists(thumbnailPath))
+            {
                 preview.loadThumbnail(thumbnailPath);
+
+                let filmstripPath = sendInternalEvent("session-manager-get-filmstrip-path", sourceNode);
+                if (filmstripPath != "" && io.path.exists(filmstripPath))
+                    preview.loadStrip(filmstripPath);
+            }
 
             let mediaPropertyPath = sourceNode + ".media.movie";
             if (propertyExists(mediaPropertyPath))


### PR DESCRIPTION
### **[SG-42241](https://jira.autodesk.com/browse/SG-42241): RV: Implement the ability to fetch filmstrips for sources incoming into RV's Session Manager**

### Summarize your change.

Defer filmstrip generation until after the thumbnail is available so the thumbnail always loads first.

### Describe the reason for the change.

We want to replace the fallback icons as soon as possible so that the user can already see a preview of the loaded media.

### Describe what you have tested and on which operating system.

Tested on MacOS by loading in media and making sure that the thumbnail preview shows up first.
