### PR TITLE
refactor: SG-44489: Replace several boost threading usages with std::thread and address sanitizer reported issues

### DIFF
--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -80,7 +80,6 @@
 #include <sched.h>
 #include <sstream>
 #include <stdlib.h>
-#include <stl_ext/thread_group.h>
 #include <signal.h>
 #include <string.h>
 #include <vector>
@@ -122,7 +121,7 @@ extern void rvThirdPartyCustomization(TwkApp::Bundle& bundle, char* licarg);
 // #error ********* NO VERSION INFORMATION ***********
 #else
 #ifndef _MSC_VER
-#warning********* NO VERSION INFORMATION ***********
+#warning ********* NO VERSION INFORMATION ***********
 #endif
 #endif
 #endif

--- a/src/bin/apps/rvpkg/main.cpp
+++ b/src/bin/apps/rvpkg/main.cpp
@@ -40,7 +40,6 @@
 #include <sched.h>
 #include <sstream>
 #include <stdlib.h>
-#include <stl_ext/thread_group.h>
 #include <string.h>
 #include <vector>
 #include <set>
@@ -71,7 +70,7 @@
 // #error ********* NO VERSION INFORMATION ***********
 #else
 #ifndef _MSC_VER
-#warning********* NO VERSION INFORMATION ***********
+#warning ********* NO VERSION INFORMATION ***********
 #endif
 #endif
 #endif

--- a/src/bin/imgtools/rvio/main.cpp
+++ b/src/bin/imgtools/rvio/main.cpp
@@ -74,7 +74,6 @@
 #include <iostream>
 #include <sched.h>
 #include <cstdlib>
-#include <stl_ext/thread_group.h>
 #include <stl_ext/string_algo.h>
 #include <cstring>
 #include <vector>

--- a/src/bin/imgtools/rvls/main.cpp
+++ b/src/bin/imgtools/rvls/main.cpp
@@ -36,7 +36,6 @@
 #include <iostream>
 #include <iterator>
 #include <numeric>
-#include <stl_ext/thread_group.h>
 #include <boost/algorithm/string.hpp>
 #include <ImfHeader.h>
 #include <yaml-cpp/yaml.h>

--- a/src/bin/nsapps/RV/main.cpp
+++ b/src/bin/nsapps/RV/main.cpp
@@ -55,7 +55,6 @@
 #include <thread>
 #include <signal.h>
 #include <stdlib.h>
-#include <stl_ext/thread_group.h>
 #include <string.h>
 #include <errno.h>
 #include <vector>
@@ -83,7 +82,7 @@ extern void rvThirdPartyCustomization(TwkApp::Bundle& bundle, char* licarg);
 #if NDEBUG
 // #error ********* NO VERSION INFORMATION ***********
 #else
-#warning********* NO VERSION INFORMATION ***********
+#warning ********* NO VERSION INFORMATION ***********
 #endif
 #endif
 

--- a/src/lib/app/RvApp/Options.cpp
+++ b/src/lib/app/RvApp/Options.cpp
@@ -42,6 +42,7 @@
 #include <fstream>
 #include <iostream>
 #include <stl_ext/string_algo.h>
+#include <stl_ext/thread_group.h>
 
 extern void TwkMovie_GenericIO_setDebug(bool);
 extern void TwkFB_GenericIO_setDebug(bool);

--- a/src/lib/app/RvCommon/RvConsoleApplication.cpp
+++ b/src/lib/app/RvCommon/RvConsoleApplication.cpp
@@ -16,6 +16,7 @@ namespace Rv
         , m_pyLibrary(INTERNAL_APPLICATION_NAME)
     {
         m_pyLibrary.setName("py-media-library");
+        m_pyLibrary.start();
     }
 
 } // namespace Rv

--- a/src/lib/app/TwkMediaLibrary/Library.cpp
+++ b/src/lib/app/TwkMediaLibrary/Library.cpp
@@ -346,7 +346,6 @@ namespace TwkMediaLibrary
         , m_appName(appName)
         , m_name(typeName)
         , m_taskStop(false)
-        , m_taskThread(threadTrampoline, this)
     {
         // globalLibraryMap[typeName] = this;
     }
@@ -359,8 +358,10 @@ namespace TwkMediaLibrary
             m_taskCond.notify_one();
         }
 
-        m_taskThread.join();
-
+        if (m_taskThread.joinable())
+        {
+            m_taskThread.join();
+        }
         //
         //  willDeleteSignal() should be sent by derived classes. Its sent
         //  here as a stop-gap but if this is used is almost certain going
@@ -636,7 +637,7 @@ namespace TwkMediaLibrary
 
     const Task* Library::referencesToNodeASync(const Node*, PropertyQueryResultFunction) const { return 0; }
 
-    void Library::threadTrampoline(Library* library) { library->threadMain(); }
+    void Library::start() { m_taskThread = Thread(&Library::threadMain, this); }
 
     void Library::addTask(Task* item) const
     {

--- a/src/lib/app/TwkMediaLibrary/TwkMediaLibrary/Library.h
+++ b/src/lib/app/TwkMediaLibrary/TwkMediaLibrary/Library.h
@@ -817,9 +817,8 @@ namespace TwkMediaLibrary
         //  ASync/Parallel Task API
         //
 
-        static void threadTrampoline(Library*);
         void threadMain();
-
+        void start();
         void addTask(Task*) const;
         void cancelTask(const Task*) const;
         void cancelTasks(const TaskVector&) const;

--- a/src/lib/audio/ALSAAudioModule/ALSAAudioModule/ALSAAudioRenderer.h
+++ b/src/lib/audio/ALSAAudioModule/ALSAAudioModule/ALSAAudioRenderer.h
@@ -13,6 +13,7 @@
 #include <TwkUtil/Timer.h>
 
 #include <alsa/asoundlib.h>
+#include <mutex>
 
 namespace IPCore
 {
@@ -92,7 +93,7 @@ namespace IPCore
         snd_pcm_uframes_t m_bufferSize;
         pthread_t m_audioThread;
         bool m_audioThreadRunning;
-        pthread_mutex_t m_runningLock;
+        std::mutex m_runningLock;
     };
 
 } // namespace IPCore

--- a/src/lib/audio/ALSAAudioModule/ALSAAudioRenderer.cpp
+++ b/src/lib/audio/ALSAAudioModule/ALSAAudioRenderer.cpp
@@ -229,7 +229,6 @@ namespace IPCore
         , m_audioThreadRunning(false)
     {
         snd_lib_error_set_handler(alsaErrorHandler);
-        pthread_mutex_init(&m_runningLock, 0);
 
         if (m_parameters.rate == 0)
             m_parameters.rate = TWEAK_AUDIO_DEFAULT_SAMPLE_RATE;
@@ -263,7 +262,6 @@ namespace IPCore
     {
         AudioRenderer::stop();
         shutdown();
-        pthread_mutex_destroy(&m_runningLock);
     }
 
     void ALSAAudioRenderer::createDeviceList()
@@ -629,7 +627,7 @@ namespace IPCore
 
             snd_pcm_hw_params_set_periods(pcm, params, periods, 0);
             snd_pcm_hw_params_set_buffer_size(pcm, params, (period_size * periods) >> 2);
-            
+
             if (snd_pcm_hw_params(pcm, params) >= 0 && rrate == rate)
             {
                 rates.push_back((unsigned int)rate);
@@ -882,10 +880,11 @@ namespace IPCore
         if (!m_pcm)
             return;
 
-        m_threadGroup.lock(m_runningLock);
-        m_audioThreadRunning = true;
-        m_audioThread = pthread_self();
-        m_threadGroup.unlock(m_runningLock);
+        {
+            std::lock_guard<std::mutex> guard(m_runningLock);
+            m_audioThreadRunning = true;
+            m_audioThread = pthread_self();
+        }
 
         //
         //  Get the current state. (yeah, I know it was just set above)
@@ -1123,9 +1122,10 @@ namespace IPCore
         if (pcmState == SND_PCM_STATE_RUNNING)
             snd_pcm_drop(m_pcm);
 
-        m_threadGroup.lock(m_runningLock);
-        m_audioThreadRunning = false;
-        m_threadGroup.unlock(m_runningLock);
+        {
+            std::lock_guard<std::mutex> guard(m_runningLock);
+            m_audioThreadRunning = false;
+        }
 
         if (debug)
             cout << "DEBUG: audio thread exiting" << endl;
@@ -1180,12 +1180,14 @@ namespace IPCore
 
         const bool holdOpen = m_parameters.holdOpen;
         m_parameters.holdOpen = false;
+        bool isrunning = false;
 
         AudioRenderer::stop();
 
-        m_threadGroup.lock(m_runningLock);
-        bool isrunning = m_audioThreadRunning;
-        m_threadGroup.unlock(m_runningLock);
+        {
+            std::lock_guard<std::mutex> guard(m_runningLock);
+            isrunning = m_audioThreadRunning;
+        }
 
         if (isrunning)
             m_threadGroup.control_wait(true, 1.0);
@@ -1199,9 +1201,10 @@ namespace IPCore
             //  the audio device until after m_pcm has been zeroed.
             //
             snd_pcm_t* tmp = m_pcm;
-            m_threadGroup.lock(m_runningLock);
-            m_pcm = 0;
-            m_threadGroup.unlock(m_runningLock);
+            {
+                std::lock_guard<std::mutex> guard(m_runningLock);
+                m_pcm = 0;
+            }
             snd_pcm_close(tmp);
         }
 

--- a/src/lib/audio/ALSASafeAudioModule/ALSASafeAudioModule/ALSASafeAudioRenderer.h
+++ b/src/lib/audio/ALSASafeAudioModule/ALSASafeAudioModule/ALSASafeAudioRenderer.h
@@ -13,6 +13,7 @@
 #include <TwkUtil/Timer.h>
 
 #include <alsa/asoundlib.h>
+#include <mutex>
 
 namespace IPCore
 {
@@ -92,7 +93,7 @@ namespace IPCore
         snd_pcm_uframes_t m_bufferSize;
         pthread_t m_audioThread;
         bool m_audioThreadRunning;
-        pthread_mutex_t m_runningLock;
+        std::mutex m_runningLock;
     };
 
 } // namespace IPCore

