### PR TITLE
feat: SG-43687: Automatic color profile setup with rvio parity

### DIFF
--- a/src/lib/app/RvCommon/CGDesktopVideoDevice.cpp
+++ b/src/lib/app/RvCommon/CGDesktopVideoDevice.cpp
@@ -458,31 +458,7 @@ namespace Rv
 
     TwkApp::VideoDevice::ColorProfile CGDesktopVideoDevice::colorProfile() const
     {
-        //
-        //  Get the display's color sync profile
-        //
-
-        if (ColorSyncProfileRef iccRef = ColorSyncProfileCreateWithDisplayID(m_cgScreen))
-        {
-            m_colorProfile.type = ICCProfile;
-
-            CFStringRef desc = ColorSyncProfileCopyDescriptionString(iccRef);
-            CFIndex n = CFStringGetLength(desc);
-            vector<char> buffer(n * 4 + 1);
-            CFStringGetCString(desc, &buffer.front(), buffer.size(), kCFStringEncodingUTF8);
-            m_colorProfile.description = &buffer.front();
-
-            CFURLRef url = ColorSyncProfileGetURL(iccRef, NULL);
-            CFStringRef urlstr = CFURLGetString(url);
-            buffer.resize(CFStringGetLength(urlstr) * 4 + 1);
-            CFStringGetCString(urlstr, &buffer.front(), buffer.size(), kCFStringEncodingUTF8);
-
-            m_colorProfile.url = &buffer.front();
-        }
-        else
-        {
-            m_colorProfile = ColorProfile();
-        }
+        m_colorProfile = colorProfileForDisplay(m_cgScreen);
 
         return m_colorProfile;
     }

--- a/src/lib/app/RvCommon/CGDesktopVideoDeviceArm.cpp
+++ b/src/lib/app/RvCommon/CGDesktopVideoDeviceArm.cpp
@@ -259,31 +259,7 @@ namespace Rv
 
     TwkApp::VideoDevice::ColorProfile CGDesktopVideoDeviceArm::colorProfile() const
     {
-        //
-        //  Get the display's color sync profile
-        //
-
-        if (ColorSyncProfileRef iccRef = ColorSyncProfileCreateWithDisplayID(m_display.cgScreen))
-        {
-            m_colorProfile.type = ICCProfile;
-
-            CFStringRef desc = ColorSyncProfileCopyDescriptionString(iccRef);
-            CFIndex n = CFStringGetLength(desc);
-            vector<char> buffer(n * 4 + 1);
-            CFStringGetCString(desc, &buffer.front(), buffer.size(), kCFStringEncodingUTF8);
-            m_colorProfile.description = &buffer.front();
-
-            CFURLRef url = ColorSyncProfileGetURL(iccRef, NULL);
-            CFStringRef urlstr = CFURLGetString(url);
-            buffer.resize(CFStringGetLength(urlstr) * 4 + 1);
-            CFStringGetCString(urlstr, &buffer.front(), buffer.size(), kCFStringEncodingUTF8);
-
-            m_colorProfile.url = &buffer.front();
-        }
-        else
-        {
-            m_colorProfile = ColorProfile();
-        }
+        m_colorProfile = colorProfileForDisplay(m_display.cgScreen);
 
         return m_colorProfile;
     }

--- a/src/lib/app/RvCommon/CMakeLists.txt
+++ b/src/lib/app/RvCommon/CMakeLists.txt
@@ -407,10 +407,11 @@ TARGET_LINK_LIBRARIES(
 )
 
 IF(RV_TARGET_DARWIN)
+  # ApplicationServices provides ColorSync, used by DesktopVideoDevice::colorProfileForDisplay().
   TARGET_LINK_LIBRARIES(
     ${_target}
     PUBLIC TwkGLFCoreGraphics
-    PRIVATE "-framework CoreVideo"
+    PRIVATE "-framework CoreVideo" "-framework ApplicationServices"
   )
 ENDIF()
 

--- a/src/lib/app/RvCommon/DesktopVideoDevice.cpp
+++ b/src/lib/app/RvCommon/DesktopVideoDevice.cpp
@@ -13,6 +13,11 @@
 #include <lcms2.h>
 #endif
 
+#ifdef PLATFORM_DARWIN
+#include <ApplicationServices/ApplicationServices.h>
+#include <ColorSync/ColorSync.h>
+#endif
+
 #include <RvCommon/DesktopVideoDevice.h>
 #include <TwkGLF/GLPipeline.h>
 #include <TwkGLF/GLRenderPrimitives.h>
@@ -906,6 +911,51 @@ namespace Rv
 
             delete path;
             ReleaseDC(hwnd, hdc);
