### PR TITLE
fix: SG-43708: Prevent preloader threads from running in rvio

### DIFF
--- a/src/lib/app/RvApp/RvSession.cpp
+++ b/src/lib/app/RvApp/RvSession.cpp
@@ -2912,8 +2912,10 @@ namespace Rv
                     ++m_gtoSourceTotal;
 
                 // Optimization: Start preloading media if this is an
-                // RVFileSource with active media
-                if (p == "RVFileSource" && !Options::sharedOptions().progressiveSourceLoading)
+                // RVFileSource with active media. Preloading is not
+                // supported in rvio/batch mode
+                if (p == "RVFileSource" && !Options::sharedOptions().progressiveSourceLoading
+                    && Options::sharedOptions().delaySessionLoading)
                 {
                     IntProperty* mediaActive = pc->property<IntProperty>("media.active");
                     if (mediaActive && !mediaActive->empty() && mediaActive->front() == 1)


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

Prevent `startPreloadingMedia()` background threads from running in rvio/batch mode where they race with synchronous session loading and cause heap corruption.

### Describe the reason for the change.

`startPreloadingMedia()` starts background threads that preload media from disk. These are only safe in interactive RV, where session loading is deferred (`delaySessionLoading=1`). In rvio, session loading is synchronous (`delaySessionLoading=0`) and the preloader threads race with it, causing non-deterministic heap corruption and SIGABRT. The preload call was added in commit `512d4182` but only gated on `progressiveSourceLoading`, inadvertently enabling it in rvio. The fix adds `delaySessionLoading` to the condition.

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9.

### Add a list of changes, and note any that might need special attention during the review.

- `RvSession.cpp`: Add `delaySessionLoading` check to the preload condition so rvio/batch mode never starts background preloader threads.

### If possible, provide screenshots.

N/A
