### PR TITLE
fix: SG-43079: Optimize time it takes to display thumbnails when we re-display them

### DIFF
--- a/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
+++ b/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
@@ -553,6 +553,7 @@ class LocalThumbnailGen(rvtypes.MinorMode):
 
     def _on_play_start(self, event: Any) -> None:
         event.reject()
+        print("DEBUG: play starting")
         with self._procs_lock:
             should_defer = self._should_defer()
             self._playback_active = True

--- a/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
+++ b/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
@@ -553,7 +553,6 @@ class LocalThumbnailGen(rvtypes.MinorMode):
 
     def _on_play_start(self, event: Any) -> None:
         event.reject()
-        print("DEBUG: play starting")
         with self._procs_lock:
             should_defer = self._should_defer()
             self._playback_active = True

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1197,12 +1197,6 @@ class: ThumbnailRenderer
         }
     }
 
-    method: resetPreviews (void;)
-    {
-        _source.reset();
-        _input.reset();
-    }
-
     // Push node to queue's deferred list. If the queue is already exhausted,
     // restart the timer so the deferred item is not stranded.
     method: deferNodeToQueue (void; PreviewRenderQueue queue, string node)

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1203,6 +1203,16 @@ class: ThumbnailRenderer
         _input.reset();
     }
 
+    // Push node to queue's deferred list. If the queue is already exhausted,
+    // restart the timer so the deferred item is not stranded.
+    method: deferNodeToQueue (void; PreviewRenderQueue queue, string node)
+    {
+        queue.progressiveRenderDeferred.push_back(node);
+
+        if (queue.renderIdx >= queue.renderQueue.size())
+            queue.renderTimer.start(0);
+    }
+
 }
 
 documentation: """
@@ -2219,7 +2229,7 @@ class: SessionManagerMode : MinorMode
     {
         if (_thumbnailRenderer._source.renderIdx >= _thumbnailRenderer._source.renderQueue.size()) return;
 
-        let node = _thumbnailRenderer._source.renderQueue[_thumbnailRenderer._source.renderIdx];
+        let node    = _thumbnailRenderer._source.renderQueue[_thumbnailRenderer._source.renderIdx];
         let preview = _thumbnailRenderer._source.progressiveRenderPreviews[_thumbnailRenderer._source.renderIdx];
         _thumbnailRenderer._source.renderIdx = _thumbnailRenderer._source.renderIdx + 1;
         _thumbnailRenderer.makeSourceRowWidget(node, preview);
@@ -2230,9 +2240,9 @@ class: SessionManagerMode : MinorMode
         }
         else if (!_thumbnailRenderer._source.progressiveRenderDeferred.empty())
         {
-            _thumbnailRenderer._source.renderQueue    = _thumbnailRenderer._source.progressiveRenderDeferred;
+            _thumbnailRenderer._source.renderQueue             = _thumbnailRenderer._source.progressiveRenderDeferred;
             _thumbnailRenderer._source.progressiveRenderDeferred = string[]();
-            _thumbnailRenderer._source.renderIdx    = 0;
+            _thumbnailRenderer._source.renderIdx               = 0;
 
             _thumbnailRenderer._source.progressiveRenderPreviews = SourcePreviewWidget[]();
             for_each (dnode; _thumbnailRenderer._source.renderQueue)
@@ -2257,7 +2267,6 @@ class: SessionManagerMode : MinorMode
         let node    = _thumbnailRenderer._input.renderQueue[_thumbnailRenderer._input.renderIdx];
         let preview = _thumbnailRenderer._input.progressiveRenderPreviews[_thumbnailRenderer._input.renderIdx];
         _thumbnailRenderer._input.renderIdx = _thumbnailRenderer._input.renderIdx + 1;
-
         _thumbnailRenderer.makeSourceRowWidget(node, preview);
 
         if (_thumbnailRenderer._input.renderIdx < _thumbnailRenderer._input.renderQueue.size())
@@ -2266,9 +2275,20 @@ class: SessionManagerMode : MinorMode
         }
         else if (!_thumbnailRenderer._input.progressiveRenderDeferred.empty())
         {
-            _thumbnailRenderer._input.renderQueue    = _thumbnailRenderer._input.progressiveRenderDeferred;
+            _thumbnailRenderer._input.renderQueue             = _thumbnailRenderer._input.progressiveRenderDeferred;
             _thumbnailRenderer._input.progressiveRenderDeferred = string[]();
-            _thumbnailRenderer._input.renderIdx    = 0;
+            _thumbnailRenderer._input.renderIdx               = 0;
+
+            _thumbnailRenderer._input.progressiveRenderPreviews = SourcePreviewWidget[]();
+            for_each (dnode; _thumbnailRenderer._input.renderQueue)
+            {
+                let item    = itemOfNode(_viewModel, dnode);
+                let preview = SourcePreviewWidget(nil);
+                let w       = _thumbnailRenderer.displaySourceRowPreview(dnode, preview);
+                _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), w);
+                _thumbnailRenderer._input.progressiveRenderPreviews.push_back(preview);
+            }
+
             _thumbnailRenderer._input.renderTimer.start(0);
         }
     }
@@ -2399,14 +2419,17 @@ class: SessionManagerMode : MinorMode
         }
         if (node eq nil) return;
 
-        bool inThumbnailQueue = false;
+        bool inSourceQueue = false;
         for (int i = _thumbnailRenderer._source.renderIdx; i < _thumbnailRenderer._source.renderQueue.size(); i++)
-            if (_thumbnailRenderer._source.renderQueue[i] == node) { inThumbnailQueue = true; break; }
-        if (inThumbnailQueue)
-        {
-            _thumbnailRenderer._source.progressiveRenderDeferred.push_back(node);
-            return;
-        }
+            if (_thumbnailRenderer._source.renderQueue[i] == node) { inSourceQueue = true; break; }
+
+        bool inInputQueue = false;
+        for (int i = _thumbnailRenderer._input.renderIdx; i < _thumbnailRenderer._input.renderQueue.size(); i++)
+            if (_thumbnailRenderer._input.renderQueue[i] == node) { inInputQueue = true; break; }
+
+        if (inSourceQueue) _thumbnailRenderer.deferNodeToQueue(_thumbnailRenderer._source, node);
+        if (inInputQueue)  _thumbnailRenderer.deferNodeToQueue(_thumbnailRenderer._input, node);
+        if (inSourceQueue || inInputQueue) return;
 
         let item = itemOfNode(_viewModel, node);
         if (item neq nil)

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -3417,9 +3417,9 @@ class: SessionManagerMode : MinorMode
         _prevViewButton     = _baseWidget.findChild("prevViewButton");
         _nextViewButton     = _baseWidget.findChild("nextViewButton");
 
-        _lazySetInputsTimer      = QTimer(_dockWidget);
-        _lazyUpdateTimer         = QTimer(_dockWidget);
-        _mainWinVisTimer         = QTimer(_dockWidget);
+        _lazySetInputsTimer = QTimer(_dockWidget);
+        _lazyUpdateTimer    = QTimer(_dockWidget);
+        _mainWinVisTimer    = QTimer(_dockWidget);
 
         _lazySetInputsTimer.setSingleShot(true);
         _lazyUpdateTimer.setSingleShot(true);

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -2219,15 +2219,9 @@ class: SessionManagerMode : MinorMode
     method: processSourceQueue (void;) { processQueue(_thumbnailRenderer._source, _viewModel, _viewTreeView); }
     method: processInputQueue  (void;) { processQueue(_thumbnailRenderer._input,  _inputsModel, _inputsView); }
 
-    // Try to load the next thumbnail and filmstrip from the given render queue,
-    // then restart the timer for the next item. When exhausted, drain deferred.
-    method: processQueue (void; PreviewRenderQueue queue, QStandardItemModel model, QAbstractItemView view)
-    {
-        if (queue.renderIdx >= queue.renderQueue.size()) return;
-
-        let node    = queue.renderQueue[queue.renderIdx];
-        let preview = queue.progressiveRenderPreviews[queue.renderIdx];
-        queue.renderIdx = queue.renderIdx + 1;
+        let node    = _thumbnailRenderer._source.renderQueue[_thumbnailRenderer._source.renderIdx];
+        let preview = _thumbnailRenderer._source.progressiveRenderPreviews[_thumbnailRenderer._source.renderIdx];
+        _thumbnailRenderer._source.renderIdx = _thumbnailRenderer._source.renderIdx + 1;
         _thumbnailRenderer.makeSourceRowWidget(node, preview);
 
         if (queue.renderIdx < queue.renderQueue.size())
@@ -2236,9 +2230,9 @@ class: SessionManagerMode : MinorMode
         }
         else if (!queue.progressiveRenderDeferred.empty())
         {
-            queue.renderQueue               = queue.progressiveRenderDeferred;
-            queue.progressiveRenderDeferred = string[]();
-            queue.renderIdx                 = 0;
+            _thumbnailRenderer._source.renderQueue               = _thumbnailRenderer._source.progressiveRenderDeferred;
+            _thumbnailRenderer._source.progressiveRenderDeferred = string[]();
+            _thumbnailRenderer._source.renderIdx                 = 0;
 
             queue.progressiveRenderPreviews = SourcePreviewWidget[]();
             for_each (dnode; queue.renderQueue)
@@ -2253,7 +2247,32 @@ class: SessionManagerMode : MinorMode
                 }
             }
 
-            queue.renderTimer.start(0);
+            _thumbnailRenderer._source.renderTimer.start(0);
+        }
+    }
+
+    // Try to load the first thumbnail and filmstrip from _input.renderQueue or decode it first, then
+    // restart the timer to queue the next preview to be processed
+    method: processInputQueue (void;)
+    {
+        if (_thumbnailRenderer._input.renderIdx >= _thumbnailRenderer._input.renderQueue.size()) return;
+
+        let node    = _thumbnailRenderer._input.renderQueue[_thumbnailRenderer._input.renderIdx];
+        let preview = _thumbnailRenderer._input.progressiveRenderPreviews[_thumbnailRenderer._input.renderIdx];
+        _thumbnailRenderer._input.renderIdx = _thumbnailRenderer._input.renderIdx + 1;
+
+        _thumbnailRenderer.makeSourceRowWidget(node, preview);
+
+        if (_thumbnailRenderer._input.renderIdx < _thumbnailRenderer._input.renderQueue.size())
+        {
+            _thumbnailRenderer._input.renderTimer.start(0);
+        }
+        else if (!_thumbnailRenderer._input.progressiveRenderDeferred.empty())
+        {
+            _thumbnailRenderer._input.renderQueue               = _thumbnailRenderer._input.progressiveRenderDeferred;
+            _thumbnailRenderer._input.progressiveRenderDeferred = string[]();
+            _thumbnailRenderer._input.renderIdx                 = 0;
+            _thumbnailRenderer._input.renderTimer.start(0);
         }
     }
 

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1065,6 +1065,135 @@ class: EventFilter : QObject
     }
 }
 
+class: ThumbnailManager
+{
+    QTimer renderTimer;
+    string[] renderQueue;
+    SourcePreviewWidget[] progressiveRenderPreviews;
+    int renderIdx;
+    string[] progressiveRenderDeferred;
+
+    method: ThumbnailManager (ThumbnailManager;)
+    {
+        renderQueue              = string[]();
+        progressiveRenderPreviews = SourcePreviewWidget[]();
+        renderIdx                = 0;
+        progressiveRenderDeferred = string[]();
+    }
+}
+
+documentation: """
+ThumbnailRenderer keeps track of the sources and inputs to render in
+the session manager. Source and input nodes are rendered progressively
+using QT single shot timers, hence the events are placed on the QT event
+queue. 
+""";
+class: ThumbnailRenderer
+{
+    // source and input each get their own render queue/timer/state
+    ThumbnailManager     _source;
+    ThumbnailManager     _input;
+    QDockWidget        _dockWidget;
+    QIcon              _fallbackSourceIcon;
+
+
+    method: ThumbnailRenderer (ThumbnailRenderer;) {
+
+        let m = mainWindowWidget();
+        _dockWidget         = QDockWidget("Session Manager", m, Qt.Widget);
+
+        _source = ThumbnailManager();
+        _source.renderTimer              = QTimer(_dockWidget);
+        _source.renderTimer.setSingleShot(true);
+
+        _input = ThumbnailManager();
+        _input.renderTimer               = QTimer(_dockWidget);
+        _input.renderTimer.setSingleShot(true);
+    }
+
+    // Load media metadata, text and placheolder image used before loading actual media
+    method: displaySourceRowPreview (QWidget; string node, SourcePreviewWidget preview)
+    {
+        let widget = QWidget(nil, 0),
+            layout = QHBoxLayout(widget);
+        widget.setObjectName("sourceRowWidget");
+        layout.setContentsMargins(SOURCE_ROW_MARGIN, 0, SOURCE_ROW_MARGIN, 0);
+        layout.setSpacing(SOURCE_ROW_SPACING);
+
+        preview.setParent(widget);
+        preview.setFixedSize(QSize(SOURCE_PREVIEW_WIDTH, SOURCE_PREVIEW_HEIGHT));
+        preview.setFallback(_fallbackSourceIcon.pixmap(QSize(SOURCE_PREVIEW_WIDTH, SOURCE_PREVIEW_HEIGHT)));
+
+        layout.addWidget(preview);
+
+        string meta = "";
+        try
+        {
+            let sourceNode = sourceNodeOfGroup(node);
+            if (sourceNode neq nil)
+            {
+                let mediaPropertyPath = sourceNode + ".media.movie";
+                if (propertyExists(mediaPropertyPath))
+                {
+                    let movieProperty = getStringProperty(mediaPropertyPath);
+                    if (!movieProperty.empty())
+                    {
+                        let parts = io.path.basename(movieProperty.front()).split(".");
+                        if (parts.size() > 1) meta = parts.back();
+                    }
+                }
+            }
+        }
+        catch (...) {;}
+
+        // Text column
+        let textWidget = QWidget(widget),
+            textLayout = QVBoxLayout(textWidget);
+        textWidget.setObjectName("sourceTextWidget");
+        textLayout.setSpacing(SOURCE_TEXT_SPACING);
+
+        let nameLabel = QLabel(uiName(node), textWidget);
+        nameLabel.setObjectName("sourceNameLabel");
+        textLayout.addWidget(nameLabel);
+
+        let metaLabel = QLabel(if meta == "" then "—" else meta, textWidget);
+        metaLabel.setObjectName("sourceMetaLabel");
+        textLayout.addWidget(metaLabel);
+        textLayout.addStretch(1);
+
+        layout.addWidget(textWidget, 1);
+
+        widget;
+    }
+
+    // Try to load or decode media, 
+    method: makeSourceRowWidget (void; string node, SourcePreviewWidget preview)
+    {
+        string sourceNode = nil;
+        try { sourceNode = sourceNodeOfGroup(node); }
+        catch (exception exc)
+        {
+            print("WARNING: Could not get source node for %s - %s\n" % (uiName(node), exc));
+        }
+        if (sourceNode eq nil) return;
+
+        // Fetch filmstrip/thumbnail paths. The local plugin has a lower priority of
+        // 10 for ordering. This means any custom plugin of higher priority will be used first.
+        // This allows users to override the local plugin with a custom plugin by making sure
+        // the ordering is less than 10 and using event.accept() to prevent the local plugin from running.
+        let thumbnailPath = sendInternalEvent("session-manager-get-thumbnail-path", sourceNode);
+        if (thumbnailPath != "" && io.path.exists(thumbnailPath))
+        {
+            preview.loadThumbnail(thumbnailPath);
+
+            let filmstripPath = sendInternalEvent("session-manager-get-filmstrip-path", sourceNode);
+            if (filmstripPath != "" && io.path.exists(filmstripPath))
+                preview.loadStrip(filmstripPath);
+        }
+    }
+
+}
+
 documentation: """
 SessionManagerMode controls UI for managing viewable nodes in the
 session and a user interface to edit the currently viewed node. New

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1663,7 +1663,7 @@ class: SessionManagerMode : MinorMode
             if (isSource && _previewsEnabled)
             {
                 let preview = SourcePreviewWidget(nil);
-                let w = _thumbnailRenderer.displaySourceRowPreview(innode, preview);
+                let w       = _thumbnailRenderer.displaySourceRowPreview(innode, preview);
                 _inputsView.setIndexWidget(_inputsModel.indexFromItem(item), w);
                 _thumbnailRenderer._input.renderQueue.push_back(innode);
                 _thumbnailRenderer._input.progressiveRenderPreviews.push_back(preview);
@@ -2240,9 +2240,9 @@ class: SessionManagerMode : MinorMode
         }
         else if (!_thumbnailRenderer._source.progressiveRenderDeferred.empty())
         {
-            _thumbnailRenderer._source.renderQueue             = _thumbnailRenderer._source.progressiveRenderDeferred;
+            _thumbnailRenderer._source.renderQueue               = _thumbnailRenderer._source.progressiveRenderDeferred;
             _thumbnailRenderer._source.progressiveRenderDeferred = string[]();
-            _thumbnailRenderer._source.renderIdx               = 0;
+            _thumbnailRenderer._source.renderIdx                 = 0;
 
             _thumbnailRenderer._source.progressiveRenderPreviews = SourcePreviewWidget[]();
             for_each (dnode; _thumbnailRenderer._source.renderQueue)
@@ -2275,20 +2275,9 @@ class: SessionManagerMode : MinorMode
         }
         else if (!_thumbnailRenderer._input.progressiveRenderDeferred.empty())
         {
-            _thumbnailRenderer._input.renderQueue             = _thumbnailRenderer._input.progressiveRenderDeferred;
+            _thumbnailRenderer._input.renderQueue               = _thumbnailRenderer._input.progressiveRenderDeferred;
             _thumbnailRenderer._input.progressiveRenderDeferred = string[]();
-            _thumbnailRenderer._input.renderIdx               = 0;
-
-            _thumbnailRenderer._input.progressiveRenderPreviews = SourcePreviewWidget[]();
-            for_each (dnode; _thumbnailRenderer._input.renderQueue)
-            {
-                let item    = itemOfNode(_viewModel, dnode);
-                let preview = SourcePreviewWidget(nil);
-                let w       = _thumbnailRenderer.displaySourceRowPreview(dnode, preview);
-                _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), w);
-                _thumbnailRenderer._input.progressiveRenderPreviews.push_back(preview);
-            }
-
+            _thumbnailRenderer._input.renderIdx                 = 0;
             _thumbnailRenderer._input.renderTimer.start(0);
         }
     }
