### PR TITLE
fix: SG-42890: Fix SEGV error when running RVIO commands on Rocky Linux 9 (part 2)

### DIFF
--- a/src/bin/imgtools/rvio/main.cpp
+++ b/src/bin/imgtools/rvio/main.cpp
@@ -1759,5 +1759,35 @@ int utf8Main(int argc, char* argv[])
     TwkFB::GenericIO::shutdown();    // Shutdown TwkFB::GenericIO plugins
 
     TwkFB::ThreadPool::shutdown();
+
+#ifdef PLATFORM_LINUX
+    //
+    //  Workaround for the libglvnd <-> NVIDIA driver shutdown race.
+    //
+    //  Returning normally from main() triggers libc's exit handlers, which
+    //  run _dl_fini. _dl_fini invokes each linked library's destructor,
+    //  including libGLX.so.0's __glXFini, which calls
+    //  __glXMappingTeardown -> dlclose("libGLX_nvidia.so.0").
+    //
+    //  Note: libglvnd (GL Vendor-Neutral Dispatch library) is the dispatch
+    //  layer that sits between an application's OpenGL/GLX/EGL calls
+    //  and the actual vendor driver on Linux.
+    //
+    //  The NVIDIA closed-source driver spawns internal helper threads
+    //  (idle/event loops inside libnvidia-glcore.so) that libglvnd has no
+    //  hook to join. The dlclose therefore unmaps libnvidia-glcore.so while
+    //  those threads are still running, and their next instruction fetch
+    //  lands on an unmapped page -> SIGSEGV at process exit.
+    //
+    //  Calling std::_Exit(0) instead of returning skips atexit/_dl_fini and
+    //  lets the kernel reap memory, threads, and file descriptors directly.
+    //  This is safe here: by this point rvio's own shutdown is complete
+    //  (the output movie is closed, MovieRV/GenericIO/ThreadPool have all
+    //  been torn down), so there is no remaining cleanup that the exit
+    //  handlers would have done for us.
+    //
+    std::_Exit(0);
+#endif
+
     return 0;
 }


### PR DESCRIPTION
### fix: SG-42890: Fix SIGSEGV error when running RVIO commands on Rocky Linux 9 (part 2)

### Linked issues
NA

### Summarize your change.

Fix an `rvio` SIGSEGV that fires at shutdown on Linux with the NVIDIA proprietary GL driver. Conversions complete successfully — the output `.mov` is written intact — but the process then exits with a segfault, which produces a crash dump and a non-zero exit code that breaks RV/CI/render-farm pipelines.

Symptoms:
- All frames are rendered and the output file is fully written.
- The process then segfaults after `main()` returns.
- Crashpad-symbolicated minidump shows the crashing thread's `rip` in an
  unmapped region with no usable call stack (only `stack scanning` frames in
  `libc.so.6`). The crash address looks like garbage because the page is
  already gone by the time the dump is written.

Constant register signatures across ASLR-randomized runs (`rax=0x6e`,
`r14=0x1e8480`, `r15=0xfffffffffffffb28`) confirmed the crash always lands at
the same instruction.

### Root cause

Captured under `gdb` (where the offending library is still mapped at the
instant of the SIGSEGV), the crashing thread is an NVIDIA driver background
worker:

```
Thread N "RVIO Main" received signal SIGSEGV
0x00007fffcd9f59ec in ?? () from /lib64/libnvidia-glcore.so.595.58.03
#0  libnvidia-glcore.so.595.58.03
#1  libnvidia-glcore.so.595.58.03
#2  libnvidia-glcore.so.595.58.03
#3  start_thread () from libc.so.6
#4  clone3 () from libc.so.6
```

…while the main thread is mid-teardown:

```
#0  _dl_close_worker (...) at dl-close.c:769
#1  _dl_close
#2  __GI__dl_catch_exception
#5  dlclose@GLIBC_2.2.5 ()
#6  __glXMappingTeardown ()  from libGLX.so.0
#7  __glXFini ()             from libGLX.so.0
#8  _dl_fini ()              at dl-fini.c:148
#9  __run_exit_handlers ()   from libc.so.6
#10 exit ()                  from libc.so.6
```

This is the well-known **libglvnd ↔ NVIDIA driver shutdown race**:

1. `main()` returns.
2. libc's `exit()` runs `__run_exit_handlers` → `_dl_fini`.
3. `_dl_fini` invokes `libGLX.so.0`'s ELF destructor `__glXFini`, which
   `dlclose`s the NVIDIA GLX vendor (`libGLX_nvidia.so.0`) and transitively
   unmaps `libnvidia-glcore.so`.
4. NVIDIA's proprietary driver maintains its own internal helper threads. They
   are **not** joined by libglvnd's teardown — NVIDIA's blob has no such
   hook. The threads are still running when `dlclose` finishes.
5. The kernel unmaps `libnvidia-glcore.so`'s code pages out from under one of
   those running threads → next instruction fetch hits unmapped memory →
   SIGSEGV.

The thread is named `"RVIO Main"` only because Linux child threads inherit
their parent's `prctl(PR_SET_NAME)` value (set by `TwkUtil::setThreadName`).
It is NOT the application's main thread.

By the time crashpad's signal handler finishes serializing the minidump,
`dlclose` has fully completed and the page is no longer in `/proc/self/maps`,
which is why the dump appeared to crash "nowhere."

### Solution

`src/bin/imgtools/rvio/main.cpp`: on Linux, replace the final `return 0;`
in `utf8Main` with `std::_Exit(0);` — but only after all of rvio's legitimate
shutdown has already run (`MovieRV::uninit`,
`TwkMovie::GenericIO::shutdown`, `TwkFB::GenericIO::shutdown`,
`TwkFB::ThreadPool::shutdown`).

`std::_Exit` is the POSIX "skip atexit / `_dl_fini` and terminate now"
primitive. It hands control directly to the kernel, which reaps memory,
file descriptors, and threads — including NVIDIA's straggler threads —
atomically, with no opportunity for the unload race.

Nothing in our shutdown is left undone:
- The output movie has already been finalized and `close`d by the writer
  before `utf8Main` reaches this point.
- All Open RV-owned plugins have been shut down explicitly above the
  `_Exit` call.

Windows and macOS still go through `return 0;` because they don't use
libglvnd and don't exhibit this race. The change is `#ifdef PLATFORM_LINUX`
guarded.

