### PR TITLE
fix: SG-42945: [RV] Thumbnails from clips that are unavailable in RV session will display a black frame

### DIFF
--- a/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
+++ b/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
@@ -136,7 +136,7 @@ class LocalThumbnailGen(rvtypes.MinorMode):
         event.reject()
         source_node = event.contents()
         media_path = self._get_media_path(source_node)
-        if not media_path:
+        if not media_path or not self._get_source_info(source_node):
             event.setReturnContent("")
             return
 


### PR DESCRIPTION
### **[SG-42945](https://jira.autodesk.com/browse/SG-42945): [RV] Thumbnails from clips that are unavailable in RV session will display a black frame**

### Summarize your change.

Added a guard to prevent thumbnail and filmstrip generation of a missing source.

### Describe the reason for the change.

Previously, if you save a session and then delete some of the sources and load the saved session, the missing sources will have a black thumbnail instead of the default fallback icon.

### Describe what you have tested and on which operating system.

Tested on MacOS by saving a session and deleting some of the sources. Reloaded the saved session and verified that missing sources show the fallback icon.