@@ -2435,7 +2424,7 @@ class: SessionManagerMode : MinorMode
         if (item neq nil)
         {
             let preview = SourcePreviewWidget(nil);
-            let w = _thumbnailRenderer.displaySourceRowPreview(node, preview);
+            let w       = _thumbnailRenderer.displaySourceRowPreview(node, preview);
             _thumbnailRenderer.makeSourceRowWidget(node, preview);
             _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), w);
         }
@@ -2444,7 +2433,7 @@ class: SessionManagerMode : MinorMode
         if (inputItem neq nil)
         {
             let preview = SourcePreviewWidget(nil);
-            let w = _thumbnailRenderer.displaySourceRowPreview(node, preview);
+            let w       = _thumbnailRenderer.displaySourceRowPreview(node, preview);
             _thumbnailRenderer.makeSourceRowWidget(node, preview);
             _inputsView.setIndexWidget(_inputsModel.indexFromItem(inputItem), w);
         }

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1065,7 +1065,7 @@ class: EventFilter : QObject
     }
 }
 
-class: ThumbnailManager
+class: PreviewRenderQueue
 {
     QTimer renderTimer;
     string[] renderQueue;
@@ -1073,12 +1073,21 @@ class: ThumbnailManager
     int renderIdx;
     string[] progressiveRenderDeferred;
 
-    method: ThumbnailManager (ThumbnailManager;)
+    method: PreviewRenderQueue (PreviewRenderQueue;)
     {
-        renderQueue              = string[]();
+        renderQueue               = string[]();
         progressiveRenderPreviews = SourcePreviewWidget[]();
-        renderIdx                = 0;
+        renderIdx                 = 0;
         progressiveRenderDeferred = string[]();
+    }
+
+    method: reset (void;)
+    {
+        renderTimer.stop();
+        renderQueue               = string[]();
+        progressiveRenderDeferred = string[]();
+        progressiveRenderPreviews = SourcePreviewWidget[]();
+        renderIdx                 = 0;
     }
 }
 
