### PR TITLE
fix: SG-42890: Fix BADACCESS X error when running RVIO commands on Rocky Linux 9

### DIFF
--- a/src/bin/imgtools/rvio/main.cpp
+++ b/src/bin/imgtools/rvio/main.cpp
@@ -970,14 +970,8 @@ int utf8Main(int argc, char* argv[])
     setEnvVar("LC_ALL", "C");
     TwkFB::ThreadPool::initialize();
 
-    //
-    //  XXX dummyDev is leaking here.  Best would be to pass it to the App so
-    //  that it could delete it after startup, since it's no longer needed at
-    //  that point.
-    //
-
 #ifdef RVIO_HW
-    TwkGLF::FBOVideoDevice* dummyDev = new TwkGLF::FBOVideoDevice(0, 10, 10, false);
+    auto dummyDev = std::make_unique<TwkGLF::FBOVideoDevice>(nullptr, 10, 10, false);
 #else
     TwkGLF::OSMesaVideoDevice* dummyDev = new TwkGLF::OSMesaVideoDevice(0, 10, 10, true);
     FrameBuffer* dummyFB = new FrameBuffer(10, 10, 4, FrameBuffer::FLOAT);

--- a/src/bin/imgtools/rvio/main.cpp
+++ b/src/bin/imgtools/rvio/main.cpp
@@ -1646,7 +1646,7 @@ int utf8Main(int argc, char* argv[])
         threadAPI.create = GC_pthread_create;
         threadAPI.join = GC_pthread_join;
         threadAPI.detach = GC_pthread_detach;
-        outmov = new ThreadedMovie(inputMovies, outFrames, 8, &threadAPI, threadedMovieInit);
+        outmov = new ThreadedMovie(inputMovies, outFrames, 8, &threadAPI, threadedMovieInit, MovieRV::uninit);
 #endif
 #endif
 
@@ -1739,10 +1739,6 @@ int utf8Main(int argc, char* argv[])
 
         if (!writer->write(outmov, outfile, writeRequest))
             exit(-2);
-
-        // clean up any frame buffers we allocated writing the movie
-        //
-        MovieRV::uninit();
     }
     catch (TwkExc::Exception& exc)
     {

--- a/src/lib/image/TwkMovie/ThreadedMovie.cpp
+++ b/src/lib/image/TwkMovie/ThreadedMovie.cpp
@@ -19,7 +19,8 @@ namespace TwkMovie
         mov->threadMain();
     }
 
-    ThreadedMovie::ThreadedMovie(const Movies& movies, const Frames& frames, size_t stackMultiplier, ThreadAPI* api, InitializeFunc F)
+    ThreadedMovie::ThreadedMovie(const Movies& movies, const Frames& frames, size_t stackMultiplier, ThreadAPI* api, InitializeFunc F,
+                                 FinalizeFunc finalizeFunction)
         : m_movies(movies)
         , m_threadGroup(movies.size(), stackMultiplier, api)
         , m_frames(frames)
@@ -27,6 +28,7 @@ namespace TwkMovie
         , m_currentIndex(0)
         , m_requestIndex(0)
         , m_initialize(F)
+        , m_finalize(finalizeFunction)
     {
         // if (!m_movie->isThreadSafe()) throw runtime_exception();
         m_info = movies.front()->info();
@@ -188,7 +190,15 @@ namespace TwkMovie
 
         m_threadGroup.lock(m_runLock);
         td->running = false;
+
+        bool allFramesDone = (m_currentIndex >= m_frames.size());
+
         m_threadGroup.unlock(m_runLock);
+
+        if (allFramesDone && m_finalize != nullptr)
+        {
+            m_finalize();
+        }
 
         // cout << "thread " << td->id << " no longer running" << endl;
     }

--- a/src/lib/image/TwkMovie/TwkMovie/ThreadedMovie.h
+++ b/src/lib/image/TwkMovie/TwkMovie/ThreadedMovie.h
@@ -57,8 +57,10 @@ namespace TwkMovie
         typedef std::vector<Movie*> Movies;
         typedef stl_ext::thread_group::thread_api ThreadAPI;
         typedef void (*InitializeFunc)();
+        using FinalizeFunc = void (*)();
 
-        ThreadedMovie(const Movies&, const Frames& frames, size_t stackMultiplier = 8, ThreadAPI* api = 0, InitializeFunc = NULL);
+        ThreadedMovie(const Movies&, const Frames& frames, size_t stackMultiplier = 8, ThreadAPI* api = nullptr, InitializeFunc = nullptr,
+                      FinalizeFunc = nullptr);
 
         virtual ~ThreadedMovie();
 
@@ -104,6 +106,7 @@ namespace TwkMovie
         int m_requestIndex;
         bool m_init;
         InitializeFunc m_initialize;
+        FinalizeFunc m_finalize;
     };
 
 } // namespace TwkMovie


### PR DESCRIPTION
### SG-42890: Fix BADACCESS X error when running RVIO commands on Rocky Linux 9

### Summarize your change.

- [X]  Make the writer thread call MovieRV::uninit instead of the main thread
- [X] Replace dummyDev raw pointer with an FBOVideoDevice unique_ptr

### Describe the reason for the change.

https://github.com/AcademySoftwareFoundation/OpenRV/pull/310 added `MovieRV::uninit` in the main function of RVIO to fix a GL error on exit on Rocky Linux 9. However, in a more recent version of the Rocky Linux 9, we are now getting a BADACCESS X error when running RVIO commands from the command line. An alert panel is also being displayed when submitting an image sequence through Screening Room after each step. This was caused by the main thread trying to access the OpenGL rendering context used by the writer thread when calling `MovieRV::uninit` at the end of the main function.

It seems that the initial GL error was actually caused by the FBOVideoDevice raw pointer created as a dummy video device at the beginning of the main RVIO function by the main thread to avoid a segmentation fault. This raw pointer was never deleted, and this was causing a GL error when the `GLSyncObjectARBSync` destructor was called at the end of the program. Replacing the raw pointer with a unique_ptr fixed the leaking pointer that was the root cause of the GL error.

`MovieRV::uninit` was not technically needed to fix the original GL error, but it's a good practice to keep it to make sure we uninit any FBOs that were allocated. The only difference is that it should have been called by the writer thread instead of the main thread since it is the one that actually created and used the FBOVideoDevice and the OpenGL rendering context during the execution of RVIO.

### Describe what you have tested and on which operating system.

Submitting an image sequence through Screening Room was tested on Rocky Linux 9.6, Windows 11, and macOS 26.3.
The following commands that were called during the submit process of Screening Room were also manually called from the command line to make sure no error remains:

- `rvio movie.####.dpx -o /tmp/thumb.#.jpg`
- `rvio movie.####.dpx -o /tmp/out.mov`
- `rvio movie.####.dpx -resize 240 132 -outres 1200 132 -o /tmp/filmstrip.jpg`