### PR TITLE
fix: Set objectName on Diagnostics QDockWidget

### DIFF
--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -207,6 +207,7 @@ namespace Rv
 
         // Dockable to QMainWindow, not centralwidget.
         m_diagnosticsDock = new QDockWidget(tr("Diagnostics"), this);
+        m_diagnosticsDock->setObjectName("Diagnostics");
         m_diagnosticsDock->setWidget(m_diagnosticsView);
         m_diagnosticsDock->setAllowedAreas(Qt::AllDockWidgetAreas);
         addDockWidget(Qt::BottomDockWidgetArea, m_diagnosticsDock);


### PR DESCRIPTION
### Linked issues

No linked issue, just a trivial one line fix.

### Summarize your change.

Added setting the object name for the Diagnostics dock widget immediately after the dock widget is constructed to avoid a runtime warning.

### Describe the reason for the change.

`QMainWindow::saveState()` requires all dock widgets to have an `objectName` set in order to correctly save and restore their layout. The Diagnostics dock was created without one, which produces this runtime warning on every call to `saveState()`:

`WARNING: QMainWindow::saveState(): 'objectName' not set for QDockWidget 0x... 'Diagnostics'`

Other dock widgets and menus in `RvDocument.cpp` already follow this pattern (e.g. `UIBlockingOverlay`, `Main Popup`, `User Popup`). This brings the Diagnostics dock in line with them.

### Describe what you have tested and on which operating system.

Verified the warning is no longer emitted on Linux (EL9) after applying the change.

### Add a list of changes, and note any that might need special attention during the review.

- `src/lib/app/RvCommon/RvDocument.cpp`, just one line added, no logic change.