### PR TITLE
ci: point pinned Rocky 9.7 repos at the vault archive (conan.yml)

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -100,9 +100,15 @@ jobs:
       # Rocky 9.8 dropped mesa-libOSMesa{,-devel} from the CRB repo. Pin all
       # subsequent dnf calls in this container to the 9.7 minor release until
       # OpenRV migrates off OSMesa. Remove this step once that's done.
-      - name: Pin Rocky 9 to 9.7 minor release
+      - name: Pin Rocky 9 to 9.7 minor release (vault)
         if: ${{ matrix.rocky-version == '9' }}
-        run: echo "9.7" > /etc/dnf/vars/releasever
+        run: |
+          echo "9.7" > /etc/dnf/vars/releasever
+          sed -i \
+            -e 's|^mirrorlist=|#mirrorlist=|g' \
+            -e 's|^#\?baseurl=https\?://dl.rockylinux.org/\$contentdir/|baseurl=https://dl.rockylinux.org/vault/rocky/|g' \
+            /etc/yum.repos.d/[Rr]ocky*.repo
+          dnf clean all
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
### ci: point pinned Rocky 9.7 repos at the vault archive (conan.yml)

### Linked issues
none

### Summarize your change.
Same change set https://github.com/AcademySoftwareFoundation/OpenRV/pull/1307 to fix Rocky 9.7

### Describe the reason for the change.
Forgot to fix the same issue in conan.yml

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.