### PR TITLE
fix: SG-43707: multiple crash and safety issues

### DIFF
--- a/src/lib/app/RvApp/CommandsModule.cpp
+++ b/src/lib/app/RvApp/CommandsModule.cpp
@@ -190,6 +190,8 @@ namespace Rv
             throwBadArgumentException(node, thread, "node name is nil");
 
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(node, thread, "no current session");
         session->findProperty(props, name->c_str());
         if (props.empty())
             throwBadProperty(thread, node, name->c_str());
@@ -243,6 +245,10 @@ namespace Rv
     NODE_IMPLEMENTATION(getCurrentImageSize, Mu::Vector2f)
     {
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+        }
         Vector2f v;
 
         FrameBufferFinder finder;
@@ -287,6 +293,9 @@ namespace Rv
         const StringType* stype = c->stringType();
         const StringType::String* tname = NODE_ARG_OBJECT(0, StringType::String);
 
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+
         if (!tname)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil tname");
 
@@ -316,6 +325,11 @@ namespace Rv
         const StringType* stype = static_cast<const StringType*>(ttype->tupleFieldTypes()[0]);
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(ttype->tupleFieldTypes()[1]);
         const StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
+
+        if (!s)
+        {
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+        }
 
         if (!name)
         {
@@ -386,6 +400,9 @@ namespace Rv
     NODE_IMPLEMENTATION(startTimer, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+
         if (s->userTimer().isRunning())
             s->userTimer().stop();
         s->userTimer().start();
@@ -394,6 +411,8 @@ namespace Rv
     NODE_IMPLEMENTATION(elapsedTime, float)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(float(s->userTimer().elapsed()));
     }
 
@@ -402,18 +421,24 @@ namespace Rv
     NODE_IMPLEMENTATION(stopTimer, float)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(float(s->userTimer().stop()));
     }
 
     NODE_IMPLEMENTATION(isTimerRunning, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->userTimer().isRunning());
     }
 
     NODE_IMPLEMENTATION(setSessionType, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int type = NODE_ARG(0, int);
         s->setSessionType((Session::SessionType)type);
     }
@@ -421,6 +446,8 @@ namespace Rv
     NODE_IMPLEMENTATION(getSessionType, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(int(s->getSessionType()));
     }
 
@@ -441,8 +468,11 @@ namespace Rv
         if (!node)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil node");
 
-        IPGraph::GraphEdit edit(RvSession::currentRvSession()->graph());
-        RvSession::currentRvSession()->readCDL(name->c_str(), node->c_str(), activate);
+        RvSession* s = RvSession::currentRvSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+        IPGraph::GraphEdit edit(s->graph());
+        s->readCDL(name->c_str(), node->c_str(), activate);
     }
 
     NODE_IMPLEMENTATION(readLUT, void)
@@ -457,8 +487,11 @@ namespace Rv
         if (!node)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "nil node");
 
-        IPGraph::GraphEdit edit(RvSession::currentRvSession()->graph());
-        RvSession::currentRvSession()->readLUT(name->c_str(), node->c_str(), activate);
+        RvSession* s = RvSession::currentRvSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+        IPGraph::GraphEdit edit(s->graph());
+        s->readLUT(name->c_str(), node->c_str(), activate);
     }
 
     NODE_IMPLEMENTATION(updateLUT, void)
