### PR TITLE
fix: SG-43607: Bugfix/aces2 support

### DIFF
--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <regex>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 namespace IPCore
@@ -313,11 +314,16 @@ namespace IPCore
             auto searchBegin = inout_glsl.cbegin();
             std::smatch match;
 
+            // A real function's name can never be a GLSL reserved keyword.
+            // The regex can spuriously match control-flow statements such
+            // as "else if (...) {" (returnType="else", name="if"); skip any
+            // match whose captured name is a keyword.
+            static const std::unordered_set<std::string> glslKeywords = {"if",   "else",   "for",   "while",    "do",      "switch",
+                                                                         "case", "return", "break", "continue", "discard", "struct"};
+
             while (std::regex_search(searchBegin, inout_glsl.cend(), match, functionStartRegex))
             {
-                // Avoid treating "else if" as a function definition by
-                // ignoring matches where the captured first word is "else".
-                if (match.str(1) == "else")
+                if (glslKeywords.count(match.str(2)))
                 {
                     searchBegin = match[0].second;
                     continue;

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -315,6 +315,14 @@ namespace IPCore
 
             while (std::regex_search(searchBegin, inout_glsl.cend(), match, functionStartRegex))
             {
+                // Avoid treating "else if" as a function definition by
+                // ignoring matches where the captured first word is "else".
+                if (match.str(1) == "else")
+                {
+                    searchBegin = match[0].second;
+                    continue;
+                }
+
                 const char* paramStart = &(*match[3].first);
                 size_t paramLen = static_cast<size_t>(std::distance(match[3].first, match[3].second));
                 std::string_view paramsView(paramStart, paramLen);


### PR DESCRIPTION
### Linked issues

#1275 #1330

### Summarize your change.

Added a check to functionsMissingLutAsParameter() to avoid treating "else if" as a function definition.

### Describe the reason for the change.

The logic added in my previous PR uses a regex to search for the start of functions.  The regex roughly follows the format of "word word (...) {". 

"else if (...) {" matches as a false positive, so if there is an "else if" block that references a LUT, the code will treat all insteads of "if (...)" as a function call that needs the LUT added as a parameter, and breaks the code.

To the best of my knowledge, "else if" may be the only combination of GLSL keywords that could match the regex as a false positive, so I just added logic to check if the first word matched is "else".

### Describe what you have tested and on which operating system.

Tested it on Rocky Linux 9.7