### PR TITLE
build: SG-43099: Enable md2 support for OpenSSL (RB-3.1.X-VFX2024)

### DIFF
--- a/src/build/make_openssl.py
+++ b/src/build/make_openssl.py
@@ -188,6 +188,8 @@ def configure() -> None:
     configure_args.append(f"--prefix={OUTPUT_DIR}")
     configure_args.append(f"--openssldir={OUTPUT_DIR}")
 
+    configure_args.append("enable-md2")
+
     if platform.system() == "Linux":
         configure_args.append("-Wl,-rpath,'$$ORIGIN/../lib'")
 


### PR DESCRIPTION
### build: Add md2 support for OpenSSL (RB-3.1.X-VFX2024)

This is a commit for RB-3.1.X-VFX2024

### Linked issues
none

### Summarize your change.
Enable md2 when building OpenSSL