### PR TITLE
fix: SG-43711: out-of-bounds access in audioFillBuffer

### DIFF
--- a/src/lib/ip/IPBaseNodes/SequenceIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/SequenceIPNode.cpp
@@ -902,6 +902,7 @@ namespace IPCore
             return context.buffer.size();
         }
 
+        const IPNodes& ins = inputs();
         const double rate = context.buffer.rate();
         const int numChannels = context.buffer.numChannels();
         const size_t requestedSamples = context.buffer.size();
@@ -938,13 +939,20 @@ namespace IPCore
             //
 
             int index = indexAtSample(readSample, rate, context.fps);
-            if (index < 0)
+            if (index < 0 || index >= m_edlGlobalIn->size() - 1)
             {
-                cerr << "ERROR: no samples read from input node" << endl;
+                cerr << "ERROR: no samples read from input node index: " << index << endl;
                 break;
             }
 
             int sourceIndex = (*m_edlSource)[index];
+            bool validSourceIndex = true;
+
+            if (sourceIndex < 0 || sourceIndex >= ins.size())
+            {
+                cerr << "WARNING: invalid source index: " << sourceIndex << endl;
+                validSourceIndex = false;
+            }
 
             //
             //  Measured in Sequence "global" scope;
@@ -956,6 +964,7 @@ namespace IPCore
             //
 
             int inputFrame = (*m_edlGlobalIn)[index] - globalOffset;
+            int outputFrame = (*m_edlGlobalIn)[index + 1] - globalOffset;
             SampleTime inputStart = frameToSample(inputFrame, context.fps, rate);
 
             //
@@ -984,13 +993,19 @@ namespace IPCore
             //
             //  sourceReadStart   - Target sample in Source (where to read
             //  from).
-            //
 
             int firstFrame = (*m_edlSourceIn)[index];
             SampleTime sourceStartSample = frameToSample(firstFrame, context.fps, rate);
-            SampleTime sourceCutInSample = frameToSample(m_rangeInfos[sourceIndex].start, context.fps, rate);
-            int lastFrame = (*m_edlSourceOut)[index];
-            int sourceDuration = m_rangeInfos[sourceIndex].end - m_rangeInfos[sourceIndex].start + 1;
+
+            SampleTime sourceCutInSample = sourceStartSample;
+            int sourceDuration = outputFrame - inputFrame;
+
+            if (validSourceIndex)
+            {
+                sourceCutInSample = frameToSample(m_rangeInfos[sourceIndex].start, context.fps, rate);
+                sourceDuration = m_rangeInfos[sourceIndex].end - m_rangeInfos[sourceIndex].start + 1;
+            }
+
             SampleTime samplesInSource = frameToSample(sourceDuration, context.fps, rate);
             SampleTime samplesIntoSource = sourceStartSample - sourceCutInSample;
             SampleTime sourceReadStart = samplesIntoInput + samplesIntoSource;
@@ -1011,8 +1026,17 @@ namespace IPCore
                 AudioBuffer audioBuffer(numSamples, channels, rate, samplesToTime(sourceReadStart, rate));
 
                 AudioContext subContext(audioBuffer, context.fps);
-                const size_t numRead = inputs()[sourceIndex]->audioFillBuffer(subContext);
-
+                size_t numRead;
+                if (validSourceIndex)
+                {
+                    numRead = ins[sourceIndex]->audioFillBuffer(subContext);
+                }
+                else
+                {
+                    // If the source index is invalid create silence
+                    subContext.buffer.zero();
+                    numRead = numSamples;
+                }
                 //
                 // If we got something back then copy it into the context buffer
                 // and advance the read location.


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

Fix an out-of-bounds array access in `SequenceIPNode::audioFillBuffer` when `sourceIndex` is invalid. Instead of accessing the audio sources array with a bad index, insert silence.

### Describe the reason for the change.

Identified by AddressSanitizer. `SequenceIPNode::audioFillBuffer` can access `m_rangeInfos` and `inputs()` out of bounds when `sourceIndex` is invalid. The fix validates the index before use and inserts silence for invalid sources instead of crashing.

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9.

### Add a list of changes, and note any that might need special attention during the review.

- `SequenceIPNode.cpp`: Add bounds check for `sourceIndex` in `audioFillBuffer`; insert silence when the index is invalid.

### If possible, provide screenshots.

N/A