--- a/src/lib/audio/ALSASafeAudioModule/ALSASafeAudioRenderer.cpp
+++ b/src/lib/audio/ALSASafeAudioModule/ALSASafeAudioRenderer.cpp
@@ -230,7 +230,6 @@ namespace IPCore
         , m_audioThreadRunning(false)
     {
         snd_lib_error_set_handler(alsaErrorHandler);
-        pthread_mutex_init(&m_runningLock, 0);
 
         if (m_parameters.rate == 0)
             m_parameters.rate = TWEAK_AUDIO_DEFAULT_SAMPLE_RATE;
@@ -264,7 +263,6 @@ namespace IPCore
     {
         AudioRenderer::stop();
         shutdown();
-        pthread_mutex_destroy(&m_runningLock);
     }
 
     void ALSASafeAudioRenderer::createDeviceList()
@@ -639,7 +637,7 @@ namespace IPCore
 
             snd_pcm_hw_params_set_periods(pcm, params, periods, 0);
             snd_pcm_hw_params_set_buffer_size(pcm, params, (period_size * periods) >> 2);
-            
+
             if (snd_pcm_hw_params(pcm, params) >= 0 && rrate == rate)
             {
                 rates.push_back((unsigned int)rate);
@@ -890,10 +888,11 @@ namespace IPCore
         if (!m_pcm)
             return;
 
-        m_threadGroup.lock(m_runningLock);
-        m_audioThreadRunning = true;
-        m_audioThread = pthread_self();
-        m_threadGroup.unlock(m_runningLock);
+        {
+            std::lock_guard<std::mutex> guard(m_runningLock);
+            m_audioThreadRunning = true;
+            m_audioThread = pthread_self();
+        }
 
         //
         //  Get the current state. (yeah, I know it was just set above)
@@ -1130,10 +1129,10 @@ namespace IPCore
             return;
         if (pcmState == SND_PCM_STATE_RUNNING)
             snd_pcm_drop(m_pcm);
-
-        m_threadGroup.lock(m_runningLock);
-        m_audioThreadRunning = false;
-        m_threadGroup.unlock(m_runningLock);
+        {
+            std::lock_guard<std::mutex> guard(m_runningLock);
+            m_audioThreadRunning = false;
+        }
 
         if (debug)
             cout << "DEBUG: audio thread exiting" << endl;
@@ -1188,12 +1187,14 @@ namespace IPCore
 
         const bool holdOpen = m_parameters.holdOpen;
         m_parameters.holdOpen = false;
+        bool isrunning = false;
 
         AudioRenderer::stop();
 
-        m_threadGroup.lock(m_runningLock);
-        bool isrunning = m_audioThreadRunning;
-        m_threadGroup.unlock(m_runningLock);
+        {
+            std::lock_guard<std::mutex> guard(m_runningLock);
+            isrunning = m_audioThreadRunning;
+        }
 
         if (isrunning)
             m_threadGroup.control_wait(true, 1.0);
@@ -1207,9 +1208,12 @@ namespace IPCore
             //  the audio device until after m_pcm has been zeroed.
             //
             snd_pcm_t* tmp = m_pcm;
-            m_threadGroup.lock(m_runningLock);
-            m_pcm = 0;
-            m_threadGroup.unlock(m_runningLock);
+
+            {
+                std::lock_guard<std::mutex> guard(m_runningLock);
+                m_pcm = 0;
+            }
+
             snd_pcm_close(tmp);
         }
 

--- a/src/lib/base/stl_ext/stl_ext/thread_group.h
+++ b/src/lib/base/stl_ext/stl_ext/thread_group.h
@@ -9,6 +9,10 @@
 #define __stl_ext__thread_group__h__
 #include <pthread.h>
 #include <vector>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
 #include <stl_ext/stl_ext_config.h>
 
 namespace stl_ext
@@ -92,18 +96,19 @@ namespace stl_ext
         bool control_wait(bool allThreads = true,
                           double timeout_seconds = 0.0); // control thread API
 
-        //
-        //  Call dispatch for each work thread you want to dispatch. Its an
-        //  error to call this if there are not available threads.
+        //  Queue a job to be executed by a worker thread asynchronously. The
+        //  job will be placed in the work queue and executed by the next
+        //  available worker. If all workers are busy, the job will wait
+        //  in the queue until a worker becomes available.
         //
 
-        void dispatch(thread_function, void*);
+        void dispatch(thread_function func, void* data) { internal_dispatch(func, data, false); }
 
         //
         //  Dispatch, but if all threads are busy returns false otherwise true
         //
 
-        bool maybe_dispatch(thread_function, void*, bool async = false);
+        bool maybe_dispatch(thread_function func, void* data) { return internal_dispatch(func, data, true); }
 
         //
         //  Use the function to add additional threads. Once a thread is added
@@ -119,39 +124,17 @@ namespace stl_ext
         //  Number of worker threads in the thread group.
         //
 
-        size_t num_threads() const { return _num_threads; }
+        size_t num_threads() const { return m_num_threads; }
 
         //
         //  set debugging messages on/off
         //
 
-        void debug(bool b) { _debugging = b; }
+        void debug(bool b) { m_debugging = b; }
 
-        static void debug_all(bool b) { _debug_all = b; }
-
-        //
-        //  Cancel a thread if its running. USE WITH CAUTION
-        //
-
-        void cancel(pthread_t);
-
-        //
-        //  Pthreads wrappers
-        //
-
-        static void lock(pthread_mutex_t&);
-        static void unlock(pthread_mutex_t&);
-        static void wait_cond(pthread_cond_t&, pthread_mutex_t&);
-        static bool wait_cond_time(pthread_cond_t&, pthread_mutex_t&, size_t usec);
-        static void signal(pthread_cond_t&);
-        static void broadcast(pthread_cond_t&);
+        static void debug_all(bool b) { DEBUG_ALL = b; }
 
         void debug(const char*, ...);
-
-        //----------------------------------------------------------------------
-        //
-        //  Worker thread API
-        //
 
         //
         //  Restart any waiting workers, using the func/data pair that
@@ -163,66 +146,52 @@ namespace stl_ext
         void awaken_all_workers();
 
     private:
-        static void* thread_main(void*);
-        static void thread_cleanup(void*);
-
-        void worker_wait(); // worker thread API
-        void worker_jump();
-        void worker_cleanup();
-        void release_control();
-        void release_worker();
-
-        typedef std::vector<pthread_t> thread_vector;
-
-        struct thread_package
+        struct WorkerState
         {
-            // thread_package () {}
-            // thread_package (thread_group* g, thread_function f, void* d) :
-            // group(g), func(f), data(d) {}
-
-            thread_group* group;
-            thread_function func;
-            void* data;
+            size_t worker_id = 0;
+            thread_group* group = nullptr;
+            thread_function original_func = nullptr; // Function to recall
+            void* original_data = nullptr;           // Data to recall
         };
 
-        typedef std::vector<thread_package> package_vector;
+        struct Job
+        {
+            thread_function func; // Function to execute
+            void* data;           // Data to pass to the function
+            bool recall;          // If true, use the thread's original func/data
+        };
 
-        bool running() { return _running; }
+        //
+        // Main loop for each worker thread.
+        //
+
+        void thread_main(WorkerState* state);
+
+        bool internal_dispatch(thread_function func, void* data, bool maybe);
 
     private:
-        thread_api _api;
-        pthread_mutex_t _wait_mutex;
-        pthread_cond_t _wait_cond;
+        thread_api m_api;
+        pthread_attr_t m_thread_attr;
+        std::vector<pthread_t> m_threads;
+        size_t m_default_stack_size = 0;
 
-        pthread_mutex_t _worker_mutex;
-        pthread_cond_t _worker_cond;
+        // Debug logging
+        static bool DEBUG_ALL;
+        static std::mutex DEBUG_MUTEX;
+        int m_group_id;
+        bool m_debugging = false;
 
-        pthread_mutex_t _control_mutex;
-        pthread_cond_t _control_cond;
+        // Work queue and synchronization
+        int m_num_threads = 0;
+        std::atomic<int> m_num_jobs{0};
+        std::atomic<bool> m_running{true};
+        std::queue<Job> m_job_queue;
+        std::mutex m_queue_mutex;
+        std::condition_variable m_queue_cond;
 
-        pthread_mutex_t _debug_mutex;
-
-        pthread_attr_t _thread_attr;
-
-        bool _wait_flag;
-        thread_vector _threads;
-        package_vector _packages;
-
-        int _num_finished;
-        int _num_threads;
-        thread_function _func;
-        void* _data;
-        bool _recall;
-        bool _debugging;
-        bool _running;
-        pthread_t _join_thread;
-
-        bool _dispatching;
-        size_t _default_stack_size;
-        static bool _debug_all;
-
-        pthread_key_t _funcKey;
-        pthread_key_t _dataKey;
+        // For control_wait synchronization
+        std::mutex m_finished_mutex;
+        std::condition_variable m_finished_cond;
     };
 
 } // namespace stl_ext

