### PR TITLE
fix: SG-43602: Fix crash when adding a session file alongside media files

### DIFF
--- a/src/lib/app/RvApp/RvSession.cpp
+++ b/src/lib/app/RvApp/RvSession.cpp
@@ -701,7 +701,7 @@ namespace Rv
             if (string(extension(infiles[i])) == "rv")
                 ++rvFileCount;
 
-        if (rvFileCount > 1)
+        if (rvFileCount && infiles.size() > 1)
             merge = true;
 
         //  PROGLOAD  this func should take tag for when called from mu


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

Fix a crash when loading an `.rv` session file alongside media files. A single session file mixed with media was not triggering merge mode, so the session import would overwrite the graph while media files were still being loaded, causing memory corruption.

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9.

**To reproduce on unpatched OpenRV:**
```bash
rv /path/to/some_image.exr session.rv
```

The crash is more likely when the session file is the last argument or in the middle of multiple files.

### If possible, provide screenshots.

N/A
