### PR TITLE
fix: SG-43709: ImGuiPythonBridge crash on shutdown

### DIFF
--- a/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
+++ b/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.cpp
@@ -5,35 +5,38 @@
 
 namespace Rv
 {
-    static bool s_shuttingDown = false;
+    std::vector<ImGuiPythonBridge::PyObjectPtr>* ImGuiPythonBridge::g_callbacks = new std::vector<ImGuiPythonBridge::PyObjectPtr>();
 
     void ImGuiPythonBridge::PyObjectDeleter::operator()(PyObject* obj) const
     {
-        if (obj && !s_shuttingDown && Py_IsInitialized())
+        if (obj && Py_IsInitialized())
         {
+            PyGILState_STATE gstate = PyGILState_Ensure();
             Py_DECREF(obj);
+            PyGILState_Release(gstate);
         }
     }
 
-    std::vector<ImGuiPythonBridge::PyObjectPtr> ImGuiPythonBridge::s_callbacks;
-
     void ImGuiPythonBridge::registerCallback(PyObject* callable)
     {
-        if (PyCallable_Check(callable))
+        if (g_callbacks && PyCallable_Check(callable))
         {
             Py_INCREF(callable);
-            s_callbacks.emplace_back(callable);
+            g_callbacks->emplace_back(callable);
         }
     }
 
     void ImGuiPythonBridge::unregisterCallback(PyObject* callable)
     {
-        for (auto it = s_callbacks.begin(); it != s_callbacks.end();)
+        if (!g_callbacks)
+            return;
+
+        for (auto it = g_callbacks->begin(); it != g_callbacks->end();)
         {
             if (PyObject_RichCompareBool(it->get(), callable, Py_EQ))
             {
                 // Deleter will handle Py_DECREF automatically.
-                it = s_callbacks.erase(it);
+                it = g_callbacks->erase(it);
                 return;
             }
             else
@@ -46,12 +49,12 @@ namespace Rv
     void ImGuiPythonBridge::callCallbacks()
     {
         // Early exit optimization - avoid Python overhead if no callbacks registered
-        if (s_callbacks.empty())
+        if (!g_callbacks || g_callbacks->empty())
         {
             return;
         }
 
-        for (auto& cb : s_callbacks)
+        for (auto& cb : *g_callbacks)
         {
             PyGILState_STATE gstate = PyGILState_Ensure();
             PyObject* result = PyObject_CallObject(cb.get(), nullptr);
@@ -62,24 +65,23 @@ namespace Rv
         }
     }
 
-    int ImGuiPythonBridge::nbCallbacks() { return (int)s_callbacks.size(); }
+    int ImGuiPythonBridge::nbCallbacks() { return g_callbacks ? (int)g_callbacks->size() : 0; }
 
-    void ImGuiPythonBridge::clearCallbacks()
+    void ImGuiPythonBridge::init()
     {
-        s_shuttingDown = true;
+        if (!g_callbacks)
+            g_callbacks = new std::vector<PyObjectPtr>();
+    }
 
-        // During shutdown, we cannot safely call Py_DECREF, so we just release
-        // the smart pointers without calling their deleters and let Python
-        // handle cleanup during interpreter shutdown.
-        for (auto& ptr : s_callbacks)
-        {
-            if (ptr)
-            {
-                // Release without calling Py_DECREF.
-                ptr.release();
-            }
-        }
+    void ImGuiPythonBridge::shutdown()
+    {
+        if (!g_callbacks)
+            return;
 
-        s_callbacks.clear();
+        // Null before delete: during destruction, PyObjectDeleter calls
+        // Py_DECREF which can trigger __del__ -> unregisterCallback re-entrancy.
+        auto* tmp = g_callbacks;
+        g_callbacks = nullptr;
+        delete tmp;
     }
 } // namespace Rv

--- a/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.h
+++ b/src/lib/app/ImGuiPythonBridge/ImGuiPythonBridge.h
@@ -18,7 +18,8 @@ namespace Rv
         static void unregisterCallback(PyObject* callable);
         static void callCallbacks();
         static int nbCallbacks();
-        static void clearCallbacks();
+        static void init();
+        static void shutdown(); // Must be called before Py_Finalize()
 
         struct PyObjectDeleter
         {
@@ -28,7 +29,7 @@ namespace Rv
         using PyObjectPtr = std::unique_ptr<PyObject, PyObjectDeleter>;
 
     private:
-        static std::vector<PyObjectPtr> s_callbacks;
+        static std::vector<PyObjectPtr>* g_callbacks;
     };
 } // namespace Rv
 

--- a/src/lib/app/PyTwkApp/PyInterface.cpp
+++ b/src/lib/app/PyTwkApp/PyInterface.cpp
@@ -13,6 +13,7 @@
 #include <PyTwkApp/PyMu.h>
 #include <PyTwkApp/PyMuSymbolType.h>
 
+#include <ImGuiPythonBridge.h>
 #include <MuPy/PyModule.h>
 #include <MuTwkApp/EventType.h>
 #include <MuTwkApp/MuInterface.h>
@@ -310,6 +311,9 @@ namespace TwkApp
 
     void finalizePython()
     {
+
+        Rv::ImGuiPythonBridge::shutdown();
+
         // Deliberately not using PyLockObject to avoid calling
         // PyGILState_Release in its destructor.
         PyGILState_Ensure();

--- a/src/lib/app/RvCommon/DiagnosticsView.cpp
+++ b/src/lib/app/RvCommon/DiagnosticsView.cpp
@@ -36,6 +36,7 @@ namespace Rv
 
         if (_initCount == 1)
         {
+            Rv::ImGuiPythonBridge::init();
             ImGui::CreateContext();
             ImPlot::CreateContext();
             ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable;
@@ -52,7 +53,7 @@ namespace Rv
 
             if (_initCount == 0)
             {
-                Rv::ImGuiPythonBridge::clearCallbacks();
+                Rv::ImGuiPythonBridge::shutdown();
                 ImGui_ImplOpenGL2_Shutdown();
                 ImGui_ImplQt_Shutdown();
                 ImPlot::DestroyContext();


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

Fix a use-after-free crash on shutdown in `ImGuiPythonBridge`.

The `s_callbacks` vector was declared as a static variable holding Python object pointers. Static destructors in C++ run after `main()` returns with no guaranteed order. If the vector is destroyed after `Py_Finalize()` has shut down the Python interpreter, `Py_DECREF` on the held objects crashes.

This crash does not always happen — it depends on static destructor ordering (which is undefined and varies between compilers and link order) and whether any ImGui Python callbacks were registered during the session. If the vector is empty or happens to be destroyed before `Py_Finalize()`, no crash occurs.

Fix by heap-allocating the callback list and adding a `shutdown()` call before `Py_Finalize()` to release Python references while the interpreter is still alive.

### Describe the reason for the change.

During shutdown, C++ static destructors run after `main()` returns. The static `s_callbacks` vector held `PyObject` pointers with custom deleters calling `Py_DECREF`. If destroyed after `Py_Finalize()`, those deleters operate on a dead interpreter, causing a use-after-free crash.

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9.

### Add a list of changes, and note any that might need special attention during the review.

- `ImGuiPythonBridge.cpp`: Heap-allocate callback list; acquire GIL in `PyObject` deleter.
- `ImGuiPythonBridge.h`: Update callback storage type.
- `PyInterface.cpp`: Call `ImGuiPythonBridge::shutdown()` before `Py_Finalize()`.
- `DiagnosticsView.cpp`: Update call to use new `shutdown()` API.

### If possible, provide screenshots.

N/A