### PR TITLE
chore: Move minor version to 3.1.1 (RB-3.1.X-VFX2024 branch)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.27)
 # cmake-format: off
 SET(RV_MAJOR_VERSION "3" CACHE STRING "RV's version major")
 SET(RV_MINOR_VERSION "1" CACHE STRING "RV's version minor")
-SET(RV_REVISION_NUMBER "0" CACHE STRING "RV's revision number")
+SET(RV_REVISION_NUMBER "1" CACHE STRING "RV's revision number")
 SET(RV_VERSION_YEAR "2025" CACHE STRING "RV's year of release.")
 # cmake-format: on
 


### PR DESCRIPTION
### chore: Move minor version to 3.1.1

### Linked issues
none

### Summarize your change.
Move minor version to 3.1.1

### Describe the reason for the change.
For the release of 3.1.1