@@ -1091,23 +1100,19 @@ queue.
 class: ThumbnailRenderer
 {
     // source and input each get their own render queue/timer/state
-    ThumbnailManager     _source;
-    ThumbnailManager     _input;
-    QDockWidget        _dockWidget;
-    QIcon              _fallbackSourceIcon;
+    PreviewRenderQueue   _source;
+    PreviewRenderQueue   _input;
+    QIcon                _fallbackSourceIcon;
 
 
-    method: ThumbnailRenderer (ThumbnailRenderer;) {
+    method: ThumbnailRenderer (ThumbnailRenderer; QDockWidget dockWidget) {
 
-        let m = mainWindowWidget();
-        _dockWidget         = QDockWidget("Session Manager", m, Qt.Widget);
-
-        _source = ThumbnailManager();
-        _source.renderTimer              = QTimer(_dockWidget);
+        _source = PreviewRenderQueue();
+        _source.renderTimer              = QTimer(dockWidget);
         _source.renderTimer.setSingleShot(true);
 
-        _input = ThumbnailManager();
-        _input.renderTimer               = QTimer(_dockWidget);
+        _input = PreviewRenderQueue();
+        _input.renderTimer               = QTimer(dockWidget);
         _input.renderTimer.setSingleShot(true);
     }
 
@@ -1192,6 +1197,12 @@ class: ThumbnailRenderer
         }
     }
 
