### PR TITLE
feat: SG-43604: Add thread safe consoleWrite command for Python console output

### DIFF
--- a/src/lib/app/PyTwkApp/PyInterface.cpp
+++ b/src/lib/app/PyTwkApp/PyInterface.cpp
@@ -453,6 +453,7 @@ namespace TwkApp
             PyModule_AddObject(pModule, "Event", reinterpret_cast<PyObject*>(pyEventType()));
         }
 
+        initPyMuSymbolType();
         if (PyType_Ready(pyMuSymbolType()) >= 0)
         {
             Py_XINCREF(pyMuSymbolType());

--- a/src/lib/app/PyTwkApp/PyMuSymbolType.cpp
+++ b/src/lib/app/PyTwkApp/PyMuSymbolType.cpp
@@ -45,8 +45,8 @@
 #include <MuTwkApp/EventType.h>
 #include <MuTwkApp/MuInterface.h>
 #include <boost/algorithm/string.hpp>
-#include <boost/thread.hpp>
 #include <half.h>
+#include <thread>
 #include <sstream>
 #include <stdexcept>
 #include <iostream>
@@ -57,24 +57,7 @@ namespace TwkApp
 
     // Thread safety tracking
     // Default constructor creates "not-a-thread" ID
-    static boost::thread::id s_mainThreadId;
-
-    // Helper function for direct cout printing
-    static PyObject* unsafe_mu_print(PyObject* args)
-    {
-        size_t nargs = PyTuple_Size(args);
-        if (nargs >= 1)
-        {
-            PyObject* arg = PyTuple_GetItem(args, 0);
-            if (PyUnicode_Check(arg))
-            {
-                const char* str = PyUnicode_AsUTF8(arg);
-                if (str)
-                    cout << str;
-            }
-        }
-        Py_RETURN_NONE;
-    }
+    static std::thread::id s_mainThreadId;
 
     Mu::FunctionObject* createFunctionObjectFromPyObject(const Mu::FunctionType* t, PyObject* pyobj)
     {
@@ -302,30 +285,12 @@ namespace TwkApp
             return NULL;
         }
 
-        // Thread safety check - initialize main thread ID on first call
-        boost::thread::id currentThreadId = boost::this_thread::get_id();
-        if (s_mainThreadId == boost::thread::id()) // Check if uninitialized
-                                                   // (default constructed)
+        // Thread safety check
+        if (std::this_thread::get_id() != s_mainThreadId)
         {
-            s_mainThreadId = currentThreadId;
-        }
+            PyErr_SetString(PyExc_RuntimeError, "Mu is not thread-safe. Mu functions must be called from the main thread");
 
-        if (currentThreadId != s_mainThreadId)
-        {
-            // fix mu print commands from python to at least not crash from
-            // non-main thread
-            //  (because python print is often used to debug python code, so
-            //  we'll tolerate this because print is likely redirected to the RV
-            //  console)
-            if (self->function->fullyQualifiedName() == "extra_commands._print")
-            {
-                return unsafe_mu_print(args);
-            }
-
-            // this cout will probably get redirected to the RV console, or go
-            // to the terminal window.
-            cout << "WARNING: Mu " << self->function->fullyQualifiedName() << "() called from non-main thread, will eventually crash "
-                 << "(Mu isn't thread-safe)." << endl;
+            return nullptr;
         }
 
         size_t nargs = PyTuple_Size(args);
@@ -485,9 +450,6 @@ namespace TwkApp
 
     PyTypeObject* pyMuSymbolType() { return &type; }
 
-    void initPyMuSymbolType()
-    {
-        //
-    }
+    void initPyMuSymbolType() { s_mainThreadId = std::this_thread::get_id(); }
 
 } // namespace TwkApp

--- a/src/lib/app/RvCommon/PyUICommands.cpp
+++ b/src/lib/app/RvCommon/PyUICommands.cpp
@@ -418,6 +418,41 @@ namespace Rv
 
 #endif
 
