### PR TITLE
ci: point pinned Rocky 9.7 repos at the vault archive

### DIFF
--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -50,12 +50,22 @@ runs:
       run: df -h /
       shell: bash
 
-    # Rocky 9.8 dropped mesa-libOSMesa{,-devel} from the CRB repo. Pin all
-    # subsequent dnf calls in this container to the 9.7 minor release until
-    # OpenRV migrates off OSMesa. Remove this step once that's done.
-    - name: Pin Rocky 9 to 9.7 minor release
+    # Rocky 9.8 dropped mesa-libOSMesa{,-devel} from the CRB repo (Mesa upstream
+    # deprecated OSMesa in favor of llvmpipe via EGL). Pin all subsequent dnf
+    # calls in this container to the 9.7 minor release until OpenRV migrates off
+    # OSMesa. 9.7 is now a superseded minor, so the production CDN no longer
+    # serves it (the default 'extras' repo 404s); point the pinned repos at the
+    # durable vault archive (dl.rockylinux.org/vault) instead. Remove this whole
+    # step once OpenRV no longer needs OSMesa.
+    - name: Pin Rocky 9 to 9.7 minor release (vault)
       if: ${{ inputs.rocky-version == '9' }}
-      run: echo "9.7" > /etc/dnf/vars/releasever
+      run: |
+        echo "9.7" > /etc/dnf/vars/releasever
+        sed -i \
+          -e 's|^mirrorlist=|#mirrorlist=|g' \
+          -e 's|^#\?baseurl=https\?://dl.rockylinux.org/\$contentdir/|baseurl=https://dl.rockylinux.org/vault/rocky/|g' \
+          /etc/yum.repos.d/[Rr]ocky*.repo
+        dnf clean all
       shell: bash
 
     - name: Install system dependencies


### PR DESCRIPTION
### ci: point pinned Rocky 9.7 repos at the vault archive

### Linked issues
none

### Summarize your change and Describe the reason for the change
Rocky 9.7 is now a superseded minor, so the ctrliq production CDN no longer serves it: the default-enabled 'extras' repo (which provides epel-release, the first package installed) 404s on every mirror, failing all dnf calls and breaking the Rocky 9 CI jobs.

Keep the 9.7 pin from #1285 (so mesa-libOSMesa{,-devel} and their runtime deps still resolve as a consistent 9.7 stack) but rewrite the Rocky repo files to use the durable vault archive (dl.rockylinux.org/vault) and disable the dead mirrorlist. Verified BaseOS, AppStream, CRB and extras all resolve 200 from vault for 9.7. 