+    method: resetPreviews (void;)
+    {
+        _source.reset();
+        _input.reset();
+    }
+
 }
 
 documentation: """
@@ -1250,6 +1261,8 @@ class: SessionManagerMode : MinorMode
     QAction[]          _viewContextMenuActions;
     QMenu              _createMenu;
     QMenu              _folderMenu;
+    QDockWidget        _dockWidget;
+    ThumbnailRenderer  _thumbnailRenderer;
 
     QDialog            _newNodeDialog;
     QComboBox          _nodeTypeCombo;
@@ -1614,6 +1627,7 @@ class: SessionManagerMode : MinorMode
         if (_disableUpdates || _progressiveLoadingInProgress) return;
 
         _inputOrderLock = true;
+        _thumbnailRenderer._input.reset();
 
         _inputsModel.clear();
         let connections = nodeInputs(node);
@@ -1637,8 +1651,17 @@ class: SessionManagerMode : MinorMode
             _inputsModel.appendRow(item);
 
             if (isSource && _previewsEnabled)
-                _inputsView.setIndexWidget(_inputsModel.indexFromItem(item), makeSourceRowWidget(innode));
+            {
+                let preview = SourcePreviewWidget(nil);
+                let w = _thumbnailRenderer.displaySourceRowPreview(innode, preview);
+                _inputsView.setIndexWidget(_inputsModel.indexFromItem(item), w);
+                _thumbnailRenderer._input.renderQueue.push_back(innode);
+                _thumbnailRenderer._input.progressiveRenderPreviews.push_back(preview);
+            }
         }
+
+        if (!_thumbnailRenderer._input.renderQueue.empty())
+            _thumbnailRenderer._input.renderTimer.start(0);
 
         _inputOrderLock = false;
     }
@@ -2031,7 +2054,10 @@ class: SessionManagerMode : MinorMode
         {
             item.setText("");
             item.setSizeHint(QSize(-1, SOURCE_ROW_HEIGHT));
-            _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), makeSourceRowWidget(node));
+            let preview = SourcePreviewWidget(nil);
+            _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), _thumbnailRenderer.displaySourceRowPreview(node, preview));
+            _thumbnailRenderer._source.renderQueue.push_back(node);
+            _thumbnailRenderer._source.progressiveRenderPreviews.push_back(preview);
         }
 
         //
@@ -2187,9 +2213,70 @@ class: SessionManagerMode : MinorMode
         }
     }
 
+    // Try to load the first thumbnail and filmstrip from _source.renderQueue or decode it first, then
+    // restart the timer to queue the next preview to be processed
+    method: processSourceQueue (void;)
+    {
+        if (_thumbnailRenderer._source.renderIdx >= _thumbnailRenderer._source.renderQueue.size()) return;
+
+        let node = _thumbnailRenderer._source.renderQueue[_thumbnailRenderer._source.renderIdx];
+        let preview = _thumbnailRenderer._source.progressiveRenderPreviews[_thumbnailRenderer._source.renderIdx];
+        _thumbnailRenderer._source.renderIdx = _thumbnailRenderer._source.renderIdx + 1;
+        _thumbnailRenderer.makeSourceRowWidget(node, preview);
+
+        if (_thumbnailRenderer._source.renderIdx < _thumbnailRenderer._source.renderQueue.size())
+        {
+            _thumbnailRenderer._source.renderTimer.start(0);
+        }
+        else if (!_thumbnailRenderer._source.progressiveRenderDeferred.empty())
+        {
+            _thumbnailRenderer._source.renderQueue    = _thumbnailRenderer._source.progressiveRenderDeferred;
+            _thumbnailRenderer._source.progressiveRenderDeferred = string[]();
+            _thumbnailRenderer._source.renderIdx    = 0;
+
+            _thumbnailRenderer._source.progressiveRenderPreviews = SourcePreviewWidget[]();
+            for_each (dnode; _thumbnailRenderer._source.renderQueue)
+            {
+                let item    = itemOfNode(_viewModel, dnode);
+                let preview = SourcePreviewWidget(nil);
+                let w       = _thumbnailRenderer.displaySourceRowPreview(dnode, preview);
+                _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), w);
+                _thumbnailRenderer._source.progressiveRenderPreviews.push_back(preview);
+            }
+
+            _thumbnailRenderer._source.renderTimer.start(0);
+        }
+    }
+
+    // Try to load the first thumbnail and filmstrip from _input.renderQueue or decode it first, then
+    // restart the timer to queue the next preview to be processed
+    method: processInputQueue (void;)
+    {
+        if (_thumbnailRenderer._input.renderIdx >= _thumbnailRenderer._input.renderQueue.size()) return;
+
+        let node    = _thumbnailRenderer._input.renderQueue[_thumbnailRenderer._input.renderIdx];
+        let preview = _thumbnailRenderer._input.progressiveRenderPreviews[_thumbnailRenderer._input.renderIdx];
+        _thumbnailRenderer._input.renderIdx = _thumbnailRenderer._input.renderIdx + 1;
+
+        _thumbnailRenderer.makeSourceRowWidget(node, preview);
+
+        if (_thumbnailRenderer._input.renderIdx < _thumbnailRenderer._input.renderQueue.size())
+        {
+            _thumbnailRenderer._input.renderTimer.start(0);
+        }
+        else if (!_thumbnailRenderer._input.progressiveRenderDeferred.empty())
+        {
+            _thumbnailRenderer._input.renderQueue    = _thumbnailRenderer._input.progressiveRenderDeferred;
+            _thumbnailRenderer._input.progressiveRenderDeferred = string[]();
+            _thumbnailRenderer._input.renderIdx    = 0;
+            _thumbnailRenderer._input.renderTimer.start(0);
+        }
+    }
+
     method: updateTree (void;)
     {
         if (_disableUpdates) return;
+        _thumbnailRenderer._source.reset();
         _srcNodeKeys = string[]();
         _grpNodeValues = string[]();
         _viewModel.clear();
@@ -2283,6 +2370,8 @@ class: SessionManagerMode : MinorMode
             selectViewableNode();
 
             resizeColumns(_viewTreeView, _viewModel);
+
+            _thumbnailRenderer._source.renderTimer.start(0);
         }
         catch (exception exc)
         {
@@ -2310,13 +2399,32 @@ class: SessionManagerMode : MinorMode
         }
         if (node eq nil) return;
 
+        bool inThumbnailQueue = false;
+        for (int i = _thumbnailRenderer._source.renderIdx; i < _thumbnailRenderer._source.renderQueue.size(); i++)
+            if (_thumbnailRenderer._source.renderQueue[i] == node) { inThumbnailQueue = true; break; }
+        if (inThumbnailQueue)
+        {
+            _thumbnailRenderer._source.progressiveRenderDeferred.push_back(node);
+            return;
+        }
+
         let item = itemOfNode(_viewModel, node);
         if (item neq nil)
-            _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), makeSourceRowWidget(node));
+        {
+            let preview = SourcePreviewWidget(nil);
+            let w = _thumbnailRenderer.displaySourceRowPreview(node, preview);
+            _thumbnailRenderer.makeSourceRowWidget(node, preview);
+            _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), w);
+        }
 
         let inputItem = itemOfNode(_inputsModel, node);
         if (inputItem neq nil)
-            _inputsView.setIndexWidget(_inputsModel.indexFromItem(inputItem), makeSourceRowWidget(node));
+        {
+            let preview = SourcePreviewWidget(nil);
+            let w = _thumbnailRenderer.displaySourceRowPreview(node, preview);
+            _thumbnailRenderer.makeSourceRowWidget(node, preview);
+            _inputsView.setIndexWidget(_inputsModel.indexFromItem(inputItem), w);
+        }
     }
 
     method: beforeProgressiveLoading (void; Event event)
@@ -3223,6 +3331,9 @@ class: SessionManagerMode : MinorMode
         _disableUpdates = false;
         _srcNodeKeys    = string[]();
         _grpNodeValues  = string[]();
+        _dockWidget         = QDockWidget("Session Manager", mainWindowWidget(), Qt.Widget);
+        _thumbnailRenderer  = ThumbnailRenderer(_dockWidget);
+        _thumbnailRenderer._fallbackSourceIcon = QIcon(auxFilePath("fallback_thumbnail.png"));
 
         let previewsEnv = system.getenv("RV_SESSION_MANAGER_USE_THUMBNAILS", nil);
         if (previewsEnv neq nil && previewsEnv == "0")
@@ -3283,9 +3394,9 @@ class: SessionManagerMode : MinorMode
         _prevViewButton     = _baseWidget.findChild("prevViewButton");
         _nextViewButton     = _baseWidget.findChild("nextViewButton");
 
-        _lazySetInputsTimer = QTimer(_dockWidget);
-        _lazyUpdateTimer    = QTimer(_dockWidget);
-        _mainWinVisTimer    = QTimer(_dockWidget);
+        _lazySetInputsTimer      = QTimer(_dockWidget);
+        _lazyUpdateTimer         = QTimer(_dockWidget);
+        _mainWinVisTimer         = QTimer(_dockWidget);
 
         _lazySetInputsTimer.setSingleShot(true);
         _lazyUpdateTimer.setSingleShot(true);
@@ -3624,6 +3735,9 @@ class: SessionManagerMode : MinorMode
         state.sessionManager = this;
 
         connect(_dockWidget, QDockWidget.visibilityChanged, visibilityChanged);
+
+        connect(_thumbnailRenderer._source.renderTimer, QTimer.timeout, processSourceQueue);
+        connect(_thumbnailRenderer._input.renderTimer, QTimer.timeout, processInputQueue);
 
         updateNavUI();
     }

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1271,7 +1271,6 @@ class: SessionManagerMode : MinorMode
     QAction[]          _viewContextMenuActions;
     QMenu              _createMenu;
     QMenu              _folderMenu;
-    QDockWidget        _dockWidget;
     ThumbnailRenderer  _thumbnailRenderer;
 
     QDialog            _newNodeDialog;
@@ -2223,62 +2222,44 @@ class: SessionManagerMode : MinorMode
         }
     }
 
-    // Try to load the first thumbnail and filmstrip from _source.renderQueue or decode it first, then
-    // restart the timer to queue the next preview to be processed
-    method: processSourceQueue (void;)
-    {
-        if (_thumbnailRenderer._source.renderIdx >= _thumbnailRenderer._source.renderQueue.size()) return;
+    method: processSourceQueue (void;) { processQueue(_thumbnailRenderer._source, _viewModel, _viewTreeView); }
+    method: processInputQueue  (void;) { processQueue(_thumbnailRenderer._input,  _inputsModel, _inputsView); }
 
-        let node    = _thumbnailRenderer._source.renderQueue[_thumbnailRenderer._source.renderIdx];
-        let preview = _thumbnailRenderer._source.progressiveRenderPreviews[_thumbnailRenderer._source.renderIdx];
-        _thumbnailRenderer._source.renderIdx = _thumbnailRenderer._source.renderIdx + 1;
+    // Try to load the next thumbnail and filmstrip from the given render queue,
+    // then restart the timer for the next item. When exhausted, drain deferred.
+    method: processQueue (void; PreviewRenderQueue queue, QStandardItemModel model, QAbstractItemView view)
+    {
+        if (queue.renderIdx >= queue.renderQueue.size()) return;
+
+        let node    = queue.renderQueue[queue.renderIdx];
+        let preview = queue.progressiveRenderPreviews[queue.renderIdx];
+        queue.renderIdx = queue.renderIdx + 1;
         _thumbnailRenderer.makeSourceRowWidget(node, preview);
 
-        if (_thumbnailRenderer._source.renderIdx < _thumbnailRenderer._source.renderQueue.size())
+        if (queue.renderIdx < queue.renderQueue.size())
         {
-            _thumbnailRenderer._source.renderTimer.start(0);
+            queue.renderTimer.start(0);
         }
-        else if (!_thumbnailRenderer._source.progressiveRenderDeferred.empty())
+        else if (!queue.progressiveRenderDeferred.empty())
         {
-            _thumbnailRenderer._source.renderQueue               = _thumbnailRenderer._source.progressiveRenderDeferred;
-            _thumbnailRenderer._source.progressiveRenderDeferred = string[]();
-            _thumbnailRenderer._source.renderIdx                 = 0;
+            queue.renderQueue               = queue.progressiveRenderDeferred;
+            queue.progressiveRenderDeferred = string[]();
+            queue.renderIdx                 = 0;
 
-            _thumbnailRenderer._source.progressiveRenderPreviews = SourcePreviewWidget[]();
-            for_each (dnode; _thumbnailRenderer._source.renderQueue)
+            queue.progressiveRenderPreviews = SourcePreviewWidget[]();
+            for_each (dnode; queue.renderQueue)
             {
-                let item    = itemOfNode(_viewModel, dnode);
-                let preview = SourcePreviewWidget(nil);
-                let w       = _thumbnailRenderer.displaySourceRowPreview(dnode, preview);
-                _viewTreeView.setIndexWidget(_viewModel.indexFromItem(item), w);
-                _thumbnailRenderer._source.progressiveRenderPreviews.push_back(preview);
+                let item    = itemOfNode(model, dnode);
+                if (item neq nil)
+                {
+                    let preview = SourcePreviewWidget(nil);
+                    let w       = _thumbnailRenderer.displaySourceRowPreview(dnode, preview);
+                    view.setIndexWidget(model.indexFromItem(item), w);
+                    queue.progressiveRenderPreviews.push_back(preview);
+                }
             }
 
-            _thumbnailRenderer._source.renderTimer.start(0);
-        }
-    }
-
-    // Try to load the first thumbnail and filmstrip from _input.renderQueue or decode it first, then
-    // restart the timer to queue the next preview to be processed
-    method: processInputQueue (void;)
-    {
-        if (_thumbnailRenderer._input.renderIdx >= _thumbnailRenderer._input.renderQueue.size()) return;
-
-        let node    = _thumbnailRenderer._input.renderQueue[_thumbnailRenderer._input.renderIdx];
-        let preview = _thumbnailRenderer._input.progressiveRenderPreviews[_thumbnailRenderer._input.renderIdx];
-        _thumbnailRenderer._input.renderIdx = _thumbnailRenderer._input.renderIdx + 1;
-        _thumbnailRenderer.makeSourceRowWidget(node, preview);
-
-        if (_thumbnailRenderer._input.renderIdx < _thumbnailRenderer._input.renderQueue.size())
-        {
-            _thumbnailRenderer._input.renderTimer.start(0);
-        }
-        else if (!_thumbnailRenderer._input.progressiveRenderDeferred.empty())
-        {
-            _thumbnailRenderer._input.renderQueue               = _thumbnailRenderer._input.progressiveRenderDeferred;
-            _thumbnailRenderer._input.progressiveRenderDeferred = string[]();
-            _thumbnailRenderer._input.renderIdx                 = 0;
-            _thumbnailRenderer._input.renderTimer.start(0);
+            queue.renderTimer.start(0);
         }
     }
 
@@ -3343,9 +3324,6 @@ class: SessionManagerMode : MinorMode
         _disableUpdates    = false;
         _srcNodeKeys       = string[]();
         _grpNodeValues     = string[]();
-        _dockWidget        = QDockWidget("Session Manager", mainWindowWidget(), Qt.Widget);
-        _thumbnailRenderer = ThumbnailRenderer(_dockWidget);
-        _thumbnailRenderer._fallbackSourceIcon = QIcon(auxFilePath("fallback_thumbnail.png"));
 
         let previewsEnv = system.getenv("RV_SESSION_MANAGER_USE_THUMBNAILS", nil);
         if (previewsEnv neq nil && previewsEnv == "0")
@@ -3384,7 +3362,10 @@ class: SessionManagerMode : MinorMode
 
         let m = mainWindowWidget();
 
-        _dockWidget         = QDockWidget("Session Manager", m, Qt.Widget);
+        _dockWidget        = QDockWidget("Session Manager", m, Qt.Widget);
+        _thumbnailRenderer = ThumbnailRenderer(_dockWidget);
+        _thumbnailRenderer._fallbackSourceIcon = QIcon(auxFilePath("fallback_thumbnail.png"));
+
         _baseWidget         = loadUIFile(auxFilePath("session_manager.ui"), m);
         _treeViewBase       = _baseWidget.findChild("treeView");
         _addButton          = _baseWidget.findChild("addButton");

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1067,11 +1067,11 @@ class: EventFilter : QObject
 
 class: PreviewRenderQueue
 {
-    QTimer renderTimer;
-    string[] renderQueue;
+    QTimer                renderTimer;
+    string[]              renderQueue;
     SourcePreviewWidget[] progressiveRenderPreviews;
-    int renderIdx;
-    string[] progressiveRenderDeferred;
+    int                   renderIdx;
+    string[]              progressiveRenderDeferred;
 
     method: PreviewRenderQueue (PreviewRenderQueue;)
     {
@@ -1107,12 +1107,12 @@ class: ThumbnailRenderer
 
     method: ThumbnailRenderer (ThumbnailRenderer; QDockWidget dockWidget) {
 
-        _source = PreviewRenderQueue();
-        _source.renderTimer              = QTimer(dockWidget);
+        _source             = PreviewRenderQueue();
+        _source.renderTimer = QTimer(dockWidget);
         _source.renderTimer.setSingleShot(true);
 
-        _input = PreviewRenderQueue();
-        _input.renderTimer               = QTimer(dockWidget);
+        _input             = PreviewRenderQueue();
+        _input.renderTimer = QTimer(dockWidget);
         _input.renderTimer.setSingleShot(true);
     }
 
@@ -3324,15 +3324,15 @@ class: SessionManagerMode : MinorMode
 
     method: SessionManagerMode (SessionManagerMode; string name)
     {
-        _darkUI         = true;
-        _inputOrderLock = false;
-        _editors        = QTreeWidgetItem[]();
-        _quitting       = false;
-        _disableUpdates = false;
-        _srcNodeKeys    = string[]();
-        _grpNodeValues  = string[]();
-        _dockWidget         = QDockWidget("Session Manager", mainWindowWidget(), Qt.Widget);
-        _thumbnailRenderer  = ThumbnailRenderer(_dockWidget);
+        _darkUI            = true;
+        _inputOrderLock    = false;
+        _editors           = QTreeWidgetItem[]();
+        _quitting          = false;
+        _disableUpdates    = false;
+        _srcNodeKeys       = string[]();
+        _grpNodeValues     = string[]();
+        _dockWidget        = QDockWidget("Session Manager", mainWindowWidget(), Qt.Widget);
+        _thumbnailRenderer = ThumbnailRenderer(_dockWidget);
         _thumbnailRenderer._fallbackSourceIcon = QIcon(auxFilePath("fallback_thumbnail.png"));
 
         let previewsEnv = system.getenv("RV_SESSION_MANAGER_USE_THUMBNAILS", nil);

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -2219,9 +2219,15 @@ class: SessionManagerMode : MinorMode
     method: processSourceQueue (void;) { processQueue(_thumbnailRenderer._source, _viewModel, _viewTreeView); }
     method: processInputQueue  (void;) { processQueue(_thumbnailRenderer._input,  _inputsModel, _inputsView); }
 
-        let node    = _thumbnailRenderer._source.renderQueue[_thumbnailRenderer._source.renderIdx];
-        let preview = _thumbnailRenderer._source.progressiveRenderPreviews[_thumbnailRenderer._source.renderIdx];
-        _thumbnailRenderer._source.renderIdx = _thumbnailRenderer._source.renderIdx + 1;
+    // Try to load the next thumbnail and filmstrip from the given render queue,
+    // then restart the timer for the next item. When exhausted, drain deferred.
+    method: processQueue (void; PreviewRenderQueue queue, QStandardItemModel model, QAbstractItemView view)
+    {
+        if (queue.renderIdx >= queue.renderQueue.size()) return;
+
+        let node    = queue.renderQueue[queue.renderIdx];
+        let preview = queue.progressiveRenderPreviews[queue.renderIdx];
+        queue.renderIdx = queue.renderIdx + 1;
         _thumbnailRenderer.makeSourceRowWidget(node, preview);
 
         if (queue.renderIdx < queue.renderQueue.size())
@@ -2230,9 +2236,9 @@ class: SessionManagerMode : MinorMode
         }
         else if (!queue.progressiveRenderDeferred.empty())
         {
-            _thumbnailRenderer._source.renderQueue               = _thumbnailRenderer._source.progressiveRenderDeferred;
-            _thumbnailRenderer._source.progressiveRenderDeferred = string[]();
-            _thumbnailRenderer._source.renderIdx                 = 0;
+            queue.renderQueue               = queue.progressiveRenderDeferred;
+            queue.progressiveRenderDeferred = string[]();
+            queue.renderIdx                 = 0;
 
             queue.progressiveRenderPreviews = SourcePreviewWidget[]();
             for_each (dnode; queue.renderQueue)
@@ -2247,32 +2253,7 @@ class: SessionManagerMode : MinorMode
                 }
             }
 
-            _thumbnailRenderer._source.renderTimer.start(0);
-        }
-    }
-
-    // Try to load the first thumbnail and filmstrip from _input.renderQueue or decode it first, then
-    // restart the timer to queue the next preview to be processed
-    method: processInputQueue (void;)
-    {
-        if (_thumbnailRenderer._input.renderIdx >= _thumbnailRenderer._input.renderQueue.size()) return;
-
-        let node    = _thumbnailRenderer._input.renderQueue[_thumbnailRenderer._input.renderIdx];
-        let preview = _thumbnailRenderer._input.progressiveRenderPreviews[_thumbnailRenderer._input.renderIdx];
-        _thumbnailRenderer._input.renderIdx = _thumbnailRenderer._input.renderIdx + 1;
-
-        _thumbnailRenderer.makeSourceRowWidget(node, preview);
-
-        if (_thumbnailRenderer._input.renderIdx < _thumbnailRenderer._input.renderQueue.size())
-        {
-            _thumbnailRenderer._input.renderTimer.start(0);
-        }
-        else if (!_thumbnailRenderer._input.progressiveRenderDeferred.empty())
-        {
-            _thumbnailRenderer._input.renderQueue               = _thumbnailRenderer._input.progressiveRenderDeferred;
-            _thumbnailRenderer._input.progressiveRenderDeferred = string[]();
-            _thumbnailRenderer._input.renderIdx                 = 0;
-            _thumbnailRenderer._input.renderTimer.start(0);
+            queue.renderTimer.start(0);
         }
     }
 


### PR DESCRIPTION
### fix: Optimize time it takes to display thumbnails when we re-display them

### Summarize your change.
Instead of blocking the main thread and building the entire session manager from scratch with all thumbnails loaded if it's closed/updated, load thumbnails progressively, letting the main thread handle other events.

### Describe the reason for the change.
When loading many files in RV, and closing/opening the session manager, it would freeze the application for an unreasonable amount of time.

### Describe what you have tested and on which operating system.
Mac CY2025

### List of changes
The goal was that when we open the session manager after all thumbnails are closed, we display the placeholder first, add the task to load the thumbnails in a queue, to run them alongside the main thread. We could also load the first 10 or so thumbnails before opening the session manager to avoid showing a placeholder.