### PR TITLE
fix: Pin Rocky 9 CI to 9.7 to keep mesa-libOSMesa available

### DIFF
--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -50,6 +50,14 @@ runs:
       run: df -h /
       shell: bash
 
+    # Rocky 9.8 dropped mesa-libOSMesa{,-devel} from the CRB repo. Pin all
+    # subsequent dnf calls in this container to the 9.7 minor release until
+    # OpenRV migrates off OSMesa. Remove this step once that's done.
+    - name: Pin Rocky 9 to 9.7 minor release
+      if: ${{ inputs.rocky-version == '9' }}
+      run: echo "9.7" > /etc/dnf/vars/releasever
+      shell: bash
+
     - name: Install system dependencies
       run: |
         retry_count=0

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -97,6 +97,13 @@ jobs:
         run: |
           df -h /
 
+      # Rocky 9.8 dropped mesa-libOSMesa{,-devel} from the CRB repo. Pin all
+      # subsequent dnf calls in this container to the 9.7 minor release until
+      # OpenRV migrates off OSMesa. Remove this step once that's done.
+      - name: Pin Rocky 9 to 9.7 minor release
+        if: ${{ matrix.rocky-version == '9' }}
+        run: echo "9.7" > /etc/dnf/vars/releasever
+
       - name: Install system dependencies
         run: |
           dnf install -y epel-release


### PR DESCRIPTION
### fix: Pin Rocky 9 CI to 9.7 to keep mesa-libOSMesa available

### Linked issues
NA

### Describe the reason for the change.

CICD build of Open RV on Rocky 9 linux started to break 3 days ago corresponding to the timeframe where Rocky Linux 9.8, released between 2026-05-27 and 2026-05-29.

### Summarize your change.

Rocky Linux 9.8, released between 2026-05-27 and 2026-05-29, removed mesa-libOSMesa and mesa-libOSMesa-devel from the CRB repo (Mesa upstream has deprecated OSMesa in favor of llvmpipe via EGL). Our Rocky 9 CI jobs use the rolling rockylinux:9 image and previously implicit $releasever, so they started failing on `dnf install ... mesa-libOSMesa mesa-libOSMesa-devel` as soon as mirrors flipped to 9.8.

Pin $releasever to 9.7 via /etc/dnf/vars/releasever before any dnf call, guarded by rocky-version == '9' so Rocky 8 jobs are untouched. All subsequent dnf calls in the same container inherit the pin without needing to touch the existing install commands.

This is a stopgap until OpenRV migrates off OSMesa; the comments in both files note that. Files touched:

    .github/actions/build-linux/action.yml
    .github/workflows/conan.yml

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.