--- a/src/lib/base/stl_ext/thread_group.cpp
+++ b/src/lib/base/stl_ext/thread_group.cpp
@@ -13,805 +13,246 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <cinttypes>
 #include <errno.h>
 #include <algorithm>
-
-#ifdef PLATFORM_WINDOWS
-#include <time.h>
-#include <winsock.h>
-#else
-#include <sys/time.h>
-#include <sys/resource.h>
-#endif
+#include <chrono>
 
 namespace stl_ext
 {
     using namespace std;
 
-    bool thread_group::_debug_all = false;
-
-#ifdef PLATFORM_WINDOWS
-    static int currentTime(struct timeval* tv)
-    {
-        union
-        {
-            // AJG - this used to be a LONG_LONG
-            __int64 ns100; // time since 1 Jan 1601 in 100ns units
-            FILETIME ft;
-        } now;
-
-        GetSystemTimeAsFileTime(&now.ft);
-        tv->tv_usec = (long)((now.ns100 / 10LL) % 1000000LL);
-        tv->tv_sec = (long)((now.ns100 - 116444736000000000LL) / 10000000LL);
-        return (0);
-    }
-#endif
-
-#if defined(PLATFORM_APPLE_MACH_BSD)
-    static int currentTime(struct timeval* tp) { return gettimeofday(tp, 0); }
-#endif
+    bool thread_group::DEBUG_ALL = false;
+    std::mutex thread_group::DEBUG_MUTEX;
 
     thread_group::thread_group(int num_threads, int stack_mult, thread_api* api, const func_vector* funcs, const data_vector* datas)
-        : _num_finished(0)
-        , _num_threads(0)
-        , _data(0)
-        , _func(0)
-        , _recall(false)
-        , _debugging(false)
-        , _running(true)
-        , _wait_flag(true)
-        , _dispatching(false)
-        , _default_stack_size(0)
-        , _api()
     {
         if (api)
-            _api = *api;
-        _debugging = _debug_all;
-        pthread_mutex_init(&_wait_mutex, 0);
-        pthread_mutex_init(&_worker_mutex, 0);
-        pthread_mutex_init(&_control_mutex, 0);
-        pthread_mutex_init(&_debug_mutex, 0);
+            m_api = *api;
 
-        pthread_cond_init(&_wait_cond, 0);
-        pthread_cond_init(&_worker_cond, 0);
-        pthread_cond_init(&_control_cond, 0);
+        static std::atomic<int> next_group_id{0};
+        m_group_id = ++next_group_id;
+        m_debugging = DEBUG_ALL;
 
-        memset(&_thread_attr, 0, sizeof(pthread_attr_t));
-        pthread_attr_init(&_thread_attr);
-        pthread_attr_getstacksize(&_thread_attr, &_default_stack_size);
+        pthread_attr_init(&m_thread_attr);
+        pthread_attr_getstacksize(&m_thread_attr, &m_default_stack_size);
 
-        pthread_key_create(&_funcKey, 0);
-        pthread_key_create(&_dataKey, 0);
-
-        add_thread(num_threads, stack_mult, funcs, datas);
+        if (num_threads)
+            add_thread(num_threads, stack_mult, funcs, datas);
     }
-
-    static void noop(void*) {}
 
     thread_group::~thread_group()
     {
-        control_wait();
-        _running = false;
-
-        debug("~thread_group: control shutting down threads");
-
-        while (_num_threads > 0)
+        m_running = false;
+        m_queue_cond.notify_all();
+        for (auto& t : m_threads)
         {
-            debug("~thread_group: control dispatch with noop, num_threads = %d", _num_threads);
-            dispatch(noop, 0);
-            debug("~thread_group: control joining worker: %d", _num_threads);
-
-            // void *retval = 0;
-            lock(_wait_mutex);
-            unlock(_wait_mutex);
-            lock(_worker_mutex);
-            unlock(_worker_mutex);
-            lock(_control_mutex);
-            unlock(_control_mutex);
-
-            //
-            // We have to do this memcpy to a size_t type
-            // do guard against a zero value for _join_thread.
-            //
-            size_t threadID = 0;
-            memcpy(&threadID, &_join_thread, std::min(sizeof(threadID), sizeof(_join_thread)));
-            if (threadID)
+            if (int err = m_api.join(t, NULL))
             {
-                if (int err = _api.join(_join_thread, NULL))
-                {
-                    pthread_t thread = pthread_self();
-                    printf("~thread_group: %p -- join: %s", thread, strerror(err));
-                }
+                pthread_t thread = pthread_self();
+                printf("~thread_group: %p -- join: %s", thread, strerror(err));
             }
-            /* AJG - This WILL break something */
-            //_join_thread = 0;
-            debug("~thread_group: control successfully joined with worker");
         }
-
-        debug("~thread_group: control destroying state");
-
-        //
-        //  need to wait until its ok to destroy all of this stuff.
-        //
-        debug("~thread_group: deleting keys");
-        pthread_key_delete(_funcKey);
-        pthread_key_delete(_dataKey);
-
-        debug("~thread_group: destroying mutexes");
-        pthread_mutex_destroy(&_wait_mutex);
-        pthread_mutex_destroy(&_worker_mutex);
-        pthread_mutex_destroy(&_control_mutex);
-
-        debug("~thread_group: destroying _wait_cond");
-        pthread_cond_destroy(&_wait_cond);
-        debug("~thread_group: destroying _worker_cond");
-        pthread_cond_destroy(&_worker_cond);
-        debug("~thread_group: destroying _control_cond");
-        pthread_cond_destroy(&_control_cond);
-
-        debug("~thread_group: destroying attr");
-        pthread_attr_destroy(&_thread_attr);
-
-        debug("~thread_group: destroying debug");
-        pthread_mutex_destroy(&_debug_mutex);
+        pthread_attr_destroy(&m_thread_attr);
+        debug("~thread_group: all threads joined");
     }
 
-    void thread_group::debug(const char* c, ...)
+    void thread_group::debug(const char* fmt, ...)
     {
-        if (_debugging)
-        {
-            va_list ap;
-            va_start(ap, c);
-            lock(_debug_mutex);
-            pthread_t thread = pthread_self();
-            int worker_num = -1;
+        if (!m_debugging)
+            return;
 
-            for (int i = 0; i < _threads.size(); i++)
+        auto now = std::chrono::system_clock::now();
+        auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+        auto microseconds = std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count() % 1000000;
+
+        std::lock_guard<std::mutex> lock(DEBUG_MUTEX);
+
+        fprintf(stderr, "%" PRId64 " %06" PRId64, static_cast<int64_t>(seconds), static_cast<int64_t>(microseconds));
+        fprintf(stderr, " [thread_group %d] ", m_group_id);
+        va_list args;
+        va_start(args, fmt);
+        vfprintf(stderr, fmt, args);
+        va_end(args);
+        fprintf(stderr, "\n");
+        fflush(stderr);
+    }
+
+    void thread_group::thread_main(WorkerState* state)
+    {
+        debug("worker %zu: started", state->worker_id);
+        while (m_running)
+        {
+            Job job;
             {
-                if (pthread_equal(thread, _threads[i]))
-                {
-                    worker_num = i;
+                std::unique_lock<std::mutex> lock(m_queue_mutex);
+                m_queue_cond.wait(lock, [this] { return !m_job_queue.empty() || !m_running; });
+                if (!m_running && m_job_queue.empty())
                     break;
+                job = m_job_queue.front();
+                m_job_queue.pop();
+            }
+
+            // If this is a recall job, restore the original function/data for this worker
+            if (job.recall)
+            {
+                job.func = state->original_func;
+                job.data = state->original_data;
+                // awaken_all_workers expects workers to have been created with
+                // a function; a null original_func would decrement m_num_jobs
+                // without doing any work, corrupting the job counter.
+                assert(job.func);
+                debug("worker %zu: recalling original func/data", state->worker_id);
+            }
+
+            // Execute the job if valid
+            if (job.func)
+            {
+                debug("worker %zu: running func %p with data %p", state->worker_id, (void*)job.func, job.data);
+                try
+                {
+                    job.func(job.data);
+                }
+                catch (...)
+                {
+                    debug("worker %zu: caught exception", state->worker_id);
                 }
             }
 
-#ifndef PLATFORM_LINUX
-            struct timeval tv;
-            int t = currentTime(&tv);
-
-            fprintf(stderr, "%d %d %p/%p/%d/%lu: ", (int)tv.tv_sec, (int)tv.tv_usec, this, thread, worker_num + 1, _threads.size());
-#endif
-            vfprintf(stderr, c, ap);
-            fprintf(stderr, "\n");
-            fflush(stderr);
-            unlock(_debug_mutex);
-        }
-    }
-
-    //
-    //  This is the "main" function of each of the worker threads. The thread
-    //  is not marked detached until its about to exit
-    //
-
-    void thread_group::thread_cleanup(void* arg)
-    {
-        thread_group* group = (thread_group*)arg;
-        group->debug("worker clean up after cancellation");
-        group->worker_cleanup();
-    }
-
-    void* thread_group::thread_main(void* arg)
-    {
-        thread_package pack = *((thread_package*)arg);
-        pack.group->debug("thread_main: worker in main, thread_package: %p", arg);
-
-#ifdef PLATFORM_APPLE_MACH_BSD
-        //
-        //  Set the initial name to thread_group to indicate that the thread
-        //  has not yet been used.
-        //
-
-        pthread_setname_np("thread_group");
-#endif
-        pack.group->debug("thread_main: pthread_setspecific: %p %p %p %p", pack.group->_funcKey, (void*)pack.func, pack.group->_dataKey,
-                          pack.data);
-
-        pthread_setspecific(pack.group->_funcKey, (void*)pack.func);
-        pthread_setspecific(pack.group->_dataKey, pack.data);
-
-        // pthread_cleanup_push(thread_cleanup, arg);
-
-        while (pack.group->running())
-        {
-            pack.group->debug("thread_main: running");
-            pack.group->worker_wait();
-            pack.group->worker_jump();
+            // Even though m_num_jobs is atomic, we lock m_finished_mutex here
+            // to synchronize with threads waiting on m_finished_cond.
+            // This ensures that decrement and notification are not separated,
+            // avoiding missed wakeups or spurious waits.
+            {
+                std::lock_guard<std::mutex> lock(m_finished_mutex);
+                m_num_jobs--;
+                m_finished_cond.notify_all();
+            }
+            debug("worker %zu: job finished, jobs left: %d ", state->worker_id, m_num_jobs.load());
         }
 
-        // pthread_cleanup_pop(1);
-
-        // pack.group->debug("worker returning");
-        pack.group->debug("thread_main: worker returning");
-        return 0;
+        debug("worker %zu: returning", state->worker_id);
     }
 
     void thread_group::add_thread(int num_to_add, size_t stack_mult, const func_vector* funcs, const data_vector* datas)
     {
-        debug("add_thread");
-        if (num_to_add)
+        debug("add_thread: resizing _threads to %d + %d, default_stack_size: %d, stack_mult: %d", m_threads.size(), num_to_add,
+              m_default_stack_size, stack_mult);
+
+        pthread_attr_setstacksize(&m_thread_attr, m_default_stack_size * stack_mult);
+
+        if (funcs)
         {
-            debug("add_thread: resizing _threads and _packages to %d + %d, "
-                  "_default_stack_size: %d, stack_mult: %d",
-                  _threads.size(), num_to_add, _default_stack_size, stack_mult);
-            size_t s = _threads.size();
-            _threads.resize(s + num_to_add);
-            _packages.resize(_threads.size());
-            pthread_attr_setstacksize(&_thread_attr, _default_stack_size * stack_mult);
-
-            if (funcs)
-                assert(funcs->size() == num_to_add);
-            if (funcs)
-            {
-                debug("add_thread: funcs size %d", funcs->size());
-            }
-            else
-            {
-                debug("add_thread: funcs is NULL");
-            }
-            for (int i = s; i < _threads.size(); i++)
-            {
-                thread_package& pack = _packages[i];
-                pack.group = this;
-                pack.func = (funcs) ? (*funcs)[i - s] : 0;
-                pack.data = (funcs) ? (*datas)[i - s] : 0;
-
-                memset(&_threads[i], 0, sizeof(pthread_t));
-                if (int err = _api.create(&_threads[i], &_thread_attr, thread_main, &pack))
-                {
-                    printf("add_thread: Error trying to create thread %d: %d", i, err);
-                    abort();
-                }
-                _num_threads++;
-                debug("add_thread: added worker #%d", _num_threads);
-            }
-            debug("add_thread: control_wait");
-            control_wait();
-            debug("add_thread done.");
-        }
-    }
-
-    void thread_group::lock(pthread_mutex_t& mutex)
-    {
-        if (int err = pthread_mutex_lock(&mutex))
-        {
-            pthread_t thread = pthread_self();
-            printf("%p -- unable to lock: %s", thread, strerror(err));
-            fflush(stdout);
-        }
-    }
-
-    void thread_group::unlock(pthread_mutex_t& mutex)
-    {
-        if (int err = pthread_mutex_unlock(&mutex))
-        {
-            pthread_t thread = pthread_self();
-            printf("%p -- unable to unlock: %s", thread, strerror(err));
-            fflush(stdout);
-        }
-    }
-
-    void thread_group::signal(pthread_cond_t& cond)
-    {
-        if (int err = pthread_cond_signal(&cond))
-        {
-            pthread_t thread = pthread_self();
-            printf("%p -- signal: %s", thread, strerror(err));
-            fflush(stdout);
-        }
-    }
-
-    void thread_group::broadcast(pthread_cond_t& cond)
-    {
-        if (int err = pthread_cond_broadcast(&cond))
-        {
-            pthread_t thread = pthread_self();
-            printf("%p -- broadcast: %s\n", thread, strerror(err));
-            fflush(stdout);
-        }
-    }
-
-    void thread_group::wait_cond(pthread_cond_t& cond, pthread_mutex_t& mutex)
-    {
-        if (int err = pthread_cond_wait(&cond, &mutex))
-        {
-            pthread_t thread = pthread_self();
-            printf("%p -- cond_wait: %s\n", thread, strerror(err));
-            fflush(stdout);
-        }
-    }
-
-    bool thread_group::wait_cond_time(pthread_cond_t& cond, pthread_mutex_t& mutex, size_t usec)
-    {
-        timespec ts;
-
-#ifdef PLATFORM_LINUX
-        clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_sec += usec / 1000000;
-        size_t r = (usec % 1000000) * 1000 + ts.tv_nsec;
-
-        if (r > 1000000000)
-        {
-            ts.tv_sec += r / 1000000000;
-            ts.tv_nsec = r % 1000000000;
-        }
-
-#else
-        struct timeval tv;
-        currentTime(&tv);
-
-        ts.tv_sec = tv.tv_sec;
-        size_t us = usec + tv.tv_usec;
-
-        if (us > 1000000)
-        {
-            ts.tv_sec += us / 1000000;
-            ts.tv_nsec = (us % 1000000) * 1000;
+            assert(funcs->size() == num_to_add);
+            debug("add_thread: funcs size %d", funcs->size());
         }
         else
         {
-            ts.tv_nsec = us * 1000;
+            debug("add_thread: funcs is NULL");
         }
-#endif
 
-        if (int err = pthread_cond_timedwait(&cond, &mutex, &ts))
+        for (int i = 0; i < num_to_add; ++i)
         {
-            if (err != ETIMEDOUT)
+            pthread_t thread;
+            int ret;
+            WorkerState* state = new WorkerState{};
+            state->worker_id = m_threads.size();
+            state->original_func = (funcs && funcs->size() > i) ? (*funcs)[i] : nullptr;
+            state->original_data = (datas && datas->size() > i) ? (*datas)[i] : nullptr;
+            state->group = this;
+
+            ret = m_api.create(
+                &thread, &m_thread_attr,
+                [](void* arg) -> void*
+                {
+                    WorkerState* state = static_cast<WorkerState*>(arg);
+                    state->group->thread_main(state);
+                    delete state;
+                    return nullptr;
+                },
+                state);
+
+            if (ret != 0)
             {
-                pthread_t thread = pthread_self();
-                printf("ERROR: %p -- cond_wait_timed: %s\n", thread, strerror(err));
-                fflush(stdout);
+                printf("add_thread: Error trying to create thread %d: %d", i, ret);
+                abort();
             }
-            //  fprintf (stderr, "err %d %s\n", err, strerror(err));
 
-            return false;
+            m_threads.push_back(thread);
+            m_num_threads++;
         }
-
-        return true;
-    }
-
-    void thread_group::release_control()
-    {
-        lock(_wait_mutex);
-        // debug("worker releasing control thread");
-        debug("release_control: _wait_mutex locked, signaling _wait_cond");
-        signal(_wait_cond);
-        unlock(_wait_mutex);
-        debug("release_control: _wait_mutex unlocked");
-    }
-
-    void thread_group::release_worker()
-    {
-        lock(_worker_mutex);
-        // debug("control releasing a worker thread");
-        debug("release_worker: _worker_mutex locked, signaling _worker_cond");
-        _wait_flag = false;
-        signal(_worker_cond);
-        unlock(_worker_mutex);
-        debug("release_worker: _worker_mutex unlocked");
+        debug("add_thread: added %d threads, total now %d", num_to_add, m_num_threads);
     }
 
     bool thread_group::control_wait(bool allThreads, double seconds)
     {
-        bool timedout = false;
+        if (m_num_threads <= 0)
+            return true;
 
-        if (_num_finished != _num_threads)
+        std::unique_lock<std::mutex> lock(m_finished_mutex);
+        int current_num_jobs = m_num_jobs.load();
+
+        // Predicate: all jobs finished (if allThreads), or any job finished
+        auto predicate = [this, allThreads, current_num_jobs]() -> bool
         {
-            lock(_wait_mutex);
-            debug("control_wait: _wait_mutex locked");
-
-            //
-            //  POSIX says that you can get a spurious wake up from a
-            //  condition variable. We need to keep checking in that case.
-            //
-
-            int num_finished = _num_finished;
-
             if (allThreads)
-            {
-                while (_num_finished != _num_threads)
-                {
-                    debug("control_wait: control waiting on %d threads, "
-                          "timeout %g seconds",
-                          (_num_threads - _num_finished), seconds);
-
-                    if (seconds)
-                    {
-                        timedout = !wait_cond_time(_wait_cond, _wait_mutex, size_t(seconds * 1000000.0));
-                        if (timedout)
-                        {
-                            debug("control_wait: control wait timed out, %d "
-                                  "threads remaining, _wait_cond and _wait_mutex",
-                                  (_num_threads - _num_finished));
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        wait_cond(_wait_cond, _wait_mutex);
-                        debug("control_wait: control wait_cond returned, "
-                              "_wait_cond and _wait_mutex");
-                    }
-                }
-            }
+                return m_num_jobs <= 0;
             else
-            {
-                while (_num_finished == num_finished)
-                {
-                    debug("control_wait: control waiting on any thread, "
-                          "timeout %g seconds, _wait_cond and _wait_mutex",
-                          seconds);
+                return m_num_jobs != current_num_jobs || m_num_jobs <= 0;
+        };
 
-                    if (seconds)
-                    {
-                        timedout = !wait_cond_time(_wait_cond, _wait_mutex, size_t(seconds * 1000000.0));
-                        if (timedout)
-                        {
-                            debug("control_wait: control wait on any thread "
-                                  "timed out");
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        wait_cond(_wait_cond, _wait_mutex);
-                    }
+        // Wait with timeout if specified, otherwise wait indefinitely
+        if (seconds > 0.0)
+        {
+            auto timeout = std::chrono::steady_clock::now() + std::chrono::duration<double>(seconds);
+            while (!predicate())
+            {
+                if (m_finished_cond.wait_until(lock, timeout) == std::cv_status::timeout)
+                {
+                    debug("control_wait: timed out waiting for %s job(s)", allThreads ? "all" : "any");
+                    return false;
                 }
             }
-
-            unlock(_wait_mutex);
-            debug("control_wait: control done waiting, _wait_mutex unlocked");
         }
         else
         {
-            debug("control did not need to wait");
+            m_finished_cond.wait(lock, predicate);
         }
-
-        return !timedout;
+        return true;
     }
 
-    void thread_group::cancel(pthread_t th)
+    bool thread_group::internal_dispatch(thread_function func, void* data, bool maybe)
     {
-        lock(_worker_mutex);
-        int f = _num_finished;
-        unlock(_worker_mutex);
-        if (f != _num_threads)
-            pthread_cancel(th);
-    }
-
-    void thread_group::worker_wait()
-    {
-        lock(_worker_mutex);
-        debug("worker_wait: _worker_mutex is locked");
-        ++_num_finished;
-
-        if (_num_finished == _num_threads)
+        bool dispatched = false;
         {
-            debug("worker_wait: workers are all waiting");
-            release_control();
-        }
-        else
-        {
-            if (_num_finished < 0 || _num_threads < 0)
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            if (!maybe || m_num_jobs < m_num_threads)
             {
-                _wait_flag = true;
-                unlock(_worker_mutex);
-                debug("worker_wait: ERROR: _num_finished %d _num_threads %d", _num_finished, _num_threads);
-                return;
+                m_job_queue.push(Job{func, data, func ? false : true});
+                m_num_jobs++;
+                dispatched = true;
             }
-            debug("worker_wait: %d workers left", _num_threads - _num_finished);
         }
-
-        while (_wait_flag)
+        if (dispatched)
         {
-            debug("worker_wait: worker waiting on _worker_cond with "
-                  "_worker_mutex");
-            wait_cond(_worker_cond, _worker_mutex);
-            debug("worker_wait: worker awoke");
+            debug("internal_dispatch: job dispatched");
+            m_queue_cond.notify_one();
         }
 
-        _wait_flag = true;
-        _num_finished--;
-        unlock(_worker_mutex);
-
-        debug("worker_wait: worker done waiting, _worker_mutex unlocked");
-    }
-
-    void thread_group::worker_jump()
-    {
-        if (running())
-        {
-            lock(_control_mutex);
-            debug("worker_jump: worker loading jump point, recall %d", _recall);
-
-            if (_recall)
-            {
-                _recall = false;
-
-                thread_function savedFunc = (thread_function)pthread_getspecific(_funcKey);
-                void* savedData = pthread_getspecific(_dataKey);
-
-                if (savedFunc)
-                {
-                    //  We want to just awaken this thread, using the func
-                    //  and data that were originally given it by dispatch.
-                    //  So recall them from thread-specific data.
-                    //
-                    _func = savedFunc;
-                    _data = savedData;
-                    debug("worker_jump: re-using data %x", _data);
-                }
-                else
-                {
-                    //  An attempt was made to awaken this thread before
-                    //  it was run the first time, so go back to sleep.
-                    //
-                    debug("worker_jump: worker returning to wait");
-                    signal(_control_cond);
-                    unlock(_control_mutex);
-                    return;
-                }
-            }
-            else
-            {
-                //  This is the first time we've dispatched this thread, so
-                //  store func/data for future awakenings.
-                //
-                pthread_setspecific(_funcKey, (void*)_func);
-                pthread_setspecific(_dataKey, _data);
-                debug("worker_jump: setting data %x", _data);
-            }
-
-            thread_function func = _func;
-            void* data = _data;
-            // assert(_dispatching);
-            assert(_func);
-            _func = 0;
-            _data = 0;
-
-            debug("worker_jump: worker signaling control");
-            signal(_control_cond);
-            unlock(_control_mutex);
-
-            debug("worker_jump: worker jumping");
-
-            try
-            {
-                (*func)(data);
-            }
-            catch (...)
-            {
-                debug("worker caught C++ exception");
-            }
-
-            debug("worker_jump: worker finished, returning to wait");
-        }
-        else
-        {
-            lock(_control_mutex);
-            _num_threads--;
-            _func = 0;
-            _join_thread = pthread_self();
-            debug("worker_jump: worker decremented, num_threads is now %d. "
-                  "_control_mutex locked",
-                  _num_threads);
-            debug("worker_jump: worker signaling _control_cond");
-            signal(_control_cond);
-            unlock(_control_mutex);
-            debug("worker_jump: worker exiting, _control_mutex unlocked");
-        }
-    }
-
-    void thread_group::worker_cleanup()
-    {
-        lock(_worker_mutex);
-        _wait_flag = false;
-        unlock(_worker_mutex);
-        worker_wait();
-
-        lock(_control_mutex);
-        _num_threads--;
-        _join_thread = pthread_self();
-        debug("worker_cleanup: worker decremented, num_threads is now %d, "
-              "_control_mutex locked",
-              _num_threads);
-        debug("worker_cleanup: worker signaling _control_cond");
-        signal(_control_cond);
-        unlock(_control_mutex);
-        debug("worker_cleanup: worker finishing, _control_mutex unlocked");
-    }
-
-    void thread_group::dispatch(thread_group::thread_function func, void* data)
-    {
-        debug("dispatch: control dispatching worker, func %p", func);
-
-        if (_num_finished == 0 && running())
-        {
-            debug("dispatch: control: thread_group: can't dispatch: no idle "
-                  "workers");
-            //
-            //  There's nothing to do, no need to abort() ...
-            //  abort();
-            //
-            return;
-        }
-
-        lock(_control_mutex);
-
-        _dispatching = true;
-        assert(_func == 0);
-
-        if (!func)
-        {
-            //
-            //  This will tell the worker to recall it's original func/data.
-            //
-            debug("dispatch: worker recall original stuff %p %p", _func, _data);
-            _recall = true;
-
-            //  We need to set _func to something, so that the wait
-            //  loop below functions as intended.
-            //
-            _func = (thread_function)0xdeadc0de;
-            _data = 0;
-        }
-        else
-        {
-            _recall = false;
-            _func = func;
-            _data = data;
-        }
-        release_worker();
-        debug("dispatch: control waiting for worker to load");
-
-        while (_func)
-        {
-            wait_cond(_control_cond, _control_mutex);
-        }
-
-        debug("dispatch: control done waiting for worker to dispatch");
-        _dispatching = false;
-        unlock(_control_mutex);
-    }
-
-    bool thread_group::maybe_dispatch(thread_group::thread_function func, void* data, bool async)
-    {
-        bool ret = false;
-        debug("control maybe dispatching worker num_finished %d", _num_finished);
-
-        lock(_control_mutex);
-
-        lock(_worker_mutex);
-        bool workersWaiting = (0 != _num_finished);
-        unlock(_worker_mutex);
-
-        if (workersWaiting && _func == 0)
-        {
-            _dispatching = true;
-            if (!func)
-            {
-                //
-                //  This will tell the worker to recall it's original func/data.
-                //
-                _recall = true;
-
-                //  We need to set _func to something, so that the wait
-                //  loop below functions as intended.
-                //
-                _func = (thread_function)0xdeadc0de;
-                _data = 0;
-            }
-            else
-            {
-                _recall = false;
-                _func = func;
-                _data = data;
-            }
-            release_worker();
-            debug("control waiting for worker to load");
-
-            while (!async && _func)
-            {
-                wait_cond(_control_cond, _control_mutex);
-            }
-
-            debug("control done waiting for worker to dispatch");
-            _dispatching = false;
-            ret = true;
-        }
-
-        unlock(_control_mutex);
-        return ret;
+        return dispatched;
     }
 
     void thread_group::awaken_all_workers()
     {
-        debug("control awakening workers");
-
-        //
-        //  We'll check again in loop below with proper locking, but can bail
-        //  now if all threads are busy.
-        //
-        if (_num_finished == 0)
-            return;
-
-        //
-        //  In theory, we could sit here forever, awakening worker
-        //  threads that immediately sleep again.  So don't try more
-        //  times than we have threads.
-        //
-        int attemptCount = _num_threads;
-        bool workersWaiting;
-
-        do
         {
-            ////////////////////////////////////////////////////////
-            //
-            //  Deadlock danger.  Note that if someone else locks
-            //  these mutexs in the opposite order, we have a
-            //  possible deadlock.
-            //
-            //  But we (and dispatch and redispatch) are already
-            //  two-level locking in this order, since
-            //  release_worker will lock _worker_mutex while
-            //  _control_mutex is locked (see below).
-            //
-            //  Further, if we don't do this, and release
-            //  _worker_mutex before we lock _control_mutex, there
-            //  is a danger that _num_finished will drop to 0 after
-            //  we release _worker_mutex, so there will be no
-            //  workers in worker_wait when we call wait_cond below,
-            //  in which case it will block until a worker enters
-            //  worker_wait, which could take forever.
-            //
-            ////////////////////////////////////////////////////////
-
-            lock(_control_mutex);
-
-            lock(_worker_mutex);
-            workersWaiting = (0 != _num_finished);
-            unlock(_worker_mutex);
-
-            if (workersWaiting)
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            while (m_num_jobs < m_num_threads)
             {
-                if (_func != 0)
-                {
-                    unlock(_control_mutex);
-                    return;
-                }
-                _dispatching = true;
-
-                //  This will tell the worker to recall it's original func/data.
-                //
-                _recall = true;
-
-                //  We need to set _func to something, so that the wait
-                //  loop below functions as intended.
-                //
-                _func = (thread_function)0xdeadc0de;
-
-                release_worker();
-
-                debug("control waiting for awakened worker to load");
-                while (_func)
-                {
-                    wait_cond(_control_cond, _control_mutex);
-                }
-                debug("control done waiting for worker to reawaken");
-
-                _dispatching = false;
+                m_job_queue.push(Job{nullptr, nullptr, true});
+                m_num_jobs++;
             }
-            unlock(_control_mutex);
-        } while (workersWaiting && --attemptCount);
+            m_queue_cond.notify_all();
+        }
+        debug("awaken_all_workers: recall jobs enqueued");
     }
-
 } // namespace stl_ext

--- a/src/lib/image/MovieFB/MovieFBWriter.cpp
+++ b/src/lib/image/MovieFB/MovieFBWriter.cpp
@@ -22,6 +22,9 @@
 #include <stl_ext/thread_group.h>
 #include <limits>
 #include <math.h>
+#include <chrono>
+#include <mutex>
+#include <condition_variable>
 
 namespace TwkMovie
 {
@@ -92,15 +95,12 @@ namespace TwkMovie
     {
     public:
         WriteTaskManager(int size);
-        ~WriteTaskManager();
 
         const WriteTask& taskByIndex(int index);
         void finishTask(int index);
         int nextReadyTaskIndex();
         void addTask(WriteTask& t);
         void waitAll();
-        void lock();
-        void unlock();
         void threadMain(int threadNumber);
         void dispatchThreads();
 
@@ -124,8 +124,8 @@ namespace TwkMovie
     private:
         vector<WriteTask> tasks;
         stl_ext::thread_group threadGroup;
-        pthread_mutex_t managerLock;
-        pthread_cond_t waitCond;
+        std::mutex managerLock;
+        std::condition_variable waitCond;
         vector<ThreadData> threadData;
 
         // Indicates that a task is currently being added when non 0
@@ -141,26 +141,13 @@ namespace TwkMovie
 
         for (int i = 0; i < size; ++i)
             threadData.push_back(ThreadData(this, i));
-
-        pthread_mutex_init(&managerLock, 0);
-        pthread_cond_init(&waitCond, 0);
     }
-
-    WriteTaskManager::~WriteTaskManager()
-    {
-        pthread_mutex_destroy(&managerLock);
-        pthread_cond_destroy(&waitCond);
-    }
-
-    void WriteTaskManager::lock() { threadGroup.lock(managerLock); }
-
-    void WriteTaskManager::unlock() { threadGroup.unlock(managerLock); }
 
     int WriteTaskManager::nextReadyTaskIndex()
     {
         int ret = NO_MORE_TASKS;
 
-        lock();
+        std::lock_guard<std::mutex> guard(managerLock);
         for (int i = 0; i < tasks.size(); ++i)
         {
             if (tasks[i].state == WriteTask::Ready)
@@ -174,7 +161,6 @@ namespace TwkMovie
         {
             ret = A_TASK_IS_CURRENTLY_BEING_ADDED;
         }
-        unlock();
 
         DB("nextReadyTaskIndex " << ret);
 
@@ -185,20 +171,19 @@ namespace TwkMovie
     {
         DB("finishTask " << index);
 
-        lock();
+        {
+            std::lock_guard<std::mutex> guard(managerLock);
 
-        //
-        //  Mark task complete
-        //
-        tasks[index].state = WriteTask::Finished;
+            //
+            //  Mark task complete
+            //
+            tasks[index].state = WriteTask::Finished;
 
-        //
-        //  Signal main thread that there's room for more tasks
-        //
-        stl_ext::thread_group::signal(waitCond);
-
-        unlock();
-
+            //
+            //  Signal main thread that there's room for more tasks
+            //
+        }
+        waitCond.notify_one();
         DB("finishTask " << index << " complete");
     }
 
@@ -258,13 +243,14 @@ namespace TwkMovie
     {
         bool addedTask = false;
 
-        lock();
-        currentlyAddingATask++;
-        unlock();
+        {
+            std::lock_guard<std::mutex> guard(managerLock);
+            currentlyAddingATask++;
+        }
 
         while (!addedTask)
         {
-            lock();
+            std::unique_lock<std::mutex> lock(managerLock);
 
             for (int i = 0; i < tasks.size(); ++i)
             {
@@ -284,8 +270,8 @@ namespace TwkMovie
                 //  Wait for worker thread to signal that there's room for more
                 //  tasks
                 //
-                static const size_t waitCondTimeOutInSecs = 5;
-                if (!stl_ext::thread_group::wait_cond_time(waitCond, managerLock, waitCondTimeOutInSecs * 1e6))
+                auto timeout = std::chrono::seconds(5);
+                if (waitCond.wait_for(lock, timeout) == std::cv_status::timeout)
                 {
                     DB("addTask waiting-timed out");
 
@@ -302,15 +288,14 @@ namespace TwkMovie
                     dispatchThreads();
                 }
             }
-
-            unlock();
         }
 
         dispatchThreads();
 
-        lock();
-        currentlyAddingATask--;
-        unlock();
+        {
+            std::lock_guard<std::mutex> guard(managerLock);
+            currentlyAddingATask--;
+        }
     }
 
     void WriteTaskManager::dispatchThreads()

--- a/src/lib/image/TwkMovie/Movie.cpp
+++ b/src/lib/image/TwkMovie/Movie.cpp
@@ -15,7 +15,6 @@
 #include <libswresample/swresample.h>
 #include <pthread.h>
 #include <stl_ext/stl_ext_algo.h>
-#include <stl_ext/thread_group.h>
 #include <string>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/lib/image/TwkMovie/ThreadedMovie.cpp
+++ b/src/lib/image/TwkMovie/ThreadedMovie.cpp
@@ -60,10 +60,6 @@ namespace TwkMovie
         }
     }
 
-    void ThreadedMovie::lock() { m_mapLock.lock(); }
-
-    void ThreadedMovie::unlock() { m_mapLock.unlock(); }
-
     void ThreadedMovie::threadMain()
     {
         const size_t threads = m_threadGroup.num_threads();
@@ -124,64 +120,69 @@ namespace TwkMovie
 
         do
         {
-            lock();
-            const size_t current = m_currentIndex;
-            const size_t requested = m_requestIndex;
+            size_t current, requested;
+            int frame;
+            bool exists;
 
-            if (current - requested < threads * 2 && current < m_frames.size())
             {
-                //
-                //  Bump the current index for the next thread
-                //
+                std::lock_guard<std::mutex> guard(m_mapLock);
+                current = m_currentIndex;
+                requested = m_requestIndex;
 
-                m_currentIndex++;
-                const int frame = m_frames[current];
-                bool exists = m_map.count(frame) > 0;
-                unlock();
-
-                if (!exists)
+                if (current - requested < threads * 2 && current < m_frames.size())
                 {
-                    td->request.frame = frame;
-                    td->request.missing = false;
-                    FrameBufferVector fbs;
+                    //
+                    //  Bump the current index for the next thread
+                    //
 
-                    try
-                    {
-                        // cout << "thread " << td->id << " @ frame " <<
-                        // td->request.frame << endl;
-                        td->movie->imagesAtFrame(td->request, fbs);
-                    }
-                    catch (std::exception& exc)
-                    {
-                        cerr << "WARNING: an exception was raised evaluting "
-                                "frame "
-                             << frame << ":" << endl;
-                        cerr << exc.what() << endl;
-                        unlock();
-                        break;
-                    }
-
-                    lock();
-                    m_map[frame] = fbs;
-                    unlock();
+                    m_currentIndex++;
+                    frame = m_frames[current];
+                    exists = m_map.count(frame) > 0;
                 }
                 else
                 {
-                    // cout << "thread " << td->id << " @ frame " <<
-                    // td->request.frame
-                    //<< " already in cache"
+                    // cout << "thread " << td->id << " finished, current = " <<
+                    // current
+                    //<< ", requested = " << requested
                     //<< endl;
+                    break;
+                }
+            }
+
+            if (!exists)
+            {
+                td->request.frame = frame;
+                td->request.missing = false;
+                FrameBufferVector fbs;
+
+                try
+                {
+                    // cout << "thread " << td->id << " @ frame " <<
+                    // td->request.frame << endl;
+                    td->movie->imagesAtFrame(td->request, fbs);
+                }
+                catch (std::exception& exc)
+                {
+                    cerr << "WARNING: an exception was raised evaluting "
+                            "frame "
+                         << frame << ":" << endl;
+                    cerr << exc.what() << endl;
+                    break;
+                }
+
+                {
+                    std::lock_guard<std::mutex> guard(m_mapLock);
+                    m_map[frame] = std::move(fbs);
                 }
             }
             else
             {
-                unlock();
-                // cout << "thread " << td->id << " finished, current = " <<
-                // current
-                //<< ", requested = " << requested
+                // cout << "thread " << td->id << " @ frame " <<
+                // td->request.frame
+                //<< " already in cache"
                 //<< endl;
-                break;
             }
+
         } while (1);
 
         bool allFramesDone;
@@ -246,13 +247,15 @@ namespace TwkMovie
 
         int frame = request.frame;
         const size_t n = m_threadGroup.num_threads();
+        size_t current, requested;
 
         dispatchAll();
 
-        lock();
-        size_t current = m_currentIndex;
-        size_t requested = m_requestIndex;
-        unlock();
+        {
+            std::lock_guard<std::mutex> guard(m_mapLock);
+            current = m_currentIndex;
+            requested = m_requestIndex;
+        }
 
 #if 0
     if (frame != m_frames[requested])
@@ -266,18 +269,23 @@ namespace TwkMovie
 
         for (size_t count = 0; true; count++)
         {
-            lock();
-            FBMap::iterator i = m_map.find(frame);
-            FBMap::iterator e = m_map.end();
-            unlock();
-
-            if (i != e)
+            bool found = false;
             {
-                fbs = i->second;
-                lock();
-                m_map.erase(i);
-                // cout << "consumed frame " << frame << endl;
-                unlock();
+                std::lock_guard<std::mutex> guard(m_mapLock);
+                FBMap::iterator i = m_map.find(frame);
+                FBMap::iterator e = m_map.end();
+
+                if (i != e)
+                {
+                    fbs = i->second;
+                    m_map.erase(i);
+                    // cout << "consumed frame " << frame << endl;
+                    found = true;
+                }
+            }
+
+            if (found)
+            {
                 dispatchAll();
                 break;
             }
@@ -299,9 +307,10 @@ namespace TwkMovie
             }
         }
 
-        lock();
-        m_requestIndex++;
-        unlock();
+        {
+            std::lock_guard<std::mutex> guard(m_mapLock);
+            m_requestIndex++;
+        }
     }
 
     void ThreadedMovie::identifiersAtFrame(const ReadRequest& request, IdentifierVector& ids)

--- a/src/lib/image/TwkMovie/ThreadedMovie.cpp
+++ b/src/lib/image/TwkMovie/ThreadedMovie.cpp
@@ -33,8 +33,6 @@ namespace TwkMovie
         // if (!m_movie->isThreadSafe()) throw runtime_exception();
         m_info = movies.front()->info();
         m_threadSafe = false;
-        pthread_mutex_init(&m_mapLock, 0);
-        pthread_mutex_init(&m_runLock, 0);
         m_threadData.resize(movies.size());
 
         for (size_t i = 0; i < m_threadData.size(); i++)
@@ -60,13 +58,11 @@ namespace TwkMovie
             for (size_t q = 0; q < i->second.size(); q++)
                 delete i->second[q];
         }
-
-        pthread_mutex_destroy(&m_mapLock);
     }
 
-    void ThreadedMovie::lock() { m_threadGroup.lock(m_mapLock); }
+    void ThreadedMovie::lock() { m_mapLock.lock(); }
 
-    void ThreadedMovie::unlock() { m_threadGroup.unlock(m_mapLock); }
+    void ThreadedMovie::unlock() { m_mapLock.unlock(); }
 
     void ThreadedMovie::threadMain()
     {
@@ -83,45 +79,45 @@ namespace TwkMovie
         ThreadData* td = 0;
         pthread_t self = pthread_self();
 
-        m_threadGroup.lock(m_runLock);
-
-        //
-        //  If we already have a ThreadData for this thread use it
-        //
-
-        for (size_t i = 0; !td && i < m_threadData.size(); i++)
         {
-            ThreadData& d = m_threadData[i];
+            std::lock_guard<std::mutex> guard(m_runLock);
 
-            if (d.init && pthread_equal(d.thread, self))
+            //
+            //  If we already have a ThreadData for this thread use it
+            //
+
+            for (size_t i = 0; !td && i < m_threadData.size(); i++)
             {
-                d.running = true;
-                td = &d;
+                ThreadData& d = m_threadData[i];
+
+                if (d.init && pthread_equal(d.thread, self))
+                {
+                    d.running = true;
+                    td = &d;
+                }
+            }
+
+            //
+            //  If we don't have a ThreadData find an available one and use
+            //  that
+            //
+
+            bool first = false;
+
+            for (size_t i = 0; !td && i < m_threadData.size(); i++)
+            {
+                ThreadData& d = m_threadData[i];
+
+                if (!d.init)
+                {
+                    d.init = true;
+                    first = true;
+                    d.thread = self;
+                    d.running = true;
+                    td = &d;
+                }
             }
         }
-
-        //
-        //  If we don't have a ThreadData find an available one and use
-        //  that
-        //
-
-        bool first = false;
-
-        for (size_t i = 0; !td && i < m_threadData.size(); i++)
-        {
-            ThreadData& d = m_threadData[i];
-
-            if (!d.init)
-            {
-                d.init = true;
-                first = true;
-                d.thread = self;
-                d.running = true;
-                td = &d;
-            }
-        }
-
-        m_threadGroup.unlock(m_runLock);
 
         if (m_initialize)
             m_initialize();
@@ -188,12 +184,12 @@ namespace TwkMovie
             }
         } while (1);
 
-        m_threadGroup.lock(m_runLock);
-        td->running = false;
-
-        bool allFramesDone = (m_currentIndex >= m_frames.size());
-
-        m_threadGroup.unlock(m_runLock);
+        bool allFramesDone;
+        {
+            std::lock_guard<std::mutex> guard(m_runLock);
+            td->running = false;
+            allFramesDone = (m_currentIndex >= m_frames.size());
+        }
 
         if (allFramesDone && m_finalize != nullptr)
         {

--- a/src/lib/image/TwkMovie/TwkMovie/ThreadedMovie.h
+++ b/src/lib/image/TwkMovie/TwkMovie/ThreadedMovie.h
@@ -12,6 +12,7 @@
 #include <TwkMovie/dll_defs.h>
 #include <stl_ext/thread_group.h>
 #include <map>
+#include <mutex>
 
 namespace TwkMovie
 {
@@ -98,8 +99,8 @@ namespace TwkMovie
         Movies m_movies;
         ThreadGroup m_threadGroup;
         FBMap m_map;
-        pthread_mutex_t m_mapLock;
-        pthread_mutex_t m_runLock;
+        std::mutex m_mapLock;
+        std::mutex m_runLock;
         Frames m_frames;
         ThreadDataVector m_threadData;
         int m_currentIndex;

--- a/src/lib/image/TwkMovie/TwkMovie/ThreadedMovie.h
+++ b/src/lib/image/TwkMovie/TwkMovie/ThreadedMovie.h
@@ -76,25 +76,6 @@ namespace TwkMovie
 
         void dispatchAll();
 
-    protected:
-        void lock();
-        void unlock();
-
-        struct Lock
-        {
-            Lock(ThreadedMovie* m)
-                : movie(m)
-            {
-                movie->lock();
-            }
-
-            ~Lock() { movie->unlock(); }
-
-            ThreadedMovie* movie;
-        };
-
-        friend class ThreadedMovie::Lock;
-
     private:
         Movies m_movies;
         ThreadGroup m_threadGroup;

--- a/src/lib/ip/IPCore/IPCore/Session.h
+++ b/src/lib/ip/IPCore/IPCore/Session.h
@@ -24,6 +24,7 @@
 #include <boost/signals2.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
+#include <stl_ext/thread_group.h>
 
 namespace IPCore
 {

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -2741,7 +2741,7 @@ IPGraph::findNodesByAbstractPath(int frame,
 
         if (ok)
         {
-            m_audioThreadGroup.maybe_dispatch(evalAudioThreadTrampoline, this, true);
+            m_audioThreadGroup.maybe_dispatch(evalAudioThreadTrampoline, this);
         }
     }
 

--- a/src/lib/mu/Mu/Mu/Thread.h
+++ b/src/lib/mu/Mu/Mu/Thread.h
@@ -349,9 +349,6 @@ namespace Mu
 
         void setProcess(Process* p) { _process = p; }
 
-        void* threadState();
-        size_t threadStateSize();
-
     private:
         Process* _process;
         const Node* _rootNode;
@@ -370,7 +367,6 @@ namespace Mu
         StackPointer _bottomOfStack;
         bool _applicationThread;
         bool _suspended;
-        size_t* _threadState;
         const Node* _continuation;
 
         pthread_mutex_t _controlMutex;

--- a/src/lib/mu/Mu/Thread.cpp
+++ b/src/lib/mu/Mu/Thread.cpp
@@ -80,18 +80,9 @@ namespace Mu
         , _continuation(0)
         , _applicationThread(appthread)
         , _returnValueType(0)
-        , _threadState(0)
     {
         GarbageCollector::init();
         _stack.reserve(_stackCapacity);
-
-#ifdef PLATFORM_DARWIN
-        _threadState = new size_t[sizeof(DARWIN_THREAD_STATE)];
-#endif
-
-#ifdef PLATFORM_LINUX
-        _threadState = (size_t*)(new ucontext_t);
-#endif
 
         if (isApplicationThread())
         {
@@ -130,14 +121,6 @@ namespace Mu
 
         _process->removeThread(this);
         _process = 0;
-
-#ifdef PLATFORM_DARWIN
-        delete[] _threadState;
-#endif
-
-#ifdef PLATFORM_LINUX
-        delete _threadState;
-#endif
     }
 
     void* Thread::trampoline(void* arg)
@@ -486,45 +469,6 @@ namespace Mu
 #endif
 #endif
         }
-    }
-
-    void* Thread::threadState()
-    {
-#ifdef PLATFORM_DARWIN
-        if (_alive)
-        {
-            mach_msg_type_number_t thread_state_count = DARWIN_THREAD_STATE_COUNT;
-            kern_return_t krc;
-            if ((krc = thread_get_state(pthread_mach_thread_np(_id), // <-- can't use self here
-                                        DARWIN_THREAD_STATE, (natural_t*)_threadState, &thread_state_count))
-                != KERN_SUCCESS)
-            {
-                return _threadState;
-            }
-            else
-            {
-                cerr << "Thread::threadState(): error obtaining thread state" << endl;
-            }
-        }
-#endif
-
-        return 0;
-    }
-
-    size_t Thread::threadStateSize()
-    {
-#if 0
-#ifdef PLATFORM_DARWIN
-    return sizeof(darwin_thread_state);
-#endif
-
-#ifdef PLATFORM_LINUX
-    return sizeof(ucontext);
-#endif
-
-#endif
-        /* AJG - baaaaad ! */
-        return sizeof(int);
     }
 
     void Thread::jump(int returnValue, int n, Value v)

--- a/src/plugins/output/BlackMagicDevices/BlackMagicDevices/DeckLinkVideoDevice.h
+++ b/src/plugins/output/BlackMagicDevices/BlackMagicDevices/DeckLinkVideoDevice.h
@@ -29,7 +29,6 @@
 
 #include <TwkGLF/GLFBO.h>
 #include <TwkGLF/GLFence.h>
-#include <stl_ext/thread_group.h>
 #include <deque>
 #include <BlackMagicDevices/StereoVideoFrame.h>
 
@@ -96,7 +95,6 @@ namespace BlackMagicDevices
         using GLFence = TwkGLF::GLFence;
         using GLFBO = TwkGLF::GLFBO;
         using BufferVector = std::vector<unsigned char*>;
-        using ThreadGroup = stl_ext::thread_group;
         using AudioBuffer = std::vector<int>;
         using StereoFrameMap = std::map<IDeckLinkMutableVideoFrame*, std::unique_ptr<StereoVideoFrame::Provider>>;
         using DLVideoFrameDeque = std::deque<IDeckLinkMutableVideoFrame*>;

--- a/src/plugins/output/NDI/NDI/NDIVideoDevice.h
+++ b/src/plugins/output/NDI/NDI/NDIVideoDevice.h
@@ -35,7 +35,6 @@
 #include <Processing.NDI.Lib.h>
 
 #include <iostream>
-#include <stl_ext/thread_group.h>
 #include <deque>
 
 namespace NDI


### PR DESCRIPTION
### Summarize your change.

Replace Boost threading primitives (`boost::mutex`, `boost::thread_group`, raw pthreads) with C++ standard library equivalents (`std::mutex`, `std::thread`, `std::lock_guard`, `std::condition_variable`). Also fix two issues identified by sanitizers: remove unused `threadState` code (AddressSanitizer new-delete-type-mismatch) and defer thread start in `TwkMediaLibrary` until after construction (ThreadSanitizer data race).

### Describe the reason for the change.

The Boost threading wrappers add unnecessary complexity and dependencies. The `stl_ext::thread_group` implementation used raw pthreads with manual mutex/cond management and a complex worker dispatch model. Replacing it with `std::thread`, `std::queue`, and `std::condition_variable` simplifies the code significantly (net reduction of ~600 lines) and removes platform-specific timing code. The two bug fixes address real issues found by AddressSanitizer and ThreadSanitizer.

### Describe what you have tested and on which operating system.

Tested on Rocky Linux 9.

### Add a list of changes, and note any that might need special attention during the review.

- `Thread.h` / `Thread.cpp`: Remove unused `threadState` code flagged by AddressSanitizer.
- `Library.h` / `Library.cpp`: Defer thread start until after construction; remove `threadTrampoline` wrapper.
- `ALSAAudioRenderer.h/.cpp`, `ALSASafeAudioRenderer.h/.cpp`: Replace `boost::mutex` with `std::mutex`.
- `ThreadedMovie.h/.cpp`: Replace `boost::mutex` with `std::mutex` and adopt `std::lock_guard`. Fixes `m_runLock` not being destroyed previously.
- `MovieFBWriter.cpp`: Replace `boost::mutex` with `std::mutex`.
- `thread_group.h` / `thread_group.cpp`: Rewrite to use `std::thread`, `std::queue`, `std::mutex`, `std::condition_variable`. Remove raw pthreads, `cancel()`, and platform-specific timing. Net reduction of ~600 lines.
- Various `main.cpp` files: Remove unused `boost::thread_group` includes.
