### PR TITLE
fix: small fix for the Python Import test that breaks Conan CI

### DIFF
--- a/src/build/test_python_imports.py
+++ b/src/build/test_python_imports.py
@@ -21,6 +21,11 @@ import os
 import re
 import sys
 
+# OpenSSL 3.x legacy provider may not be available when OpenSSL is built from
+# source or supplied by Conan without the legacy module on the search path.
+# OpenRV does not use legacy algorithms, so allow cryptography to run without it.
+os.environ.setdefault("CRYPTOGRAPHY_OPENSSL_NO_LEGACY", "1")
+
 # Packages to skip from requirements.txt.in (e.g., build dependencies that don't need import testing).
 SKIP_IMPORTS = [
     "pip",


### PR DESCRIPTION
### fix: small fix for the Python Import test that breaks Conan CI

### Linked issues
n/a

### Summarize your change.
Fix issue with OpenSSL legacy algorithm in the Python import test

### Describe the reason for the change.
I have the fix in https://github.com/AcademySoftwareFoundation/OpenRV/pull/1234, but I decided to create a new PR to merge the fix faster.

```
FAILED IMPORTS:
  - cryptography.fernet: RuntimeError: OpenSSL 3.0's legacy provider failed to load. This is a fatal error by default, but cryptography supports running without legacy algorithms by setting the environment variable CRYPTOGRAPHY_OPENSSL_NO_LEGACY. If you did not expect this error, you have likely made a mistake with your OpenSSL configuration.
  - cryptography.hazmat.bindings._rust: RuntimeError: OpenSSL 3.0's legacy provider failed to load. This is a fatal error by default, but cryptography supports running without legacy algorithms by setting the environment variable CRYPTOGRAPHY_OPENSSL_NO_LEGACY. If you did not expect this error, you have likely made a mistake with your OpenSSL configuration.

Build-time import test FAILED!
One or more required Python packages could not be imported.
```

### Describe what you have tested and on which operating system.
CI