### PR TITLE
fix: SG-43605: OTIO export failing when OCIO is active, and support reversed-order stack blending

### DIFF
--- a/src/plugins/rv-packages/otio_reader/otio_writer.py
+++ b/src/plugins/rv-packages/otio_reader/otio_writer.py
@@ -226,9 +226,12 @@ def _create_stack(node_name, *args, **kwargs):
     :return: `otio.schema.Stack`
     """
     stack_node = group_member_of_type(node_name, "RVStack")
-    fps = commands.getFloatProperty(stack_node + ".output.fps")[0]
+    fps = commands.getFloatProperty(f"{stack_node}.output.fps")[0]
+    reverse_order = commands.getIntProperty(f"{stack_node}.mode.supportReversedOrderBlending")
 
     input_node_names, _ = commands.nodeConnections(node_name)
+    if reverse_order and reverse_order[0]:
+        input_node_names.reverse()
 
     stack = otio.schema.Stack(extra_commands.uiName(node_name), metadata=get_node_otio_metadata(node_name))
     stack.markers.extend(_create_markers(node_name, fps))

--- a/src/plugins/rv-packages/otio_reader/sourcePostExportHook.py
+++ b/src/plugins/rv-packages/otio_reader/sourcePostExportHook.py
@@ -16,19 +16,25 @@ def hook_function(in_timeline, argument_map):
         return
 
     source = extra_commands.nodesInGroupOfType(source_group, "RVSource")[0]
-    linearize = extra_commands.associatedNode("RVLinearize", source)
+    for nodeType in ("RVLinearize", "RVColor"):
+        node = extra_commands.associatedNode(nodeType, source)
+        if not commands.propertyExists(f"{node}.CDL.active"):
+            continue
 
-    if commands.getIntProperty("{}.CDL.active".format(linearize))[0] != 0:
+        active = commands.getIntProperty(f"{node}.CDL.active")
+        if not active or active[0] == 0:
+            continue
+
         cdl = otio.schemadef.CDL.CDL(
-            name=extra_commands.uiName(linearize),
-            slope=commands.getFloatProperty("{}.CDL.slope".format(linearize)),
-            power=commands.getFloatProperty("{}.CDL.power".format(linearize)),
-            offset=commands.getFloatProperty("{}.CDL.offset".format(linearize)),
-            saturation=commands.getFloatProperty("{}.CDL.saturation".format(linearize))[0],
+            name=extra_commands.uiName(node),
+            slope=commands.getFloatProperty(f"{node}.CDL.slope"),
+            power=commands.getFloatProperty(f"{node}.CDL.power"),
+            offset=commands.getFloatProperty(f"{node}.CDL.offset"),
+            saturation=commands.getFloatProperty(f"{node}.CDL.saturation")[0],
             visible=True,
         )
 
-        cdl.metadata.update(get_otio_metadata("{}.CDL".format(linearize)))
+        cdl.metadata.update(get_otio_metadata(f"{node}.CDL"))
         clip.effects.append(cdl)
 
     # for releases >= 0.15


### PR DESCRIPTION
### Summarize your change.

Fix OTIO export failing when OCIO is active, and support reversed-order stack blending.

When OCIO is enabled, the `RVLinearize` node is not present and the CDL parameters are instead located on an `RVColor` node. The export hook calls `associatedNode("RVLinearize")`, which returns an empty string, and the subsequent call to `commands.getIntProperty("{}.CDL.active".format(linearize))` then raises an exception.

This fix loops over both `RVLinearize` and `RVColor` nodes, checking `propertyExists` before accessing CDL properties.

Also reverses the input ordering when exporting an RVStack with `supportReversedOrderBlending` enabled, so the OTIO layer order matches RV.

### Describe the reason for the change.

OTIO export throws this exception when OCIO is active:

```
File ".../sourcePostExportHook.py", line 21, in hook_function
    if commands.getIntProperty("{}.CDL.active".format(linearize))[0] != 0:
Exception: "invalid property name .CDL.active", program exception
```

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9.

1. Load media with OCIO active
2. Activate a CDL on RVColor:
```python
from rv import commands, extra_commands
source = commands.nodesOfType("RVSource")[0]
color = extra_commands.associatedNode("RVColor", source)
commands.setIntProperty(f"{color}.CDL.active", [1], True)
commands.setFloatProperty(f"{color}.CDL.slope", [1.1, 0.9, 1.0], True)
```
3. File > Export > OTIO — fails with `"invalid property name .CDL.active"`
