### PR TITLE
fix: SG-43710: saveSession(asACopy=true) overwrites the working session filename

### DIFF
--- a/src/lib/app/RvApp/RvSession.cpp
+++ b/src/lib/app/RvApp/RvSession.cpp
@@ -2126,6 +2126,7 @@ namespace Rv
             newRequest.setOption("sessionProtocol", string("RVSession"));
             newRequest.setOption("sessionProtocolVersion", 4);
             newRequest.setOption("sessionName", string("rv"));
+            newRequest.setOption("saveAs", writeAsCopy);
             newRequest.setOption("version", 2);
             if (bigFile)
                 newRequest.setOption("compressed", true);
@@ -2144,7 +2145,6 @@ namespace Rv
             //
 
             Session::write(filename, newRequest);
-            setFileName(filename.c_str());
 
             //
             //  post write events


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

Fix `saveSession(asACopy=true)` so it writes a copy of the session without changing the current session's filename.

### Describe the reason for the change.

Two bugs caused `saveSession(asACopy=true)` to rename the working session to the copy path. First, `RvSession::write()` did not forward `writeAsCopy` as the `saveAs` option, so `Session::write()` defaulted to calling `setFileName()`. Second, `RvSession::write()` unconditionally called `setFileName()` after the write, so even with the correct option the rename would still happen. The fix passes `saveAs=writeAsCopy` in the `WriteRequest` and removes the unconditional `setFileName()`.

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9.

### Add a list of changes, and note any that might need special attention during the review.

- `RvSession.cpp`: Pass `saveAs=writeAsCopy` in the write request; remove unconditional `setFileName()` after write.

### If possible, provide screenshots.

N/A