+    static PyObject* consoleWrite(PyObject*, PyObject* args)
+    {
+        PyLockObject locker;
+        const char* message = nullptr;
+        bool foundConsole = false;
+
+        if (!PyArg_ParseTuple(args, "s", &message))
+            return nullptr;
+
+        Py_BEGIN_ALLOW_THREADS;
+
+        if (RvApplication* app = RvApp())
+        {
+            if (RvConsoleWindow* console = app->console())
+            {
+                foundConsole = true;
+                size_t size = strlen(message);
+                console->append(message, size);
+
+                // Invoke processTextBuffer using AutoConnection to automatically
+                // use queued connection if we're not on the main thread
+                QMetaObject::invokeMethod(console, "processTextBuffer", Qt::AutoConnection);
+            }
+        }
+
+        if (!foundConsole)
+        {
+            cout << message;
+        }
+
+        Py_END_ALLOW_THREADS;
+
+        Py_RETURN_NONE;
+    }
+
     static PyMethodDef localmethods[] = {
 
         {"readSettings", readSettings, METH_VARARGS, ""},
@@ -437,6 +472,8 @@ namespace Rv
         {"sessionBottomToolBar", sessionBottomToolBar, METH_NOARGS, ""},
 
         {"javascriptExport", javascriptExport, METH_VARARGS, ""},
+
+        {"consoleWrite", consoleWrite, METH_VARARGS, "Write a message to the RV console window."},
 
         {NULL}};
 

--- a/src/lib/app/RvCommon/RvConsoleWindow.cpp
+++ b/src/lib/app/RvCommon/RvConsoleWindow.cpp
@@ -207,17 +207,24 @@ namespace Rv
 
     void RvConsoleWindow::processTextBuffer()
     {
-        if (!m_textBuffer.str().empty())
+        std::string text;
+        {
+            QMutexLocker l(&m_lock);
+            text = m_textBuffer.str();
+            m_textBuffer.str("");
+        }
+
+        if (!text.empty())
         {
             vector<string> lines;
-            stl_ext::tokenize(lines, m_textBuffer.str(), "\n\r");
+            stl_ext::tokenize(lines, text, "\n\r");
 
             bool shouldShow = false;
 
             textEdit()->moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
 
             // QTextEdit::insertHtml() is slow so we use it only when necessary
-            if (stringPotentiallyContainsHtml(m_textBuffer.str()))
+            if (stringPotentiallyContainsHtml(text))
             {
                 QString html;
 
@@ -244,8 +251,6 @@ namespace Rv
                 show();
                 raise();
             }
-
-            m_textBuffer.str("");
         }
 
         if (m_processTimerRunning)

--- a/src/lib/app/RvCommon/RvConsoleWindow.cpp
+++ b/src/lib/app/RvCommon/RvConsoleWindow.cpp
@@ -119,7 +119,6 @@ namespace Rv
             m_cerr = new ostream(m_stderrBuf);
         }
 #endif
-
         RV_QSETTINGS;
 
         settings.beginGroup("Console");
@@ -291,31 +290,35 @@ namespace Rv
             lineLogLevel = spdlog::level::err;
             line.erase(0, 6);
             out = m_cerr;
-            *out << "ERROR: ";
+            if (out)
+                *out << "ERROR: ";
         }
         else if (line.find("WARNING:") == 0)
         {
             lineLogLevel = spdlog::level::warn;
             line.erase(0, 8);
             out = m_cerr;
-            *out << "WARNING: ";
+            if (out)
+                *out << "WARNING: ";
         }
         else if (line.find("INFO:") == 0)
         {
             lineLogLevel = spdlog::level::info;
             line.erase(0, 5);
-            *out << "INFO: ";
+            if (out)
+                *out << "INFO: ";
         }
         else if (line.find("DEBUG:") == 0)
         {
             lineLogLevel = spdlog::level::debug;
             line.erase(0, 6);
-            *out << "DEBUG: ";
+            if (out)
+                *out << "DEBUG: ";
         }
 
         // We removed the message type from the line, let's make sure
         // that we also remove the space between the type and the line
-        if (std::isspace(line.at(0)))
+        if (!line.empty() && std::isspace(line.at(0)))
         {
             line.erase(0, 1);
         }
@@ -341,7 +344,8 @@ namespace Rv
         m_fileLogger.logToFile(lineLogLevel, line);
         if (line.size() && line[0] != '<')
         {
-            *out << line;
+            if (out)
+                *out << line;
             html += "<br>";
         }
 
