### PR TITLE
fix: Add DesktopVideoDevice::colorProfile() on macOS

### DIFF
--- a/src/lib/app/RvCommon/DesktopVideoDevice.cpp
+++ b/src/lib/app/RvCommon/DesktopVideoDevice.cpp
@@ -13,6 +13,11 @@
 #include <lcms2.h>
 #endif
 
+#ifdef PLATFORM_DARWIN
+#include <ApplicationServices/ApplicationServices.h>
+#include <ColorSync/ColorSync.h>
+#endif
+
 #include <RvCommon/DesktopVideoDevice.h>
 #include <TwkGLF/GLPipeline.h>
 #include <TwkGLF/GLRenderPrimitives.h>
@@ -906,6 +911,51 @@ namespace Rv
 
             delete path;
             ReleaseDC(hwnd, hdc);
+        }
+        else
+        {
+            m_colorProfile = ColorProfile();
+        }
+
+        return m_colorProfile;
+    }
+#endif
+
+#ifdef PLATFORM_DARWIN
+    TwkApp::VideoDevice::ColorProfile DesktopVideoDevice::colorProfile() const
+    {
+        //
+        //  Get the display's color sync profile
+        //
+
+        CGDirectDisplayID displayIDs[20];
+        uint32_t displayCount = 0;
+        CGGetOnlineDisplayList(20, displayIDs, &displayCount);
+
+        if (m_screen < 0 || m_screen >= static_cast<int>(displayCount))
+        {
+            m_colorProfile = ColorProfile();
+            return m_colorProfile;
+        }
+
+        CGDirectDisplayID cgScreen = displayIDs[m_screen];
+
+        if (ColorSyncProfileRef iccRef = ColorSyncProfileCreateWithDisplayID(cgScreen))
+        {
+            m_colorProfile.type = ICCProfile;
+
+            CFStringRef desc = ColorSyncProfileCopyDescriptionString(iccRef);
+            CFIndex n = CFStringGetLength(desc);
+            std::vector<char> buffer(n * 4 + 1);
+            CFStringGetCString(desc, &buffer.front(), buffer.size(), kCFStringEncodingUTF8);
+            m_colorProfile.description = &buffer.front();
+
+            CFURLRef url = ColorSyncProfileGetURL(iccRef, NULL);
+            CFStringRef urlstr = CFURLGetString(url);
+            buffer.resize(CFStringGetLength(urlstr) * 4 + 1);
+            CFStringGetCString(urlstr, &buffer.front(), buffer.size(), kCFStringEncodingUTF8);
+
+            m_colorProfile.url = &buffer.front();
         }
         else
         {

--- a/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
@@ -247,7 +247,7 @@ namespace Rv
     private:
         void addDataFormatAtDepth(size_t depth, DesktopStereoMode m);
 
-#ifdef PLATFORM_WINDOWS
+#if defined(PLATFORM_WINDOWS) || defined(PLATFORM_DARWIN)
         virtual ColorProfile colorProfile() const;
 #endif
 

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -231,6 +231,8 @@ namespace IPCore
 
         updateContext();
         updateFunction();
+
+        m_initialized = true;
     }
 
     void OCIOIPNode::updateContext()
@@ -352,7 +354,10 @@ namespace IPCore
         boost::hash<string> string_hash;
         string inName = stringProp("ocio.inColorSpace", m_state->linear);
 
-        if (inName.empty())
+        // synlinearize/syndisplay build their pipeline from file/URL
+        // transforms, so an empty input color space is valid for those modes.
+        const bool needsInColorSpace = ociofunction != "synlinearize" && ociofunction != "syndisplay";
+        if (inName.empty() && needsInColorSpace)
             return;
 
         try
@@ -436,6 +441,8 @@ namespace IPCore
                 string inTransformURL = stringProp("inTransform.url", "");
                 if (inTransformURL.empty() && (!m_inTransformData || m_inTransformData->size() == 0))
                 {
+                    if (!m_initialized)
+                        return;
                     TWK_THROW_EXC_STREAM("Either inTransform.url or inTransform.data property "
                                          "needs to be set for synlinearize function");
                 }
@@ -481,6 +488,8 @@ namespace IPCore
                 const string outTransformURL = stringProp("outTransform.url", "");
                 if (outTransformURL.empty())
                 {
+                    if (!m_initialized)
+                        return;
                     TWK_THROW_EXC_STREAM("outTransform.url property needs to "
                                          "be set for syndisplay function");
                 }

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
@@ -72,6 +72,7 @@ namespace IPCore
         std::vector<OCIO3DLUTPtr> m_3DLUTs;
         OCIOState* m_state{nullptr};
         bool m_useRawConfig{false};
+        bool m_initialized{false};
 
         // synlinearize/syndisplay functions
         StringProperty* m_inTransformURL{nullptr};


### PR DESCRIPTION
### Add DesktopVideoDevice::colorProfile() on macOS

### Linked issues
Fixes #1034 

### Describe the reason for the change.

Note that this PR is adding the following to @williamwira 's PR: https://github.com/AcademySoftwareFoundation/OpenRV/pull/1080

Prior to Open RV 3.1.0 (aka 2025.1.0), the macOS supported automatic color profile detection because it was implemented in CGDesktopVideoDevice.
Now CGDesktopVideoDevice is no longer used and DesktopVideoDevice is used instead which does not contain automatic color profile detection on macOS.
This PR solves this regression by adding the code that used to be in CGDesktopVideoDevice to DesktopVideoDevice::colorProfile() on macOS.

### Summarize your change.

-  macOS color profile support: Implements DesktopVideoDevice::colorProfile() for macOS using the ColorSync framework. The method enumerates online displays, finds the correct screen by index, and reads the ICC profile description and file URL from the display's ColorSyncProfileRef. Previously this virtual method was only implemented on Windows.

- OCIO synlinearize/syndisplay initialization fix: Adds an m_initialized flag to OCIOIPNode to prevent spurious exceptions being thrown during node construction. The updateFunction() call in the constructor can fire before transform URL/data properties are set; the guard lets those early calls return cleanly instead of throwing.
 
- OCIO empty input color space fix: synlinearize and syndisplay build their pipelines from file/URL transforms rather than named OCIO color spaces, so an empty ocio.inColorSpace is valid for those modes. The early return in updateFunction() is now skipped for those two function types.

### Describe what you have tested and on which operating system.

Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.