@@ -470,6 +503,10 @@ namespace Rv
     {
         RvSession* s = RvSession::currentRvSession();
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
+
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+
         const TwkFB::FrameBuffer* fb = s->currentFB();
 
         const TwkFB::FrameBuffer* outfb = fb;
@@ -508,7 +545,11 @@ namespace Rv
     {
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         ImageRenderer* renderer = s->renderer();
+        if (!renderer)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no renderer");
         const TwkGLF::GLVideoDevice* d = renderer->controlDevice().glDevice;
 
         if (!name)
@@ -681,8 +722,8 @@ namespace Rv
                         cout << "pixel block x,y = "
                              << pe->x()
                              << ", " << pe->y()
-                             << "  w,h = " << pe->width() 
-                             << ", " << pe->height() 
+                             << "  w,h = " << pe->width()
+                             << ", " << pe->height()
                              << "  view = " << pe->view()
                              << endl;
 #endif
@@ -1774,6 +1815,8 @@ namespace Rv
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
 
         IPNode* node = 0;
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         if (name)
         {

--- a/src/lib/app/RvApp/RvApp/RvSession.h
+++ b/src/lib/app/RvApp/RvApp/RvSession.h
@@ -386,9 +386,6 @@ namespace Rv
 
         static std::string m_initEval;
         static std::string m_pyInitEval;
-
-    public:
-        static Session* m_currentSession;
     };
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -1793,7 +1793,10 @@ namespace Rv
         if (!s)
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
-        QTabWidget* w = RvApp()->prefDialog()->tabWidget();
+        RvPreferences* pref = RvApp()->prefDialog();
+        if (!pref)
+            NODE_RETURN(nullptr);
+        QTabWidget* w = pref->tabWidget();
 
         const QTabWidgetType* type = c->findSymbolOfTypeByQualifiedName<QTabWidgetType>(c->internName("qt.QTabWidget"), false);
 

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -382,6 +382,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         QWidget* w = doc->view();
 
@@ -462,6 +464,8 @@ namespace Rv
     NODE_IMPLEMENTATION(startupResize, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         NODE_RETURN(rvDoc->startupResize());
     }
@@ -491,6 +495,8 @@ namespace Rv
     NODE_IMPLEMENTATION(popupMenu, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
 
         TwkApp::EventType::EventInstance* e = NODE_ARG_OBJECT(0, TwkApp::EventType::EventInstance);
@@ -513,6 +519,8 @@ namespace Rv
     NODE_IMPLEMENTATION(popupMenuAtPoint, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         int x = NODE_ARG(0, int);
         int y = NODE_ARG(1, int);
@@ -528,7 +536,8 @@ namespace Rv
         const StringType::String* title = NODE_ARG_OBJECT(0, StringType::String);
 
         Session* s = Session::currentSession();
-        assert(s);
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         assert(rvDoc);
@@ -539,7 +548,8 @@ namespace Rv
     NODE_IMPLEMENTATION(center, void)
     {
         Session* s = Session::currentSession();
-        assert(s);
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         assert(rvDoc);
@@ -551,7 +561,8 @@ namespace Rv
     NODE_IMPLEMENTATION(close, void)
     {
         Session* s = Session::currentSession();
-        assert(s);
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         assert(rvDoc);
@@ -562,7 +573,8 @@ namespace Rv
     NODE_IMPLEMENTATION(toggleMenuBar, void)
     {
         Session* s = Session::currentSession();
-        assert(s);
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         rvDoc->toggleMenuBar();
     }
@@ -570,7 +582,8 @@ namespace Rv
     NODE_IMPLEMENTATION(isMenuBarVisible, bool)
     {
         Session* s = Session::currentSession();
-        assert(s);
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         NODE_RETURN(rvDoc->menuBarShown());
     }
@@ -582,6 +595,8 @@ namespace Rv
         HOP_PROF_FUNC();
 
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         Process* p = NODE_THREAD.process();
         bool sheet = NODE_ARG(0, bool);
@@ -701,6 +716,8 @@ namespace Rv
     NODE_IMPLEMENTATION(openFileDialog, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         Process* p = NODE_THREAD.process();
         bool sheet = NODE_ARG(0, bool);
@@ -813,6 +830,8 @@ namespace Rv
     NODE_IMPLEMENTATION(saveFileDialog, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         Process* p = NODE_THREAD.process();
         bool sheet = NODE_ARG(0, bool);
@@ -954,6 +973,8 @@ namespace Rv
     NODE_IMPLEMENTATION(setCursor, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         rvDoc->view()->setCursor(QCursor(Qt::CursorShape(NODE_ARG(0, int))));
     }
@@ -961,6 +982,8 @@ namespace Rv
     NODE_IMPLEMENTATION(alertPanel, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = (RvDocument*)s->opaquePointer();
         Process* p = NODE_THREAD.process();
         bool sheet = NODE_ARG(0, bool);
@@ -1033,6 +1056,8 @@ namespace Rv
     NODE_IMPLEMENTATION(stereoSupported, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = (RvDocument*)s->opaquePointer();
 
         NODE_RETURN(true);
@@ -1041,6 +1066,8 @@ namespace Rv
     NODE_IMPLEMENTATION(watchFile, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = (RvDocument*)s->opaquePointer();
         StringType::String* file = NODE_ARG_OBJECT(0, StringType::String);
         bool watch = NODE_ARG(1, bool);
@@ -1159,6 +1186,8 @@ namespace Rv
     NODE_IMPLEMENTATION(remoteConnections, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         const StringType* stype = static_cast<const StringType*>(atype->elementType());
@@ -1186,6 +1215,8 @@ namespace Rv
     NODE_IMPLEMENTATION(remoteApplications, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         const StringType* stype = static_cast<const StringType*>(atype->elementType());
@@ -1206,6 +1237,8 @@ namespace Rv
     NODE_IMPLEMENTATION(remoteContacts, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         const StringType* stype = static_cast<const StringType*>(atype->elementType());
@@ -1535,6 +1568,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* url = NODE_ARG_OBJECT(0, StringType::String);
         ClassInstance* hlist = NODE_ARG_OBJECT(1, ClassInstance);
         StringType::String* replyEvent = NODE_ARG_OBJECT(2, StringType::String);
@@ -1570,6 +1605,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* url = NODE_ARG_OBJECT(0, StringType::String);
         ClassInstance* hlist = NODE_ARG_OBJECT(1, ClassInstance);
         StringType::String* postString = NODE_ARG_OBJECT(2, StringType::String);
@@ -1606,6 +1643,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* url = NODE_ARG_OBJECT(0, StringType::String);
         ClassInstance* hlist = NODE_ARG_OBJECT(1, ClassInstance);
         DynamicArray* postData = NODE_ARG_OBJECT(2, DynamicArray);
@@ -1644,6 +1683,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* url = NODE_ARG_OBJECT(0, StringType::String);
         ClassInstance* hlist = NODE_ARG_OBJECT(1, ClassInstance);
         StringType::String* putString = NODE_ARG_OBJECT(2, StringType::String);
@@ -1680,6 +1721,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* url = NODE_ARG_OBJECT(0, StringType::String);
         ClassInstance* hlist = NODE_ARG_OBJECT(1, ClassInstance);
         DynamicArray* putData = NODE_ARG_OBJECT(2, DynamicArray);
@@ -1718,6 +1761,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
 
         const QMainWindowType* type = c->findSymbolOfTypeByQualifiedName<QMainWindowType>(c->internName("qt.QMainWindow"), false);
@@ -1730,6 +1775,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         QWidget* w = doc->view();
 
@@ -1743,6 +1790,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         QTabWidget* w = RvApp()->prefDialog()->tabWidget();
 
@@ -1756,6 +1805,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
 
         QToolBar* toolBar = doc->bottomViewToolBar();
@@ -1770,6 +1821,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvWebManager* m = RvApp()->webManager();
 
         const QNetworkAccessManagerType* type =
@@ -1783,6 +1836,8 @@ namespace Rv
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
 
         QWebEnginePage* frame = Mu::object<QWebEnginePage>(NODE_ARG_OBJECT(0, ClassInstance));
@@ -1962,6 +2017,8 @@ namespace Rv
         //  kick cache to be sure we recache if necessary.
         //
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Session::CachingMode mode = s->cachingMode();
         s->setCaching(Session::NeverCache);
 
@@ -1971,7 +2028,6 @@ namespace Rv
         }
         else if (value)
         {
-            Session* s = Session::currentSession();
             RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
 
             QString message = "Cannot start presentation mode when multiple "
@@ -2000,6 +2056,8 @@ namespace Rv
         {
             bool presenting = RvApp()->isInPresentationMode();
             Session* s = Session::currentSession();
+            if (!s)
+                throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
             Session::CachingMode mode = s->cachingMode();
 
             if (presenting)
@@ -2065,6 +2123,8 @@ namespace Rv
     NODE_IMPLEMENTATION(showTopViewToolbar, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         bool value = NODE_ARG(0, bool);
         doc->topViewToolBar()->makeActive(value);
@@ -2073,6 +2133,8 @@ namespace Rv
     NODE_IMPLEMENTATION(isTopViewToolbarVisible, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         NODE_RETURN(doc->topViewToolBar()->isVisible());
     }
@@ -2080,6 +2142,8 @@ namespace Rv
     NODE_IMPLEMENTATION(showBottomViewToolbar, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         bool value = NODE_ARG(0, bool);
         doc->bottomViewToolBar()->makeActive(value);
@@ -2088,6 +2152,8 @@ namespace Rv
     NODE_IMPLEMENTATION(isBottomViewToolbarVisible, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         NODE_RETURN(doc->bottomViewToolBar()->isVisible());
     }
@@ -2095,6 +2161,8 @@ namespace Rv
     NODE_IMPLEMENTATION(editNodeSource, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         StringType::String* node = NODE_ARG_OBJECT(0, StringType::String);
 
@@ -2143,6 +2211,8 @@ namespace Rv
         //        Process* p = NODE_THREAD.process();
         //        MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         doc->showDiagnostics();
     }
@@ -2152,6 +2222,8 @@ namespace Rv
         float devicePixelRatio = 1.0f;
 
         const Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
 
         if (doc != nullptr && doc->view() != nullptr)

--- a/src/lib/app/RvCommon/PyUICommands.cpp
+++ b/src/lib/app/RvCommon/PyUICommands.cpp
@@ -260,6 +260,11 @@ namespace Rv
     {
         PyLockObject locker;
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "no current session");
+            return NULL;
+        }
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         PyEventObject* event;
         PyObject* pylist;
@@ -290,6 +295,11 @@ namespace Rv
     {
         PyLockObject locker;
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "no current session");
+            return NULL;
+        }
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
         int x, y;
         PyObject* pylist;
@@ -311,6 +321,11 @@ namespace Rv
     {
         PyLockObject locker;
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "no current session");
+            return NULL;
+        }
         void* rvDoc = (void*)s->opaquePointer();
 
         PyObject* ret = Py_None;
@@ -328,6 +343,11 @@ namespace Rv
     {
         PyLockObject locker;
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "no current session");
+            return NULL;
+        }
 
         PyObject* ret = Py_None;
 
@@ -347,6 +367,11 @@ namespace Rv
     {
         PyLockObject locker;
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "no current session");
+            return NULL;
+        }
         void* rvDoc = (void*)s->opaquePointer();
 
         PyObject* ret = Py_None;
@@ -367,6 +392,11 @@ namespace Rv
     {
         PyLockObject locker;
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "no current session");
+            return NULL;
+        }
         PyObject* ret = Py_None;
 
         if (RvDocument* rvDoc = (RvDocument*)s->opaquePointer())
@@ -385,6 +415,11 @@ namespace Rv
     static PyObject* javascriptExport(PyObject* self, PyObject* args)
     {
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "no current session");
+            return NULL;
+        }
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         uint64_t pointer;
 
@@ -402,6 +437,11 @@ namespace Rv
     static PyObject* javascriptExport(PyObject* self, PyObject* args)
     {
         Session* s = Session::currentSession();
+        if (!s)
+        {
+            PyErr_SetString(PyExc_RuntimeError, "no current session");
+            return NULL;
+        }
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
         uint64_t pointer;
 

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -1080,7 +1080,8 @@ namespace Rv
         if (!m_prefDialog)
         {
             Rv::Session* session = Rv::Session::currentSession();
-            assert(session);
+            if (!session)
+                return nullptr;
             RvDocument* rvDoc = (RvDocument*)session->opaquePointer();
             m_prefDialog = new RvPreferences(rvDoc);
             QRect docGeom = rvDoc->geometry();
@@ -1127,6 +1128,8 @@ namespace Rv
         }
 
         RvPreferences* prefs = prefDialog();
+        if (!prefs)
+            return;
         prefs->update();
 
         const TwkApp::Application::Documents& docs = documents();

--- a/src/lib/app/RvCommon/RvCommon/RvApplication.h
+++ b/src/lib/app/RvCommon/RvCommon/RvApplication.h
@@ -11,6 +11,7 @@
 #include <TwkMediaLibrary/Library.h>
 #include <PyMediaLibrary/PyMediaLibrary.h>
 #include <QtCore/QTimer>
+#include <QtCore/QPointer>
 #include <IPCore/Application.h>
 #include <QtNetwork/QTcpServer>
 #include <QtNetwork/QTcpSocket>
@@ -148,7 +149,7 @@ namespace Rv
         QTimer* m_newTimer;
         QTimer* m_lazyBuildTimer;
         Timer m_fireTimer;
-        RvPreferences* m_prefDialog;
+        QPointer<RvPreferences> m_prefDialog;
         RvProfileManager* m_profileDialog;
         QMenuBar* m_macMenuBar;
         QMenu* m_macRVMenu;

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -693,8 +693,11 @@ namespace Rv
         if (box.clickedButton() == b2)
         {
             RvApp()->prefs();
-            RvApp()->prefDialog()->tabWidget()->setCurrentIndex(2);
-            RvApp()->prefDialog()->raise();
+            if (RvPreferences* p = RvApp()->prefDialog())
+            {
+                p->tabWidget()->setCurrentIndex(2);
+                p->raise();
+            }
         }
         else
         {
@@ -714,9 +717,12 @@ namespace Rv
                 settings.endGroup();
             }
 
-            RvApp()->prefDialog()->update();
-            RvApp()->prefDialog()->write();
-            RvApp()->prefDialog()->raise();
+            if (RvPreferences* p = RvApp()->prefDialog())
+            {
+                p->update();
+                p->write();
+                p->raise();
+            }
         }
     }
 

--- a/src/lib/app/RvPackage/PackageManager.cpp
+++ b/src/lib/app/RvPackage/PackageManager.cpp
@@ -2027,6 +2027,7 @@ namespace Rv
         {
             m_globalSettingsP->sync();
             delete m_globalSettingsP;
+            m_globalSettingsP = nullptr;
         }
     }
 

--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -385,15 +385,19 @@ namespace IPCore
 
     void PaintIPNode::compileFrame(Component* comp)
     {
-        const StringProperty* orderP = comp->property<StringProperty>("order");
-        size_t s = orderP->size();
-
         const string frameName = comp->name().substr(6);
         int frame = atoi(frameName.c_str());
 
         Components& fcomps = m_frameMap[frame];
         fcomps.clear();
 
+        const StringProperty* orderP = comp->property<StringProperty>("order");
+        if (!orderP || orderP->size() == 0)
+        {
+            return;
+        }
+
+        size_t s = orderP->size();
         for (size_t i = 0; i < s; i++)
         {
             const string& c = (*orderP)[i];

--- a/src/lib/ip/IPCore/IPCore/ImageRenderer.h
+++ b/src/lib/ip/IPCore/IPCore/ImageRenderer.h
@@ -175,7 +175,9 @@ namespace IPCore
             };
 
             TextureDescription()
-                : uploaded(false)
+                : id(0)
+                , bufferId(0)
+                , uploaded(false)
                 , age(-1)
             {
             }

--- a/src/lib/ip/IPCore/IPCore/ImageRenderer.h
+++ b/src/lib/ip/IPCore/IPCore/ImageRenderer.h
@@ -646,6 +646,7 @@ namespace IPCore
         //
 
         static void queryGL();
+        static void declareGLProperties(IPNode*);
         static void queryGLIntoContainer(IPNode*);
 
         static bool queryGLFinished() { return !m_queryInit; }

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -630,6 +630,36 @@ namespace IPCore
         controlDevice().glDevice->makeCurrent();
     }
 
+    void ImageRenderer::declareGLProperties(IPNode* node)
+    {
+        // Declare all opengl.* property slots with empty/zero defaults.
+        // No GL context is required. The real values are filled later by
+        // queryGLIntoContainer() once a context is current.
+        node->declareProperty<StringProperty>("opengl.GL_VERSION", string(""), 0, false);
+        node->declareProperty<IntProperty>("opengl.majorVersion", 0, 0, false);
+        node->declareProperty<IntProperty>("opengl.minorVersion", 0, 0, false);
+        node->declareProperty<StringProperty>("opengl.GL_SHADING_LANGUAGE_VERSION", string(""), 0, false);
+        node->declareProperty<StringProperty>("opengl.GL_VENDOR", string(""), 0, false);
+        node->declareProperty<StringProperty>("opengl.GL_RENDERER", string(""), 0, false);
+        node->declareProperty<IntProperty>("opengl.GL_MAX_TEXTURE_SIZE", 0, 0, false);
+#ifdef GL_MAX_TEXTURE_BUFFER_SIZE
+        node->declareProperty<IntProperty>("opengl.GL_MAX_TEXTURE_BUFFER_SIZE", 0, 0, false);
+#endif
+        node->declareProperty<IntProperty>("opengl.GL_MAX_TEXTURE_IMAGE_UNITS", 0, 0, false);
+        node->declareProperty<IntProperty>("opengl.GL_MAX_TEXTURE_COORDS", 0, 0, false);
+        node->declareProperty<IntProperty>("opengl.GL_MAX_TEXTURE_UNITS", 0, 0, false);
+        node->declareProperty<IntProperty>("opengl.GL_MAX_VERTEX_ATTRIBS", 0, 0, false);
+        node->declareProperty<IntProperty>("opengl.GL_MAX_DRAW_BUFFERS", 0, 0, false);
+        node->declareProperty<IntProperty>("opengl.GL_MAX_SAMPLES", 0, 0, false);
+#ifdef GL_MAX_RECTANGLE_TEXTURE_SIZE
+        node->declareProperty<IntProperty>("opengl.GL_MAX_RECTANGLE_TEXTURE_SIZE", 0, 0, false);
+#endif
+        node->declareProperty<IntProperty>("opengl.GL_MAX_3D_TEXTURE_SIZE", 0, 0, false);
+        node->createProperty<StringProperty>("opengl.GL_EXTENSIONS");
+        node->declareProperty<IntProperty>("opengl.glsl.majorVersion", 0, 0, false);
+        node->declareProperty<IntProperty>("opengl.glsl.minorVersion", 0, 0, false);
+    }
+
     void ImageRenderer::queryGLIntoContainer(IPNode* node)
     {
         const string glver = TwkGLF::safeGLGetString(GL_VERSION);

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -628,6 +628,10 @@ namespace IPCore
     Session::~Session()
     {
         m_beingDeleted = true;
+        if (m_currentSession == this)
+        {
+            m_currentSession = nullptr;
+        }
 
         breakVideoDeviceConnections();
 

--- a/src/lib/ip/IPCore/SessionIPNode.cpp
+++ b/src/lib/ip/IPCore/SessionIPNode.cpp
@@ -29,7 +29,7 @@ namespace IPCore
         declareProperty<IntProperty>("paintEffects.ghostAfter", 5);
         setMaxInputs(0);
 
-        ImageRenderer::queryGLIntoContainer(this);
+        ImageRenderer::declareGLProperties(this);
     }
 
     SessionIPNode::~SessionIPNode()

--- a/src/lib/ip/IPMu/CommandsModule.cpp
+++ b/src/lib/ip/IPMu/CommandsModule.cpp
@@ -315,12 +315,16 @@ namespace IPMu
     NODE_IMPLEMENTATION(inPoint, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->inPoint());
     }
 
     NODE_IMPLEMENTATION(outPoint, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->outPoint() - 1);
     }
 
@@ -328,6 +332,8 @@ namespace IPMu
     {
         int f = NODE_ARG(0, int);
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int newOut = f + 1, oldIn = s->inPoint();
         {
             IPGraph::GraphEdit edit(s->graph());
@@ -342,6 +348,8 @@ namespace IPMu
     {
         int f = NODE_ARG(0, int);
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int oldOut = s->outPoint();
         {
             IPGraph::GraphEdit edit(s->graph());
@@ -357,6 +365,8 @@ namespace IPMu
         Vector4f m = NODE_ARG(0, Vector4f);
         const bool allDevices = NODE_ARG(1, bool);
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->setMargins(m[0], m[1], m[2], m[3], allDevices);
         s->askForRedraw(true /*force*/);
     }
@@ -364,6 +374,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(margins, Mu::Vector4f)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const VideoDevice* d = s->eventVideoDevice() ? s->eventVideoDevice() : s->outputVideoDevice();
         TwkApp::VideoDevice::Margins m = d->margins();
 
@@ -380,6 +392,8 @@ namespace IPMu
     {
         int m = NODE_ARG(0, int);
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         switch (m)
         {
@@ -398,6 +412,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(playMode, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int rval = 0;
 
         switch (s->playMode())
@@ -420,7 +436,8 @@ namespace IPMu
     {
         int f = NODE_ARG(0, int);
         Session* s = Session::currentSession();
-
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->graph().cache().lock();
         s->graph().cache().clearAllButFrame(f);
         s->graph().cache().unlock();
@@ -430,6 +447,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(reload, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            return;
         Session::NodeVector nodes;
 
         s->findCurrentNodesByTypeName(nodes, "RVFileSource");
@@ -451,6 +470,8 @@ namespace IPMu
         int start = NODE_ARG(0, int);
         int end = NODE_ARG(1, int);
         Session* s = Session::currentSession();
+        if (!s)
+            return;
         Session::NodeVector nodes;
 
         s->findNodesByTypeName(nodes, "RVFileSource");
@@ -470,6 +491,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(loadChangedFrames, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            return;
         DynamicArray* inputs = NODE_ARG_OBJECT(0, DynamicArray);
 
         //  Turn off cache
@@ -524,6 +547,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(play, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            return;
         s->play();
         s->askForRedraw(true);
     }
@@ -531,12 +556,17 @@ namespace IPMu
     NODE_IMPLEMENTATION(isPlaying, bool)
     {
         Session* s = Session::currentSession();
-        NODE_RETURN(bool(s->isPlaying()));
+        if (!s)
+            NODE_RETURN(bool(false));
+        else
+            NODE_RETURN(bool(s->isPlaying()));
     }
 
     NODE_IMPLEMENTATION(stop, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            return;
         s->stop();
         s->askForRedraw(true);
     }
@@ -544,13 +574,18 @@ namespace IPMu
     NODE_IMPLEMENTATION(frame, int)
     {
         Session* s = Session::currentSession();
-        NODE_RETURN(s->currentFrame());
+        if (!s)
+            NODE_RETURN(0);
+        else
+            NODE_RETURN(s->currentFrame());
     }
 
     NODE_IMPLEMENTATION(metaEvaluate, Pointer)
     {
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const int frame = NODE_ARG(0, int);
         const DynamicArrayType* dtype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         DynamicArray* array = new DynamicArray(dtype, 1);
@@ -646,6 +681,8 @@ namespace IPMu
     {
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const int frame = NODE_ARG(0, int);
         const DynamicArrayType* dtype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         DynamicArray* array = new DynamicArray(dtype, 1);
@@ -724,6 +761,8 @@ namespace IPMu
     {
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         int depth = NODE_ARG(1, int);
         StringType::String* root = NODE_ARG_OBJECT(2, StringType::String);
@@ -786,6 +825,8 @@ namespace IPMu
     {
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const DynamicArrayType* dtype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         DynamicArray* array = new DynamicArray(dtype, 1);
         StringType::String* typeName = NODE_ARG_OBJECT(0, StringType::String);
@@ -827,30 +868,40 @@ namespace IPMu
     NODE_IMPLEMENTATION(frameStart, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->rangeStart());
     }
 
     NODE_IMPLEMENTATION(frameEnd, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->rangeEnd() - 1);
     }
 
     NODE_IMPLEMENTATION(narrowedFrameStart, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->narrowedRangeStart());
     }
 
     NODE_IMPLEMENTATION(narrowedFrameEnd, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->narrowedRangeEnd() - 1);
     }
 
     NODE_IMPLEMENTATION(narrowToRange, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->setNarrowedRange(NODE_ARG(0, int), NODE_ARG(1, int) + 1);
         s->askForRedraw(true);
     }
@@ -858,42 +909,56 @@ namespace IPMu
     NODE_IMPLEMENTATION(setRealtime, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->setRealtime(NODE_ARG(0, bool));
     }
 
     NODE_IMPLEMENTATION(isRealtime, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->realtime());
     }
 
     NODE_IMPLEMENTATION(skipped, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->skipped());
     }
 
     NODE_IMPLEMENTATION(isCurrentFrameIncomplete, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->currentStateIsIncomplete());
     }
 
     NODE_IMPLEMENTATION(isCurrentFrameError, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->currentStateIsError());
     }
 
     NODE_IMPLEMENTATION(currentFrameStatus, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->currentFrameState());
     }
 
     NODE_IMPLEMENTATION(setFPS, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         float fps = NODE_ARG(0, float);
         s->setFPS(double(fps));
     }
@@ -901,24 +966,32 @@ namespace IPMu
     NODE_IMPLEMENTATION(setFrameStart, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->setRangeStart(NODE_ARG(0, int));
     }
 
     NODE_IMPLEMENTATION(setFrameEnd, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->setRangeEnd(NODE_ARG(0, int) + 1);
     }
 
     NODE_IMPLEMENTATION(realFPS, float)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(float(s->realFPS()));
     }
 
     NODE_IMPLEMENTATION(fps, float)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(float(s->fps()));
     }
 
@@ -929,6 +1002,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(setInc, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int inc = NODE_ARG(0, int);
         s->setInc(inc);
     }
@@ -936,12 +1011,16 @@ namespace IPMu
     NODE_IMPLEMENTATION(inc, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->inc());
     }
 
     NODE_IMPLEMENTATION(markFrame, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int frame = NODE_ARG(0, int);
         bool mark = NODE_ARG(1, bool);
 
@@ -954,6 +1033,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(isMarked, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int frame = NODE_ARG(0, int);
 
         NODE_RETURN(s->isMarked(frame));
@@ -962,6 +1043,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(markedFrames, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         DynamicArrayType* type = (DynamicArrayType*)NODE_THIS.type();
 
@@ -982,6 +1065,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(setCacheMode, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Session::CachingMode mode = Session::CachingMode(NODE_ARG(0, int));
         s->setCaching(mode);
 
@@ -1011,6 +1096,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(releaseAllCachedImages, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->setCaching(Session::NeverCache);
 
         s->graph().cache().lock();
@@ -1021,6 +1108,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(releaseAllUnusedImages, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         FBCache& cache = s->graph().cache();
         cache.lock();
         cache.freeAllTrash();
@@ -1030,18 +1119,24 @@ namespace IPMu
     NODE_IMPLEMENTATION(setAudioCacheMode, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->setAudioCaching(Session::CachingMode(NODE_ARG(0, int)));
     }
 
     NODE_IMPLEMENTATION(audioCacheMode, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(int(s->audioCachingMode()));
     }
 
     NODE_IMPLEMENTATION(cacheMode, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(int(s->cachingMode()));
     }
 
@@ -1050,6 +1145,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(setCacheOutsideRegion, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Session::CachingMode mode = s->cachingMode();
         s->setCaching(Session::NeverCache);
 
@@ -1061,13 +1158,19 @@ namespace IPMu
 
     NODE_IMPLEMENTATION(isCaching, bool)
     {
-        bool b = Session::currentSession()->isCaching();
+        Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+        bool b = s->isCaching();
         NODE_RETURN(b);
     }
 
     NODE_IMPLEMENTATION(isBuffering, bool)
     {
-        bool b = Session::currentSession()->isBuffering();
+        Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+        bool b = s->isBuffering();
         NODE_RETURN(b);
     }
 
@@ -1122,6 +1225,8 @@ namespace IPMu
     {
         Process* p = NODE_THREAD.process();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const Class* ttype = (const Class*)NODE_THIS.type();
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(ttype->fieldType(1));
 
@@ -1149,9 +1254,21 @@ namespace IPMu
         NODE_RETURN(tuple);
     }
 
-    NODE_IMPLEMENTATION(fullScreenMode, void) { Session::currentSession()->fullScreenMode(NODE_ARG(0, bool)); }
+    NODE_IMPLEMENTATION(fullScreenMode, void)
+    {
+        Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+        s->fullScreenMode(NODE_ARG(0, bool));
+    }
 
-    NODE_IMPLEMENTATION(isFullScreen, bool) { NODE_RETURN(Session::currentSession()->isFullScreen()); }
+    NODE_IMPLEMENTATION(isFullScreen, bool)
+    {
+        Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
+        NODE_RETURN(s->isFullScreen());
+    }
 
     struct FrameBufferFinder
     {
@@ -1177,6 +1294,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(getCurrentImageSize, Mu::Vector2f)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Vector2f v;
 
         FrameBufferFinder finder;
@@ -1217,6 +1336,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const DynamicArrayType* atype = reinterpret_cast<const DynamicArrayType*>(NODE_THIS.type());
         const StringType* stype = c->stringType();
         const StringType::String* tname = NODE_ARG_OBJECT(0, StringType::String);
@@ -1242,6 +1363,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* tname = NODE_ARG_OBJECT(0, StringType::String);
         const DynamicArrayType* atype = reinterpret_cast<const DynamicArrayType*>(NODE_THIS.type());
         const StringType* stype = c->stringType();
@@ -1265,6 +1388,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(event2image, Mu::Vector2f)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         Vector2f inp = NODE_ARG(1, Vector2f);
         bool normalize = NODE_ARG(2, bool);
@@ -1486,6 +1611,8 @@ namespace IPMu
         Vector2f inp = NODE_ARG(0, Vector2f);
         bool strict = NODE_ARG(1, bool);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Box2f vp = session->renderer()->viewport();
         float x = (inp[0] - vp.min.x) / (vp.size().x - 1.0) * 2.0 - 1.0;
         float y = (inp[1] - vp.min.y) / (vp.size().y - 1.0) * 2.0 - 1.0;
@@ -1601,6 +1728,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(image2event, Mu::Vector2f)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         Vector2f inp = NODE_ARG(1, Vector2f);
         bool normalize = NODE_ARG(2, bool);
@@ -1678,6 +1807,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(event2camera, Mu::Vector2f)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         Vector2f inp = NODE_ARG(1, Vector2f);
         float x = inp[0];
@@ -1732,6 +1863,8 @@ namespace IPMu
         // this doesn't matter one bit.
         //
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Vector2f inp = NODE_ARG(0, Vector2f);
         float x = inp[0];
         float y = inp[1];
@@ -1763,6 +1896,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType* stype = c->stringType();
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         const Class* rtype = static_cast<const Class*>(atype->elementType());
@@ -1936,6 +2071,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType* stype = c->stringType();
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         const int frame = NODE_ARG(0, int);
@@ -1966,6 +2103,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType* stype = c->stringType();
         const DynamicArrayType* atype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         const Class* rtype = static_cast<const Class*>(atype->elementType());
@@ -2088,6 +2227,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Box2f vp = s->renderer()->viewport();
         const DynamicArrayType* atype = reinterpret_cast<const DynamicArrayType*>(NODE_THIS.type());
         const Class* ttype = static_cast<const Class*>(atype->elementType());
@@ -2122,6 +2263,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Box2f vp = s->renderer()->viewport();
         const DynamicArrayType* atype = reinterpret_cast<const DynamicArrayType*>(NODE_THIS.type());
         const Class* ttype = static_cast<const Class*>(atype->elementType());
@@ -2160,6 +2303,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Box2f vp = s->renderer()->viewport();
         const DynamicArrayType* atype = reinterpret_cast<const DynamicArrayType*>(NODE_THIS.type());
         const Class* ttype = static_cast<const Class*>(atype->elementType());
@@ -2200,6 +2345,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(sessionFileName, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         const StringType* t = static_cast<const StringType*>(NODE_THIS.type());
         NODE_RETURN(t->allocate(s->fileName()));
@@ -2248,6 +2395,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(readProfile, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* filename = NODE_ARG_OBJECT(0, StringType::String);
         const StringType::String* nodename = NODE_ARG_OBJECT(1, StringType::String);
         const bool usePath = NODE_ARG(2, bool);
@@ -2298,6 +2447,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(writeProfile, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* filename = NODE_ARG_OBJECT(0, StringType::String);
         const StringType::String* nodename = NODE_ARG_OBJECT(1, StringType::String);
         const StringType::String* comments = NODE_ARG_OBJECT(2, StringType::String);
@@ -2342,6 +2493,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(saveSession, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         bool ascopy = NODE_ARG(1, bool);
         bool compressed = NODE_ARG(2, bool);
@@ -2370,6 +2523,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(writeNodeDefinition, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* typeName = NODE_ARG_OBJECT(0, StringType::String);
         const StringType::String* fileName = NODE_ARG_OBJECT(1, StringType::String);
         const NodeManager* nodeManager = s->graph().nodeManager();
@@ -2406,6 +2561,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(writeAllNodeDefinitions, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* fileName = NODE_ARG_OBJECT(0, StringType::String);
         const NodeManager* nodeManager = s->graph().nodeManager();
         bool inlineSource = NODE_ARG(1, bool);
@@ -2430,6 +2587,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const DynamicArrayType* type = (const DynamicArrayType*)NODE_THIS.type();
         DynamicArray* array = new DynamicArray(type, 1);
         const StringType* stype = c->stringType();
@@ -2459,6 +2618,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(updateNodeDefinition, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* nodeType = NODE_ARG_OBJECT(0, StringType::String);
         NodeManager* nodeManager = IPCore::App()->nodeManager();
         const NodeDefinition* def = nodeManager->definition(nodeType->c_str());
@@ -2494,6 +2655,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(clearSession, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         IPMu::RemoteRvCommand remoteRvCommand(s, "clearSession");
 
@@ -2504,6 +2667,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(newSession, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         DynamicArray* newValues = NODE_ARG_OBJECT(0, DynamicArray);
@@ -2575,6 +2740,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         bool allowResize = NODE_ARG(2, bool);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         Session::PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -2620,7 +2787,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         int index = NODE_ARG(2, int);
         Session* session = Session::currentSession();
-
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Session::PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
 
@@ -2700,6 +2868,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         bool allowResize = NODE_ARG(2, bool);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -2745,6 +2915,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         int index = NODE_ARG(2, int);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         Session::PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -2825,6 +2997,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         bool allowResize = NODE_ARG(2, bool);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         Session::PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -2869,6 +3043,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         int index = NODE_ARG(2, int);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         Session::PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -2948,6 +3124,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         bool allowResize = NODE_ARG(2, bool);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         Session::PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -2992,6 +3170,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         int index = NODE_ARG(2, int);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         Session::PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -3072,6 +3252,8 @@ namespace IPMu
         DynamicArray* newValues = NODE_ARG_OBJECT(1, DynamicArray);
         bool allowResize = NODE_ARG(2, bool);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -3141,6 +3323,8 @@ namespace IPMu
         DynamicArray* newValues0 = NODE_ARG_OBJECT(1, DynamicArray);
         int index = NODE_ARG(2, int);
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         Session::PropertyVector props;
         getProperty(props, NODE_THREAD, NODE_THIS, name);
@@ -3198,6 +3382,8 @@ namespace IPMu
     {
         Process* p = NODE_THREAD.process();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int filter = NODE_ARG(0, int);
 
         if (filter != GL_LINEAR && filter != GL_NEAREST)
@@ -3214,12 +3400,16 @@ namespace IPMu
     NODE_IMPLEMENTATION(getFiltering, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(s->renderer()->filterType());
     }
 
     NODE_IMPLEMENTATION(viewSize, Vector2f)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Vector2f v = {static_cast<float>(s->eventVideoDevice()->width()), static_cast<float>(s->eventVideoDevice()->height())};
         NODE_RETURN(v);
     }
@@ -3229,6 +3419,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType* stype = c->stringType();
 
         const char* n = "";
@@ -3267,6 +3459,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const Class* stype = c->stringType();
         const StringType::String* method = NODE_ARG_OBJECT(0, StringType::String);
 
@@ -3309,6 +3503,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(setRendererType, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
 
         if (!name)
@@ -3324,6 +3520,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
 
         StringType::String* n = c->stringType()->allocate(s->renderer()->name());
 
@@ -3333,6 +3531,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(setSessionType, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         int type = NODE_ARG(0, int);
         s->setSessionType((Session::SessionType)type);
     }
@@ -3340,12 +3540,16 @@ namespace IPMu
     NODE_IMPLEMENTATION(getSessionType, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         NODE_RETURN(int(s->getSessionType()));
     }
 
     NODE_IMPLEMENTATION(setHardwareStereoMode, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         bool on = NODE_ARG(0, bool);
 
         if (on)
@@ -3361,6 +3565,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(scrubAudio, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         bool on = NODE_ARG(0, bool);
         float duration = NODE_ARG(1, float);
         int count = NODE_ARG(2, int);
@@ -3537,6 +3743,8 @@ namespace IPMu
     {
         Process* p = NODE_THREAD.process();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         int type = NODE_ARG(1, int);
         int width = NODE_ARG(2, int);
@@ -3548,6 +3756,8 @@ namespace IPMu
     {
         Process* p = NODE_THREAD.process();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         int type = NODE_ARG(1, int);
         ClassInstance* dims = NODE_ARG_OBJECT(2, ClassInstance);
@@ -3560,6 +3770,8 @@ namespace IPMu
     {
         Process* p = NODE_THREAD.process();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
 
         if (!name)
@@ -3689,6 +3901,8 @@ namespace IPMu
 
         Session::PropertyVector props;
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         std::string newName = session->nextUIName(name->c_str());
 
         return stype->allocate(newName);
@@ -3705,6 +3919,8 @@ namespace IPMu
 
         Session::PropertyVector props;
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         session->findProperty(props, name->c_str());
         NODE_RETURN(!props.empty());
     }
@@ -3714,6 +3930,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Mu::StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         const DynamicArrayType* type = (const DynamicArrayType*)NODE_THIS.type();
         DynamicArray* array = new DynamicArray(type, 1);
@@ -3795,6 +4013,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const DynamicArrayType* type = (const DynamicArrayType*)NODE_THIS.type();
         DynamicArray* array = new DynamicArray(type, 1);
         const StringType* stype = c->stringType();
@@ -3817,6 +4037,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* node = NODE_ARG_OBJECT(0, StringType::String);
         const StringType* stype = c->stringType();
         StringType::String* type = 0;
@@ -3842,6 +4064,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(deleteNode, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
 
         if (!name)
@@ -3865,18 +4089,18 @@ namespace IPMu
     NODE_IMPLEMENTATION(sendInternalEvent, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         StringType::String* contents = NODE_ARG_OBJECT(1, StringType::String);
         StringType::String* sender = NODE_ARG_OBJECT(2, StringType::String);
-        const StringType* stype = static_cast<const StringType*>(name->type());
 
         if (!name)
-        {
             throwBadArgumentException(NODE_THIS, NODE_THREAD, "no event name specified");
-        }
 
         string r = s->userGenericEvent(name->c_str(), contents ? contents->c_str() : "", sender ? sender->c_str() : "");
 
+        const StringType* stype = static_cast<const StringType*>(name->type());
         NODE_RETURN(stype->allocate(r));
     }
 
@@ -3885,6 +4109,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(setFilterLiveReviewEvents, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         bool shouldFilterEvents = NODE_ARG(0, bool);
 
         if (s && shouldFilterEvents)
@@ -3943,6 +4169,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(nextViewNode, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
 
@@ -3957,6 +4185,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(previousViewNode, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
 
@@ -3971,6 +4201,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(setViewNode, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
 
         if (!name)
@@ -3997,6 +4229,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(viewNodes, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         const DynamicArrayType* type = (const DynamicArrayType*)NODE_THIS.type();
@@ -4018,6 +4252,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(viewNode, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
 
@@ -4040,6 +4276,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(nodeConnections, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         const TupleType* type = (const TupleType*)NODE_THIS.type();
@@ -4142,6 +4380,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(nodesInGroup, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         const TupleType* type = (const TupleType*)NODE_THIS.type();
@@ -4199,6 +4439,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(nodeGroup, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         const TupleType* type = (const TupleType*)NODE_THIS.type();
@@ -4223,6 +4465,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(nodeGroupRoot, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         const TupleType* type = (const TupleType*)NODE_THIS.type();
@@ -4251,6 +4495,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(nodeExists, bool)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
@@ -4262,6 +4508,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(nodeImageGeometry, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
@@ -4308,6 +4556,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(nodeRangeInfo, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
@@ -4354,6 +4604,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(newNode, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         StringType::String* type = NODE_ARG_OBJECT(0, StringType::String);
@@ -4386,6 +4638,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(setNodeInputs, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
@@ -4450,6 +4704,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(testNodeInputs, Pointer)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
@@ -4510,6 +4766,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(flushCachedNode, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         Process* p = NODE_THREAD.process();
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
@@ -4616,6 +4874,8 @@ namespace IPMu
     {
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const DynamicArrayType* dtype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         DynamicArray* array = new DynamicArray(dtype, 1);
         const Class* itype = static_cast<const Class*>(dtype->elementType());
@@ -4702,6 +4962,8 @@ namespace IPMu
     {
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const DynamicArrayType* dtype = static_cast<const DynamicArrayType*>(NODE_THIS.type());
         DynamicArray* array = new DynamicArray(dtype, 1);
         const Class* itype = static_cast<const Class*>(dtype->elementType());
@@ -4761,6 +5023,8 @@ namespace IPMu
     {
         MuLangContext* c = TwkApp::muContext();
         Session* session = Session::currentSession();
+        if (!session)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const Class* vtype = static_cast<const Class*>(NODE_THIS.type());
         const StringType* stype = c->stringType();
 
@@ -4875,6 +5139,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(refreshOutputVideoDevice, void)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         auto outputDevice = s->outputVideoDevice();
 
         s->setOutputVideoDevice(outputDevice);
@@ -4883,6 +5149,8 @@ namespace IPMu
     NODE_IMPLEMENTATION(audioTextureID, int)
     {
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         ImageRenderer* renderer = s->renderer();
 
         IPCore::RenderQuery::TaggedTextureImagesMap taggedTextures;
@@ -4900,6 +5168,8 @@ namespace IPMu
     {
         Session::NodeVector nodes;
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         s->findNodesByTypeName(nodes, "RVSoundTrack");
 
         float complete = 0.0;
@@ -4951,6 +5221,8 @@ namespace IPMu
         Process* p = NODE_THREAD.process();
         MuLangContext* c = TwkApp::muContext();
         Session* s = Session::currentSession();
+        if (!s)
+            throwBadArgumentException(NODE_THIS, NODE_THREAD, "no current session");
         const StringType::String* name = NODE_ARG_OBJECT(0, StringType::String);
         const StringType::String* media = NODE_ARG_OBJECT(1, StringType::String);
         const MovieInfo* info = 0;


### PR DESCRIPTION
### Linked issues

N/A

### Summarize your change.

A collection of crash fixes and safety improvements found during internal testing and AddressSanitizer analysis. These are independent fixes grouped together for convenience.

### Describe the reason for the change.

1. **GL version error on startup**: `SessionIPNode` queried GL state during construction before the correct context was current, returning wrong capabilities or crashing in multi-window setups.

2. **Dangling preferences window pointer**: Non-owning raw pointer to the preferences window could dangle after the window was destroyed. Replaced with `QPointer`.

3. **Dangling global settings pointer**: `PackageManager` did not null its global settings pointer after deletion.

4. **Uninitialized GL IDs in TextureDescription**: `id` and `bufferId` were not initialized, so `gcTextures()` could call `glDeleteBuffers` on garbage values, destroying unrelated live GL buffers.

5. **Null order properties in PaintIPNode**: Missing null check for order properties.

6. **Null session pointer in command modules**: ~190 command entry points dereferenced `Session::currentSession()` without checking for null, risking crashes during teardown or before a session is fully initialized.

7. **Dangling session pointer after destruction**: `Session::~Session()` did not null `m_currentSession` when the active session was destroyed, leaving a dangling pointer. Also removes a duplicate `m_currentSession` declaration from `RvSession.h` that shadowed the base class member.

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9. Several of these issues were identified with AddressSanitizer.

### Add a list of changes, and note any that might need special attention during the review.

- `SessionIPNode.cpp`: Defer GL queries to first render pass.
- `RvApplication.h`: Use `QPointer` for preferences window reference.
- `PackageManager.cpp`: Null global settings pointer after deletion.
- `ImageRenderer.h`: Zero-initialize `id` and `bufferId` in `TextureDescription`.
- `PaintIPNode.cpp`: Add null check for order properties.
- `CommandsModule.cpp`, `MuUICommands.cpp`, `PyUICommands.cpp`, `IPMu/CommandsModule.cpp`: Add null session checks to ~190 command entry points. **This is the largest change** and touches many functions.
- `Session.cpp`, `RvSession.h`: Null `m_currentSession` in destructor; remove duplicate declaration.

### If possible, provide screenshots.

N/A