@@ -375,7 +379,8 @@ namespace Rv
             textEdit()->insertPlainText("ERROR: ");
             line.erase(0, 6);
             out = m_cerr;
-            *out << "ERROR: ";
+            if (out)
+                *out << "ERROR: ";
             lineLogLevel = spdlog::level::err;
         }
         else if (line.find("WARNING:") == 0)
@@ -385,7 +390,8 @@ namespace Rv
             textEdit()->insertPlainText("WARNING: ");
             line.erase(0, 8);
             out = m_cerr;
-            *out << "WARNING: ";
+            if (out)
+                *out << "WARNING: ";
             lineLogLevel = spdlog::level::warn;
         }
         else if (line.find("INFO:") == 0)
@@ -393,7 +399,8 @@ namespace Rv
             textEdit()->setTextColor(Qt::cyan);
             textEdit()->insertPlainText("INFO: ");
             line.erase(0, 5);
-            *out << "INFO: ";
+            if (out)
+                *out << "INFO: ";
             lineLogLevel = spdlog::level::info;
         }
         else if (line.find("DEBUG:") == 0)
@@ -401,20 +408,22 @@ namespace Rv
             textEdit()->setTextColor(Qt::green);
             textEdit()->insertPlainText("DEBUG: ");
             line.erase(0, 6);
-            *out << "DEBUG: ";
+            if (out)
+                *out << "DEBUG: ";
             lineLogLevel = spdlog::level::debug;
         }
 
         // We removed the message type from the line, let's make sure
         // that we also remove the space between the type and the line
-        if (std::isspace(line.at(0)))
+        if (!line.empty() && std::isspace(line.at(0)))
         {
             line.erase(0, 1);
         }
 
         textEdit()->setTextColor(Qt::white);
         textEdit()->insertPlainText(line.c_str());
-        *out << line;
+        if (out)
+            *out << line;
         m_fileLogger.logToFile(lineLogLevel, line);
 
         int showIndex = m_ui.showComboBox->currentIndex();

--- a/src/lib/app/py_rvui/rv_commands_setup.py
+++ b/src/lib/app/py_rvui/rv_commands_setup.py
@@ -507,8 +507,8 @@ rv.extra_commands.displayFeedbackQueue = _displayFeedbackQueue_wrapper
 if "RV_NO_CONSOLE_REDIRECT" not in os.environ:
 
     class RVStdOut:
-        def __init__(self):
-            self.write = MuSymbol("extra_commands._print")
+        def write(self, s):
+            rv.commands.consoleWrite(s)
 
         def flush(self):
             pass


### PR DESCRIPTION
### Linked issues

Follow-up to #907

### Summarize your change.

In python, calling print() from a background is still not thread safe and can still lead to rv crashing.

#907 added a thread-safety guard in `PyMuSymbolType::call()` to detect if python is calling a Mu command from a non-main thread. To try and fix the crashing when printing/logging from a python thread, the guard calls `self->function->fullyQualifiedName()` to check if we are calling `extra_commands._print`. If we are, it re-routes the call to a safe print.  Unfortunately it turns out, `fullyQualifiedName()` allocates memory with the Mu garbage collector. This is not thread-safe and can case the very heap corruption it was trying to prevent :(

This PR introduces a dedicated, thread-safe Python `consoleWrite` command instead of relying on Mu’s `print` command. Then it changes any attempt to run Mu from Python on a non-main thread into an unconditional `RuntimeError`. 

### Describe the reason for the change.

To prevent memory corruption if python attempts to run Mu code from a background thread and still allow printing to the RVConsole window. 

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9. 

### Add a list of changes, and note any that might need special attention during the review.

- `PyMuSymbolType.cpp`: 
   - Add unconditional `RuntimeError` for Mu calls from non-main threads. **This is the critical change**.
   - replace `boost::thread` with `std::thread`
- `PyInterface.cpp`: Initialize main thread ID at startup instead of lazily on first call.
- `PyUICommands.cpp`: Add `consoleWrite` command for thread-safe Python console output.
- `rv_commands_setup.py`: Replace `extra_commands._print` with `rv.commands.consoleWrite`.
- `RvConsoleWindow.cpp`: 
   - Add null checks for output streams and handle empty lines.
   - Fix data race in processTextBuffer

### If possible, provide screenshots.

N/A