+        }
+        else
+        {
+            m_colorProfile = ColorProfile();
+        }
+
+        return m_colorProfile;
+    }
+#endif
+
+#ifdef PLATFORM_DARWIN
+    TwkApp::VideoDevice::ColorProfile DesktopVideoDevice::colorProfile() const
+    {
+        //
+        //  Get the display's color sync profile
+        //
+
+        CGDirectDisplayID displayIDs[20];
+        uint32_t displayCount = 0;
+        CGGetOnlineDisplayList(20, displayIDs, &displayCount);
+
+        if (m_screen < 0 || m_screen >= static_cast<int>(displayCount))
+        {
+            m_colorProfile = ColorProfile();
+            return m_colorProfile;
+        }
+
+        CGDirectDisplayID cgScreen = displayIDs[m_screen];
+
+        if (ColorSyncProfileRef iccRef = ColorSyncProfileCreateWithDisplayID(cgScreen))
+        {
+            m_colorProfile.type = ICCProfile;
+
+            CFStringRef desc = ColorSyncProfileCopyDescriptionString(iccRef);
+            CFIndex n = CFStringGetLength(desc);
+            std::vector<char> buffer(n * 4 + 1);
+            CFStringGetCString(desc, &buffer.front(), buffer.size(), kCFStringEncodingUTF8);
+            m_colorProfile.description = &buffer.front();
+
+            CFURLRef url = ColorSyncProfileGetURL(iccRef, NULL);
+            CFStringRef urlstr = CFURLGetString(url);
+            buffer.resize(CFStringGetLength(urlstr) * 4 + 1);
+            CFStringGetCString(urlstr, &buffer.front(), buffer.size(), kCFStringEncodingUTF8);
+
+            m_colorProfile.url = &buffer.front();
         }
         else
         {

--- a/src/lib/app/RvCommon/DesktopVideoDevice.cpp
+++ b/src/lib/app/RvCommon/DesktopVideoDevice.cpp
@@ -13,6 +13,15 @@
 #include <lcms2.h>
 #endif
 
+#ifdef PLATFORM_DARWIN
+#include <ApplicationServices/ApplicationServices.h>
+#include <ColorSync/ColorSync.h>
+#include <array>
+#include <cmath>
+#include <string>
+#include <vector>
+#endif
+
 #include <RvCommon/DesktopVideoDevice.h>
 #include <TwkGLF/GLPipeline.h>
 #include <TwkGLF/GLRenderPrimitives.h>
@@ -911,6 +920,154 @@ namespace Rv
         {
             m_colorProfile = ColorProfile();
         }
+
+        return m_colorProfile;
+    }
+#endif
+
+#ifdef PLATFORM_DARWIN
+    namespace
+    {
+
+        //
+        //  RAII wrapper for CoreFoundation objects returned by Create/Copy
+        //  functions, which the caller owns and must release.
+        //
+        template <typename T> class CFRef
+        {
+        public:
+            explicit CFRef(T ref = nullptr)
+                : m_ref(ref)
+            {
+            }
+
+            ~CFRef()
+            {
+                if (m_ref)
+                    CFRelease(m_ref);
+            }
+
+            CFRef(const CFRef&) = delete;
+            CFRef& operator=(const CFRef&) = delete;
+
+            T get() const { return m_ref; }
+
+            explicit operator bool() const { return m_ref != nullptr; }
+
+        private:
+            T m_ref;
+        };
+
+        //
+        //  Copies a CFString into a std::string. Returns an empty string if
+        //  the input is null or cannot be converted, so callers do not have to
+        //  null check every ColorSync getter individually.
+        //
+        std::string stringFromCFString(CFStringRef string)
+        {
+            if (!string)
+                return std::string();
+
+            //  CFStringGetLength() counts UTF-16 code units and a UTF-8
+            //  encoding needs at most 4 bytes per code unit, plus the
+            //  terminator.
+            constexpr CFIndex kMaxUTF8BytesPerCodeUnit = 4;
+            std::vector<char> buffer(CFStringGetLength(string) * kMaxUTF8BytesPerCodeUnit + 1, '\0');
+
+            if (!CFStringGetCString(string, buffer.data(), buffer.size(), kCFStringEncodingUTF8))
+                return std::string();
+
+            return std::string(buffer.data());
+        }
+
+        //
+        //  Resolves the CGDirectDisplayID backing a Qt screen.
+        //
+        //  Qt screen indices and the CoreGraphics online display list are not
+        //  guaranteed to be in the same order, so the screen is matched by its
+        //  position in the global desktop coordinate space, which both APIs
+        //  express in top-left-origin points.
+        //
+        bool cgDisplayIDForQtScreen(const QScreen* screen, CGDirectDisplayID& displayID)
+        {
+            if (!screen)
+                return false;
+
+            constexpr uint32_t kMaxDisplays = 64;
+            std::array<CGDirectDisplayID, kMaxDisplays> displayIDs{};
+            uint32_t displayCount = 0;
+
+            if (CGGetOnlineDisplayList(kMaxDisplays, displayIDs.data(), &displayCount) != kCGErrorSuccess)
+                return false;
+
+            const QRect geometry = screen->geometry();
+
+            for (uint32_t index = 0; index < displayCount; index++)
+            {
+                const CGRect bounds = CGDisplayBounds(displayIDs[index]);
+
+                if (static_cast<int>(std::lround(bounds.origin.x)) == geometry.x()
+                    && static_cast<int>(std::lround(bounds.origin.y)) == geometry.y())
+                {
+                    displayID = displayIDs[index];
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+    } // namespace
+
+    TwkApp::VideoDevice::ColorProfile DesktopVideoDevice::colorProfileForDisplay(CGDirectDisplayID displayID)
+    {
+        //
+        //  Get the display's color sync profile
+        //
+
+        const CFRef<ColorSyncProfileRef> iccRef(ColorSyncProfileCreateWithDisplayID(displayID));
+
+        if (!iccRef)
+            return ColorProfile();
+
+        ColorProfile profile;
+        profile.type = ICCProfile;
+
+        const CFRef<CFStringRef> description(ColorSyncProfileCopyDescriptionString(iccRef.get()));
+        profile.description = stringFromCFString(description.get());
+
+        //
+        //  ColorSyncProfileGetURL() follows the Get rule: the URL belongs to
+        //  the profile and must not be released. It is null for a profile
+        //  which has no backing file.
+        //
+        if (CFURLRef url = ColorSyncProfileGetURL(iccRef.get(), nullptr))
+        {
+            profile.url = stringFromCFString(CFURLGetString(url));
+        }
+
+        return profile;
+    }
+
+    TwkApp::VideoDevice::ColorProfile DesktopVideoDevice::colorProfile() const
+    {
+        const QList<QScreen*> screens = QGuiApplication::screens();
+
+        if (m_screen < 0 || m_screen >= screens.size())
+        {
+            m_colorProfile = ColorProfile();
+            return m_colorProfile;
+        }
+
+        CGDirectDisplayID displayID = 0;
+
+        if (!cgDisplayIDForQtScreen(screens[m_screen], displayID))
+        {
+            m_colorProfile = ColorProfile();
+            return m_colorProfile;
+        }
+
+        m_colorProfile = colorProfileForDisplay(displayID);
 
         return m_colorProfile;
     }

--- a/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
@@ -247,7 +247,7 @@ namespace Rv
     private:
         void addDataFormatAtDepth(size_t depth, DesktopStereoMode m);
 
-#ifdef PLATFORM_WINDOWS
+#if defined(PLATFORM_WINDOWS) || defined(PLATFORM_DARWIN)
         virtual ColorProfile colorProfile() const;
 #endif
 

--- a/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
@@ -20,6 +20,10 @@
 #include <QOpenGLWidget>
 #include <QGuiApplication>
 
+#ifdef PLATFORM_DARWIN
+#include <CoreGraphics/CGDirectDisplay.h>
+#endif
+
 namespace Rv
 {
 
@@ -244,10 +248,19 @@ namespace Rv
 
         bool maybeFramePacked(const TwkApp::VideoDevice::VideoFormat&) const;
 
+#ifdef PLATFORM_DARWIN
+        //
+        //  Builds a ColorProfile from a CoreGraphics display's ColorSync
+        //  profile. Shared by this class and the CoreGraphics device
+        //  subclasses, which each resolve their own CGDirectDisplayID.
+        //
+        static ColorProfile colorProfileForDisplay(CGDirectDisplayID displayID);
+#endif
+
     private:
         void addDataFormatAtDepth(size_t depth, DesktopStereoMode m);
 
-#ifdef PLATFORM_WINDOWS
+#if defined(PLATFORM_WINDOWS) || defined(PLATFORM_DARWIN)
         virtual ColorProfile colorProfile() const;
 #endif
 

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -229,6 +229,8 @@ namespace IPCore
 
         updateContext();
         updateFunction();
+
+        m_initialized = true;
     }
 
     void OCIOIPNode::updateContext()
@@ -528,7 +530,10 @@ namespace IPCore
         boost::hash<string> string_hash;
         string inName = stringProp("ocio.inColorSpace", m_state->linear);
 
-        if (inName.empty())
+        // synlinearize/syndisplay build their pipeline from file/URL
+        // transforms, so an empty input color space is valid for those modes.
+        const bool needsInColorSpace = ociofunction != "synlinearize" && ociofunction != "syndisplay";
+        if (inName.empty() && needsInColorSpace)
             return;
 
         try
@@ -612,6 +617,8 @@ namespace IPCore
                 string inTransformURL = stringProp("inTransform.url", "");
                 if (inTransformURL.empty() && (!m_inTransformData || m_inTransformData->size() == 0))
                 {
+                    if (!m_initialized)
+                        return;
                     TWK_THROW_EXC_STREAM("Either inTransform.url or inTransform.data property "
                                          "needs to be set for synlinearize function");
                 }
@@ -657,6 +664,8 @@ namespace IPCore
                 const string outTransformURL = stringProp("outTransform.url", "");
                 if (outTransformURL.empty())
                 {
+                    if (!m_initialized)
+                        return;
                     TWK_THROW_EXC_STREAM("outTransform.url property needs to "
                                          "be set for syndisplay function");
                 }

--- a/src/lib/ip/OCIONodes/OCIOIPNode.cpp
+++ b/src/lib/ip/OCIONodes/OCIOIPNode.cpp
@@ -233,6 +233,8 @@ namespace IPCore
 
         updateContext();
         updateFunction();
+
+        m_initialized = true;
     }
 
     void OCIOIPNode::updateContext()
@@ -519,7 +521,10 @@ namespace IPCore
         boost::hash<string> string_hash;
         string inName = stringProp("ocio.inColorSpace", m_state->linear);
 
-        if (inName.empty())
+        // synlinearize/syndisplay build their pipeline from file/URL
+        // transforms, so an empty input color space is valid for those modes.
+        const bool needsInColorSpace = ociofunction != "synlinearize" && ociofunction != "syndisplay";
+        if (inName.empty() && needsInColorSpace)
             return;
 
         try
@@ -603,6 +608,8 @@ namespace IPCore
                 string inTransformURL = stringProp("inTransform.url", "");
                 if (inTransformURL.empty() && (!m_inTransformData || m_inTransformData->size() == 0))
                 {
+                    if (!m_initialized)
+                        return;
                     TWK_THROW_EXC_STREAM("Either inTransform.url or inTransform.data property "
                                          "needs to be set for synlinearize function");
                 }
@@ -648,6 +655,8 @@ namespace IPCore
                 const string outTransformURL = stringProp("outTransform.url", "");
                 if (outTransformURL.empty())
                 {
+                    if (!m_initialized)
+                        return;
                     TWK_THROW_EXC_STREAM("outTransform.url property needs to "
                                          "be set for syndisplay function");
                 }

--- a/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
+++ b/src/lib/ip/OCIONodes/OCIONodes/OCIOIPNode.h
@@ -72,6 +72,7 @@ namespace IPCore
         std::vector<OCIO3DLUTPtr> m_3DLUTs;
         OCIOState* m_state{nullptr};
         bool m_useRawConfig{false};
+        bool m_initialized{false};
 
         // synlinearize/syndisplay functions
         StringProperty* m_inTransformURL{nullptr};

--- a/src/plugins/rv-packages/color_profile_setup/CMakeLists.txt
+++ b/src/plugins/rv-packages/color_profile_setup/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (C) 2026  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+SET(_target
+    "color_profile_setup"
+)
+
+RV_STAGE(TYPE "RVPKG" TARGET ${_target})

--- a/src/plugins/rv-packages/color_profile_setup/PACKAGE
+++ b/src/plugins/rv-packages/color_profile_setup/PACKAGE
@@ -1,0 +1,46 @@
+package: Color Profile Setup
+author: Autodesk, Inc.
+organization: Autodesk, Inc.
+version: 1.0
+requires: ''
+rv: 4.0
+openrv: 1.0.0
+optional: true
+system: true
+hidden: false
+
+modes:
+  - file: color_profile_setup.py
+    menu: ''
+    shortcut: ''
+    event: ''
+    load: immediate
+
+description: |
+    <p>
+    Automatically inserts the SYNLinearize (source linearization) and
+    SYNDisplay (display color management) OCIO nodes based on embedded ICC
+    color profiles and the display's system profile, replacing the manual,
+    key-bound script that previously had to be run by hand.
+    </p>
+
+    <p>
+    Source media carrying an embedded ICC profile has its
+    RVLinearizePipelineGroup switched to a SYNLinearize node whose
+    inTransform.data is set to the profile blob. Each RVDisplayGroup whose
+    device has a system ICC profile has its display pipeline switched to a
+    SYNDisplay node pointed at that profile.
+    </p>
+
+    <p>
+    For rvio parity, the display transform is baked into the RVOutputGroup(s)
+    at session-write time (RVDisplayGroup is not persisted, and rvio renders
+    through the output group), so an exported session renders identically in
+    rvio.
+    </p>
+
+    <p>
+    The feature is opt-in and self-contained: enable it via the
+    "Automatic Color Profile Setup" checkbox under the package's menu. The
+    setting is stored in the package's own preferences and is off by default.
+    </p>

--- a/src/plugins/rv-packages/color_profile_setup/color_profile_setup.py
+++ b/src/plugins/rv-packages/color_profile_setup/color_profile_setup.py
@@ -1,0 +1,377 @@
+#
+# Copyright (C) 2026  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+from rv import rvtypes, commands
+
+import platform
+import re
+from six.moves.urllib.parse import urlparse
+
+#
+# Per-pipeline-group snapshot of the "pipeline.nodes" value taken just before
+# SYN nodes were inserted, keyed by the pipeline group node name. Used to
+# restore the original pipeline when the feature is disabled.
+#
+DEFAULT_PIPE = {}
+
+#
+# The native RV defaults, used as the restore target when we are reloading a
+# session whose pipeline is already SYN managed (so the persisted SYN pipeline
+# is not mistaken for the user's "default" pipeline).
+#
+DEFAULT_RV_PIPE = {
+    "RVLinearizePipelineGroup": ["RVLinearize", "RVLensWarp"],
+    "RVDisplayPipelineGroup": ["RVDisplayColor"],
+}
+
+# Source data attribute that holds an embedded ICC profile blob.
+ICC_DATA_KEY = "ColorSpace/ICC/Data"
+
+# Self-contained, package-owned preference (off by default). Stored in this
+# package's own QSettings group so the feature needs no entry in RV's
+# Preferences dialog.
+SETTINGS_GROUP = "color_profile_setup"
+SETTINGS_KEY = "enabled"
+
+
+def groupMemberOfType(node, memberType):
+    for n in commands.nodesInGroup(node):
+        if commands.nodeType(n) == memberType:
+            return n
+    return None
+
+
+def normalizeProfileURL(url):
+    #
+    # device.systemProfileURL is a file:// URL. Convert it to a filesystem
+    # path the same way source_setup.py does for ICCDisplayTransform.
+    #
+    path = urlparse(url.replace("%20", " ")).path
+    if "windows" in platform.platform().lower() and re.match("^/.:.*$", path):
+        path = path[1:]
+    return path
+
+
+class ColorProfileSetupMode(rvtypes.MinorMode):
+    """
+    Automatically inserts the SYNLinearize and SYNDisplay OCIO nodes that
+    previously had to be inserted by hand via a key-bound script.
+
+    Source side:
+        When media carries an embedded ICC profile (a data attribute), the
+        source's RVLinearizePipelineGroup is switched to a single SYNLinearize
+        node whose inTransform.data is set to the profile blob. Because the
+        source group is persisted to .rv, this carries over to rvio for free.
+
+    Display side:
+        For each RVDisplayGroup whose device has a system ICC profile, the
+        display pipeline is switched to a single SYNDisplay node whose
+        outTransform.url points at the profile.
+
+    rvio parity:
+        RVDisplayGroup is NOT written to a session file and rvio renders
+        through RVOutputGroup instead. So at session-write time the display
+        SYNDisplay transform is baked into every RVOutputGroup's display
+        pipeline (which IS persisted), then reverted after the write so the
+        interactive graph is left unchanged.
+
+    The feature is opt-in and self-contained: it is controlled by the
+    "Automatic Color Profile Setup" checkbox in this package's own menu,
+    backed by a package-owned preference (off by default). No entry is added
+    to RV's Preferences dialog.
+
+    ORDERING: sort key "source_setup", ordering 20 -- runs after the base
+    source_setup (0) and ocio_source_setup (10).
+    """
+
+    #
+    #   Source side
+    #
+
+    def _iccBlob(self, source):
+        try:
+            medias = commands.getStringProperty("%s.media.movie" % source)
+            media = medias[0] if medias else ""
+            data = commands.sourceDataAttributes(source, media)
+        except Exception:
+            return None
+
+        if not data:
+            return None
+
+        dataDict = dict((name, blob) for (name, blob) in data)
+        blob = dataDict.get(ICC_DATA_KEY)
+        if blob is None:
+            #
+            # Fall back to the first data attribute. This mirrors the original
+            # manually-bound script, which used attrs[0] regardless of name.
+            #
+            blob = data[0][1]
+        if blob is None or len(blob) == 0:
+            return None
+        return blob
+
+    def useSourceSYN(self, source):
+        linPipe = groupMemberOfType(commands.nodeGroup(source), "RVLinearizePipelineGroup")
+        if linPipe is None:
+            return
+
+        blob = self._iccBlob(source)
+        if blob is None:
+            # No embedded ICC profile: leave / restore the default pipeline.
+            self.disableSourceSYN(source)
+            return
+
+        current = commands.getStringProperty(linPipe + ".pipeline.nodes")
+        if linPipe not in DEFAULT_PIPE:
+            if "SYNLinearize" in current:
+                DEFAULT_PIPE[linPipe] = DEFAULT_RV_PIPE["RVLinearizePipelineGroup"]
+            else:
+                DEFAULT_PIPE[linPipe] = current
+
+        # Match the original script: the linearize pipeline becomes just
+        # SYNLinearize.
+        if current != ["SYNLinearize"]:
+            commands.setStringProperty(linPipe + ".pipeline.nodes", ["SYNLinearize"], True)
+
+        syn = groupMemberOfType(linPipe, "SYNLinearize")
+        if syn is not None:
+            commands.setByteProperty(syn + ".inTransform.data", blob, True)
+            print("INFO: SYNLinearize applied to %s" % source)
+        commands.redraw()
+
+    def disableSourceSYN(self, source):
+        linPipe = groupMemberOfType(commands.nodeGroup(source), "RVLinearizePipelineGroup")
+        if linPipe is None or linPipe not in DEFAULT_PIPE:
+            return
+        current = commands.getStringProperty(linPipe + ".pipeline.nodes")
+        if current == DEFAULT_PIPE[linPipe]:
+            return
+        commands.setStringProperty(linPipe + ".pipeline.nodes", DEFAULT_PIPE[linPipe], True)
+        commands.redraw()
+
+    #
+    #   Display side
+    #
+
+    def useDisplaySYN(self, group):
+        url = commands.getStringProperty(group + ".device.systemProfileURL")
+        if not url or url[0] == "":
+            self.disableDisplaySYN(group)
+            return
+
+        dpipe = groupMemberOfType(group, "RVDisplayPipelineGroup")
+        if dpipe is None:
+            return
+
+        path = normalizeProfileURL(url[0])
+        current = commands.getStringProperty(dpipe + ".pipeline.nodes")
+
+        # Already configured with this profile: nothing to do.
+        if current == ["SYNDisplay"]:
+            syn = groupMemberOfType(dpipe, "SYNDisplay")
+            if syn is not None and commands.getStringProperty(syn + ".outTransform.url") == [path]:
+                return
+
+        if dpipe not in DEFAULT_PIPE:
+            if "SYNDisplay" in current:
+                DEFAULT_PIPE[dpipe] = DEFAULT_RV_PIPE["RVDisplayPipelineGroup"]
+            else:
+                DEFAULT_PIPE[dpipe] = current
+
+        if current != ["SYNDisplay"]:
+            commands.setStringProperty(dpipe + ".pipeline.nodes", ["SYNDisplay"], True)
+
+        syn = groupMemberOfType(dpipe, "SYNDisplay")
+        if syn is not None:
+            commands.setStringProperty(syn + ".outTransform.url", [path], True)
+            print("INFO: SYNDisplay applied to %s" % group)
+        commands.redraw()
+
+    def disableDisplaySYN(self, group):
+        dpipe = groupMemberOfType(group, "RVDisplayPipelineGroup")
+        if dpipe is None or dpipe not in DEFAULT_PIPE:
+            return
+        current = commands.getStringProperty(dpipe + ".pipeline.nodes")
+        if current == DEFAULT_PIPE[dpipe]:
+            return
+        commands.setStringProperty(dpipe + ".pipeline.nodes", DEFAULT_PIPE[dpipe], True)
+        commands.redraw()
+
+    #
+    #   Whole-graph helpers
+    #
+
+    def _sources(self):
+        result = []
+        for t in ("RVFileSource", "RVImageSource"):
+            result += commands.nodesOfType(t)
+        return result
+
+    def _applyDisplays(self):
+        for group in commands.nodesOfType("RVDisplayGroup"):
+            self.useDisplaySYN(group)
+
+    def applyAll(self):
+        for source in self._sources():
+            self.useSourceSYN(source)
+        self._applyDisplays()
+
+    def restoreAll(self):
+        for source in self._sources():
+            self.disableSourceSYN(source)
+        for group in commands.nodesOfType("RVDisplayGroup"):
+            self.disableDisplaySYN(group)
+
+    def _currentDisplayProfilePath(self):
+        #
+        # Pick a display profile to bake into the output group(s). Prefer the
+        # first display with a non-empty system profile.
+        #
+        for group in commands.nodesOfType("RVDisplayGroup"):
+            url = commands.getStringProperty(group + ".device.systemProfileURL")
+            if url and url[0] != "":
+                return normalizeProfileURL(url[0])
+        return None
+
+    #
+    #   Event handlers
+    #
+
+    def sourceSetup(self, event):
+        event.reject()  # allow other source-group-complete handlers to run
+        if not self._enabled:
+            return
+        group = event.contents().split(";;")[0]
+        fileSource = groupMemberOfType(group, "RVFileSource")
+        imageSource = groupMemberOfType(group, "RVImageSource")
+        source = fileSource if imageSource is None else imageSource
+        if source is not None:
+            self.useSourceSYN(source)
+        # A source's embedded profile does not drive the display; the display
+        # is configured from its own device system profile.
+        self._applyDisplays()
+
+    def checkForDisplayGroup(self, event):
+        event.reject()
+        if not self._enabled:
+            return
+        try:
+            node = event.contents()
+            if commands.nodeType(node) == "RVDisplayGroup":
+                self.useDisplaySYN(node)
+        except Exception:
+            pass
+
+    def beforeSessionRead(self, event):
+        event.reject()
+        self._readingSession = True
+
+    def afterSessionRead(self, event):
+        event.reject()
+        self._readingSession = False
+        if self._enabled:
+            self._applyDisplays()
+
+    def beforeSessionWrite(self, event):
+        #
+        # rvio parity: bake the display SYNDisplay transform into every output
+        # group so the exported .rv reproduces it under rvio (RVDisplayGroup is
+        # not persisted; RVOutputGroup is, and rvio renders through it).
+        #
+        event.reject()
+        self._bakedOutputGroups = {}
+        if not self._enabled:
+            return
+        path = self._currentDisplayProfilePath()
+        if path is None:
+            return
+        for og in commands.nodesOfType("RVOutputGroup"):
+            dpipe = groupMemberOfType(og, "RVDisplayPipelineGroup")
+            if dpipe is None:
+                continue
+            self._bakedOutputGroups[dpipe] = commands.getStringProperty(dpipe + ".pipeline.nodes")
+            if "SYNDisplay" not in self._bakedOutputGroups[dpipe]:
+                commands.setStringProperty(dpipe + ".pipeline.nodes", ["SYNDisplay"], True)
+            syn = groupMemberOfType(dpipe, "SYNDisplay")
+            if syn is not None:
+                commands.setStringProperty(syn + ".outTransform.url", [path], True)
+                print("INFO: SYNDisplay baked into %s for rvio parity" % og)
+
+    def afterSessionWrite(self, event):
+        #
+        # Revert the output groups to their pre-write state so the parity bake
+        # does not alter the live interactive graph.
+        #
+        event.reject()
+        for dpipe, nodes in self._bakedOutputGroups.items():
+            try:
+                current = commands.getStringProperty(dpipe + ".pipeline.nodes")
+                if current != nodes:
+                    commands.setStringProperty(dpipe + ".pipeline.nodes", nodes, True)
+            except Exception:
+                pass
+        self._bakedOutputGroups = {}
+
+    #
+    #   Menu toggle (self-contained, package-owned preference)
+    #
+
+    def toggleEnabled(self, event):
+        self._enabled = not self._enabled
+        commands.writeSettings(SETTINGS_GROUP, SETTINGS_KEY, self._enabled)
+        if self._enabled:
+            self.applyAll()
+        else:
+            self.restoreAll()
+        commands.redraw()
+
+    def enabledState(self):
+        return commands.CheckedMenuState if self._enabled else commands.UncheckedMenuState
+
+    def _buildMenu(self):
+        return [
+            (
+                "Color",
+                [
+                    (
+                        "Automatic Color Profile Setup",
+                        self.toggleEnabled,
+                        None,
+                        self.enabledState,
+                    )
+                ],
+            )
+        ]
+
+    def __init__(self):
+        rvtypes.MinorMode.__init__(self)
+
+        self._enabled = bool(commands.readSettings(SETTINGS_GROUP, SETTINGS_KEY, False))
+        self._readingSession = False
+        self._bakedOutputGroups = {}
+
+        self.init(
+            "color-profile-setup",
+            None,
+            [
+                ("source-group-complete", self.sourceSetup, "Color and Geometry Management"),
+                ("before-session-read", self.beforeSessionRead, ""),
+                ("after-session-read", self.afterSessionRead, ""),
+                ("graph-new-node", self.checkForDisplayGroup, ""),
+                ("graph-node-inputs-changed", self.checkForDisplayGroup, ""),
+                ("before-session-write", self.beforeSessionWrite, ""),
+                ("before-session-write-copy", self.beforeSessionWrite, ""),
+                ("after-session-write", self.afterSessionWrite, ""),
+                ("after-session-write-copy", self.afterSessionWrite, ""),
+            ],
+            self._buildMenu(),
+            "source_setup",
+            20,
+        )  # "source_setup" key shared with source_setup and ocio_source_setup
+
+
+def createMode():
+    return ColorProfileSetupMode()

--- a/src/plugins/rv-packages/color_profile_setup/color_profile_setup.py
+++ b/src/plugins/rv-packages/color_profile_setup/color_profile_setup.py
@@ -1,0 +1,421 @@
+#
+# Copyright (C) 2026  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+from rv import rvtypes, commands
+
+import platform
+import re
+from six.moves.urllib.parse import urlparse
+
+#
+# Per-pipeline-group snapshot of the "pipeline.nodes" value taken just before
+# SYN nodes were inserted, keyed by the pipeline group node name. Used to
+# restore the original pipeline when the feature is disabled.
+#
+DEFAULT_PIPE = {}
+
+#
+# The native RV defaults, used as the restore target when we are reloading a
+# session whose pipeline is already SYN managed (so the persisted SYN pipeline
+# is not mistaken for the user's "default" pipeline).
+#
+DEFAULT_RV_PIPE = {
+    "RVLinearizePipelineGroup": ["RVLinearize", "RVLensWarp"],
+    "RVDisplayPipelineGroup": ["RVDisplayColor"],
+}
+
+# Source data attribute that holds an embedded ICC profile blob.
+ICC_DATA_KEY = "ColorSpace/ICC/Data"
+
+# Self-contained, package-owned preference (off by default). Stored in this
+# package's own QSettings group so the feature needs no entry in RV's
+# Preferences dialog.
+SETTINGS_GROUP = "color_profile_setup"
+SETTINGS_KEY = "enabled"
+
+
+def groupMemberOfType(node, memberType):
+    for n in commands.nodesInGroup(node):
+        if commands.nodeType(n) == memberType:
+            return n
+    return None
+
+
+def normalizeProfileURL(url):
+    #
+    # device.systemProfileURL is a file:// URL. Convert it to a filesystem
+    # path the same way source_setup.py does for ICCDisplayTransform.
+    #
+    path = urlparse(url.replace("%20", " ")).path
+    if "windows" in platform.platform().lower() and re.match("^/.:.*$", path):
+        path = path[1:]
+    return path
+
+
+class ColorProfileSetupMode(rvtypes.MinorMode):
+    """
+    Automatically inserts the SYNLinearize and SYNDisplay OCIO nodes that
+    previously had to be inserted by hand via a key-bound script.
+
+    Source side:
+        When media carries an embedded ICC profile (a data attribute), the
+        source's RVLinearizePipelineGroup is switched to a single SYNLinearize
+        node whose inTransform.data is set to the profile blob. Because the
+        source group is persisted to .rv, this carries over to rvio for free.
+
+    Display side:
+        For each RVDisplayGroup whose device has a system ICC profile, the
+        display pipeline is switched to a single SYNDisplay node whose
+        outTransform.url points at the profile.
+
+    rvio parity:
+        RVDisplayGroup is NOT written to a session file and rvio renders
+        through RVOutputGroup instead. So at session-write time the display
+        SYNDisplay transform is baked into every RVOutputGroup's display
+        pipeline (which IS persisted), then reverted after the write so the
+        interactive graph is left unchanged.
+
+    The feature is opt-in and self-contained: it is controlled by the
+    "Automatic Color Profile Setup" checkbox in this package's own menu,
+    backed by a package-owned preference (off by default). No entry is added
+    to RV's Preferences dialog.
+
+    ORDERING: sort key "source_setup", ordering 20 -- runs after the base
+    source_setup (0) and ocio_source_setup (10).
+    """
+
+    #
+    #   Source side
+    #
+
+    def _iccBlob(self, source):
+        try:
+            medias = commands.getStringProperty("%s.media.movie" % source)
+            media = medias[0] if medias else ""
+            data = commands.sourceDataAttributes(source, media)
+        except Exception as exc:
+            print("WARNING: could not read data attributes of %s: %s" % (source, exc))
+            return None
+
+        if not data:
+            return None
+
+        #
+        # Only accept the ICC profile attribute. sourceDataAttributes() returns
+        # every binary attribute on the framebuffer, so matching on the name is
+        # what keeps an unrelated blob from being handed to OCIO as a profile.
+        #
+        blob = dict(data).get(ICC_DATA_KEY)
+
+        if blob is None or len(blob) == 0:
+            return None
+        return blob
+
+    def useSourceSYN(self, source):
+        linPipe = groupMemberOfType(commands.nodeGroup(source), "RVLinearizePipelineGroup")
+        if linPipe is None:
+            return
+
+        blob = self._iccBlob(source)
+        if blob is None:
+            # No embedded ICC profile: leave / restore the default pipeline.
+            self.disableSourceSYN(source)
+            return
+
+        current = commands.getStringProperty(linPipe + ".pipeline.nodes")
+        if linPipe not in DEFAULT_PIPE:
+            if "SYNLinearize" in current:
+                DEFAULT_PIPE[linPipe] = DEFAULT_RV_PIPE["RVLinearizePipelineGroup"]
+            else:
+                DEFAULT_PIPE[linPipe] = current
+
+        # Match the original script: the linearize pipeline becomes just
+        # SYNLinearize.
+        if current != ["SYNLinearize"]:
+            commands.setStringProperty(linPipe + ".pipeline.nodes", ["SYNLinearize"], True)
+
+        syn = groupMemberOfType(linPipe, "SYNLinearize")
+        if syn is not None:
+            commands.setByteProperty(syn + ".inTransform.data", blob, True)
+            print("INFO: SYNLinearize applied to %s" % source)
+        commands.redraw()
+
+    def disableSourceSYN(self, source):
+        linPipe = groupMemberOfType(commands.nodeGroup(source), "RVLinearizePipelineGroup")
+        if linPipe is None or linPipe not in DEFAULT_PIPE:
+            return
+        current = commands.getStringProperty(linPipe + ".pipeline.nodes")
+        if current == DEFAULT_PIPE[linPipe]:
+            return
+        commands.setStringProperty(linPipe + ".pipeline.nodes", DEFAULT_PIPE[linPipe], True)
+        commands.redraw()
+
+    #
+    #   Display side
+    #
+
+    def useDisplaySYN(self, group):
+        url = commands.getStringProperty(group + ".device.systemProfileURL")
+        if not url or url[0] == "":
+            self.disableDisplaySYN(group)
+            return
+
+        dpipe = groupMemberOfType(group, "RVDisplayPipelineGroup")
+        if dpipe is None:
+            return
+
+        path = normalizeProfileURL(url[0])
+        current = commands.getStringProperty(dpipe + ".pipeline.nodes")
+
+        # Already configured with this profile: nothing to do.
+        if current == ["SYNDisplay"]:
+            syn = groupMemberOfType(dpipe, "SYNDisplay")
+            if syn is not None and commands.getStringProperty(syn + ".outTransform.url") == [path]:
+                return
+
+        if dpipe not in DEFAULT_PIPE:
+            if "SYNDisplay" in current:
+                DEFAULT_PIPE[dpipe] = DEFAULT_RV_PIPE["RVDisplayPipelineGroup"]
+            else:
+                DEFAULT_PIPE[dpipe] = current
+
+        if current != ["SYNDisplay"]:
+            commands.setStringProperty(dpipe + ".pipeline.nodes", ["SYNDisplay"], True)
+
+        syn = groupMemberOfType(dpipe, "SYNDisplay")
+        if syn is not None:
+            commands.setStringProperty(syn + ".outTransform.url", [path], True)
+            print("INFO: SYNDisplay applied to %s" % group)
+        commands.redraw()
+
+    def disableDisplaySYN(self, group):
+        dpipe = groupMemberOfType(group, "RVDisplayPipelineGroup")
+        if dpipe is None or dpipe not in DEFAULT_PIPE:
+            return
+        current = commands.getStringProperty(dpipe + ".pipeline.nodes")
+        if current == DEFAULT_PIPE[dpipe]:
+            return
+        commands.setStringProperty(dpipe + ".pipeline.nodes", DEFAULT_PIPE[dpipe], True)
+        commands.redraw()
+
+    #
+    #   Whole-graph helpers
+    #
+
+    def _sources(self):
+        result = []
+        for t in ("RVFileSource", "RVImageSource"):
+            result += commands.nodesOfType(t)
+        return result
+
+    def _applyDisplays(self):
+        for group in commands.nodesOfType("RVDisplayGroup"):
+            self.useDisplaySYN(group)
+
+    def applyAll(self):
+        for source in self._sources():
+            self.useSourceSYN(source)
+        self._applyDisplays()
+
+    def restoreAll(self):
+        for source in self._sources():
+            self.disableSourceSYN(source)
+        for group in commands.nodesOfType("RVDisplayGroup"):
+            self.disableDisplaySYN(group)
+
+    def _currentDisplayProfilePath(self):
+        #
+        # Pick a display profile to bake into the output group(s). Prefer the
+        # first display with a non-empty system profile.
+        #
+        for group in commands.nodesOfType("RVDisplayGroup"):
+            url = commands.getStringProperty(group + ".device.systemProfileURL")
+            if url and url[0] != "":
+                return normalizeProfileURL(url[0])
+        return None
+
+    #
+    #   Event handlers
+    #
+
+    def sourceSetup(self, event):
+        event.reject()  # allow other source-group-complete handlers to run
+        if not self._enabled or self._readingSession:
+            #
+            # While a session is being read the graph is still incomplete, so
+            # snapshotting a pipeline now could capture a partial state as the
+            # user's default. afterSessionRead() applies everything instead.
+            #
+            return
+        group = event.contents().split(";;")[0]
+        fileSource = groupMemberOfType(group, "RVFileSource")
+        imageSource = groupMemberOfType(group, "RVImageSource")
+        source = fileSource if imageSource is None else imageSource
+        if source is not None:
+            self.useSourceSYN(source)
+        # A source's embedded profile does not drive the display; the display
+        # is configured from its own device system profile.
+        self._applyDisplays()
+
+    def checkForDisplayGroup(self, event):
+        event.reject()
+        if not self._enabled or self._readingSession:
+            return
+        node = event.contents()
+        try:
+            isDisplayGroup = commands.nodeType(node) == "RVDisplayGroup"
+        except Exception:
+            # The node may already be gone by the time the event is handled.
+            return
+        if isDisplayGroup:
+            self.useDisplaySYN(node)
+
+    def beforeSessionRead(self, event):
+        event.reject()
+        self._readingSession = True
+        #
+        # Pipeline snapshots are keyed by node name and node names are reused
+        # across sessions, so a snapshot from the outgoing session must not be
+        # allowed to restore itself onto the incoming one.
+        #
+        DEFAULT_PIPE.clear()
+
+    def afterSessionRead(self, event):
+        event.reject()
+        self._readingSession = False
+        if self._enabled:
+            self.applyAll()
+
+    def beforeSessionWrite(self, event):
+        #
+        # rvio parity: bake the display SYNDisplay transform into every output
+        # group so the exported .rv reproduces it under rvio (RVDisplayGroup is
+        # not persisted; RVOutputGroup is, and rvio renders through it).
+        #
+        event.reject()
+        self._bakedOutputGroups = {}
+        if not self._enabled:
+            return
+        path = self._currentDisplayProfilePath()
+        if path is None:
+            return
+        for og in commands.nodesOfType("RVOutputGroup"):
+            dpipe = groupMemberOfType(og, "RVDisplayPipelineGroup")
+            if dpipe is None:
+                continue
+
+            nodes = commands.getStringProperty(dpipe + ".pipeline.nodes")
+
+            #
+            # Snapshot the existing SYNDisplay url along with the pipeline: when
+            # the output group is already SYNDisplay based the pipeline list is
+            # left untouched, so restoring the list alone would not undo the
+            # bake and the user's own profile would be lost.
+            #
+            syn = groupMemberOfType(dpipe, "SYNDisplay")
+            url = commands.getStringProperty(syn + ".outTransform.url") if syn is not None else None
+            self._bakedOutputGroups[dpipe] = (nodes, url)
+
+            if "SYNDisplay" not in nodes:
+                commands.setStringProperty(dpipe + ".pipeline.nodes", ["SYNDisplay"], True)
+                syn = groupMemberOfType(dpipe, "SYNDisplay")
+
+            if syn is not None:
+                commands.setStringProperty(syn + ".outTransform.url", [path], True)
+                print("INFO: SYNDisplay baked into %s for rvio parity" % og)
+
+    def afterSessionWrite(self, event):
+        #
+        # Revert the output groups to their pre-write state so the parity bake
+        # does not alter the live interactive graph.
+        #
+        event.reject()
+        for dpipe, (nodes, url) in self._bakedOutputGroups.items():
+            try:
+                current = commands.getStringProperty(dpipe + ".pipeline.nodes")
+                if current != nodes:
+                    #
+                    # Restoring the pipeline rebuilds the group, which discards
+                    # the SYNDisplay node we inserted along with its url.
+                    #
+                    commands.setStringProperty(dpipe + ".pipeline.nodes", nodes, True)
+                elif url is not None:
+                    #
+                    # The pipeline was already SYNDisplay based, so the node
+                    # survived the bake and its url has to be put back.
+                    #
+                    syn = groupMemberOfType(dpipe, "SYNDisplay")
+                    if syn is not None:
+                        commands.setStringProperty(syn + ".outTransform.url", url, True)
+            except Exception as exc:
+                print("WARNING: could not revert %s after session write: %s" % (dpipe, exc))
+        self._bakedOutputGroups = {}
+
+    #
+    #   Menu toggle (self-contained, package-owned preference)
+    #
+
+    def toggleEnabled(self, event):
+        #
+        # A session read that fails part way through never emits
+        # after-session-read, which would otherwise leave the flag set and
+        # silently stop the feature from applying. Toggling always recovers.
+        #
+        self._readingSession = False
+        self._enabled = not self._enabled
+        commands.writeSettings(SETTINGS_GROUP, SETTINGS_KEY, self._enabled)
+        if self._enabled:
+            self.applyAll()
+        else:
+            self.restoreAll()
+        commands.redraw()
+
+    def enabledState(self):
+        return commands.CheckedMenuState if self._enabled else commands.UncheckedMenuState
+
+    def _buildMenu(self):
+        return [
+            (
+                "Color",
+                [
+                    (
+                        "Automatic Color Profile Setup",
+                        self.toggleEnabled,
+                        None,
+                        self.enabledState,
+                    )
+                ],
+            )
+        ]
+
+    def __init__(self):
+        rvtypes.MinorMode.__init__(self)
+
+        self._enabled = bool(commands.readSettings(SETTINGS_GROUP, SETTINGS_KEY, False))
+        self._readingSession = False
+        self._bakedOutputGroups = {}
+
+        self.init(
+            "color-profile-setup",
+            None,
+            [
+                ("source-group-complete", self.sourceSetup, "Color and Geometry Management"),
+                ("before-session-read", self.beforeSessionRead, ""),
+                ("after-session-read", self.afterSessionRead, ""),
+                ("graph-new-node", self.checkForDisplayGroup, ""),
+                ("graph-node-inputs-changed", self.checkForDisplayGroup, ""),
+                ("before-session-write", self.beforeSessionWrite, ""),
+                ("before-session-write-copy", self.beforeSessionWrite, ""),
+                ("after-session-write", self.afterSessionWrite, ""),
+                ("after-session-write-copy", self.afterSessionWrite, ""),
+            ],
+            self._buildMenu(),
+            "source_setup",
+            20,
+        )  # "source_setup" key shared with source_setup and ocio_source_setup
+
+
+def createMode():
+    return ColorProfileSetupMode()


### PR DESCRIPTION
### feat: SG-43687: Automatic color profile setup (SYNLinearize/SYNDisplay) with rvio parity

### Linked issues
Fixes #1034

### Describe the reason for the change.

RV users had to manually insert two custom OCIO nodes to get correct color management:

SYNLinearize — source-side linearization, driven by an ICC profile embedded in the media (inTransform.data byte blob).

SYNDisplay — display-side color management, driven by the monitor's system ICC profile (outTransform.url).

This was done by executing a user script (NOT part of RV) after loading media. Moreover, the display-side transform did not survive a session export to rvio, so batch renders via rvio did not match what the user saw in interactive RV.

### Summarize your change.

Note that this PR includes @williamwira's fix from https://github.com/AcademySoftwareFoundation/OpenRV/pull/1080

Replaces the manual, key-bound script for inserting SYNLinearize / SYNDisplay color-management nodes with an automatic, opt-in mechanism, and makes exported sessions render identically in `rvio`.

- New self-contained `color_profile_setup` rv-package (off by default; toggle under **Color → "Automatic Color Profile Setup"**).
- **Source:** media with an embedded ICC profile → `RVLinearizePipelineGroup` switched to `SYNLinearize` with `inTransform.data` set from the profile.
- **Display:** each `RVDisplayGroup` with a system profile → `SYNDisplay` with `outTransform.url`.
- **rvio parity:** at session-write, `SYNDisplay` is baked into every `RVOutputGroup` (the writable group rvio renders through) and reverted after the write.
- Includes **PR #1239** (macOS `DesktopVideoDevice::colorProfile()` + OCIO `synlinearize`/`syndisplay` init fixes), which the display side depends on.

FYI @williamwira 

### Describe what you have tested and on which operating system.
Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.