### PR TITLE
fix: hang when movie plugins invoke python

### DIFF
--- a/src/lib/app/RvApp/RvSession.cpp
+++ b/src/lib/app/RvApp/RvSession.cpp
@@ -6,6 +6,7 @@
 //
 //
 #include <RvApp/CommandsModule.h>
+#include <Python.h>
 #include <RvApp/Options.h>
 #include <RvApp/RvNodeDefinitions.h>
 #include <RvApp/RvSession.h>
@@ -243,6 +244,22 @@ namespace Rv
             //          new Shader::Function -> initGLSLVersion() -> glGetString
             //          -> crashes because no context
             IPCore::Application::instance()->loadOptionNodeDefinitions();
+
+            // Set TwkMovie's blocking callbacks to release (and re-acquire) the Python GIL while it waits for its
+            // plugins to initialize in separate threads. If any of them need Python, they will try to acquire the
+            // GIL and deadlock with the main thread.
+            //
+            thread_local PyThreadState* preloadGilState = nullptr;
+            TwkMovie::GenericIO::setBlockingWaitCallbacks([]() { preloadGilState = PyGILState_Check() ? PyEval_SaveThread() : nullptr; },
+                                                          []()
+                                                          {
+                                                              if (preloadGilState)
+                                                              {
+                                                                  PyEval_RestoreThread(preloadGilState);
+                                                                  preloadGilState = nullptr;
+                                                              }
+                                                          });
+
             firstTime = false;
         }
 

--- a/src/lib/image/TwkMovie/MovieIO.cpp
+++ b/src/lib/image/TwkMovie/MovieIO.cpp
@@ -212,8 +212,14 @@ namespace TwkMovie
         if (reader->isFinishedLoading())
             return;
 
+        if (GenericIO::m_onBlockingWaitRelease)
+            GenericIO::m_onBlockingWaitRelease();
+
         std::unique_lock<std::mutex> lock(m_mainThread_mutex);
         m_mainThread_cv.wait(lock, [&reader] { return reader->isFinishedLoading(); });
+
+        if (GenericIO::m_onBlockingWaitAcquire)
+            GenericIO::m_onBlockingWaitAcquire();
     }
 
     MovieReader* GenericIO::Preloader::getReader(std::string_view filename, const MovieInfo& info, Movie::ReadRequest& request)
@@ -534,6 +540,14 @@ namespace TwkMovie
     bool GenericIO::m_loadedAll = false;
     bool GenericIO::m_dnxhdDecodingAllowed = true;
     GenericIO::Preloader GenericIO::m_preloader;
+    GenericIO::WaitCallback GenericIO::m_onBlockingWaitRelease;
+    GenericIO::WaitCallback GenericIO::m_onBlockingWaitAcquire;
+
+    void GenericIO::setBlockingWaitCallbacks(WaitCallback onRelease, WaitCallback onAcquire)
+    {
+        m_onBlockingWaitRelease = std::move(onRelease);
+        m_onBlockingWaitAcquire = std::move(onAcquire);
+    }
 
     void GenericIO::init()
     {

--- a/src/lib/image/TwkMovie/TwkMovie/MovieIO.h
+++ b/src/lib/image/TwkMovie/TwkMovie/MovieIO.h
@@ -414,6 +414,21 @@ namespace TwkMovie
         static void init();
 
         ///
+        ///  Optional callbacks invoked in Preloader::waitForFinishedLoading
+        ///  immediately before and after the blocking condition variable wait.
+        ///
+        ///  Applications that hold resouces they shared with workers (e.g. Python's
+        ///  GIL) should set these to release their lock before the wait and reacquire
+        ///  it afterward, so that background threads can avoid deadlocking the main thread
+        ///  when they access the shared resources.
+        ///
+        ///  Both callbacks default to nullptr (no-op).
+        ///
+
+        using WaitCallback = std::function<void()>;
+        static void setBlockingWaitCallbacks(WaitCallback onRelease, WaitCallback onAcquire);
+
+        ///
         ///  Shutdown and free generic movieio plugins.
         ///  This needs to be called in the application main thread in main.
         ///
@@ -539,6 +554,8 @@ namespace TwkMovie
         static bool m_loadedAll;
         static bool m_dnxhdDecodingAllowed;
         static Preloader m_preloader;
+        static WaitCallback m_onBlockingWaitRelease;
+        static WaitCallback m_onBlockingWaitAcquire;
     };
 
 } // namespace TwkMovie

--- a/src/lib/image/TwkMovie/TwkMovie/MovieIO.h
+++ b/src/lib/image/TwkMovie/TwkMovie/MovieIO.h
@@ -17,6 +17,7 @@
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <functional>
 
 #include <TwkFB/FrameBuffer.h>
 #include <TwkFB/IO.h>


### PR DESCRIPTION
### Fix deadlock when MovieIO Plugins invoke Python

### Summarize your change.
If a plugin in the MovieIO plugin folder invokes Python in its initialization, a deadlock will occur.  This is because the main thread is holding the GIL (global interpreter lock) when the plugins are initialized (in their own threads). If any of these plugins uses Python it will wait on the GIL held by the main thread, which is waiting on its preloader threads to terminate so deadlock will occur.

The cleanest fix for this is to pass callbacks to MovieIO to avoid introducing a Python dependency in it. We'll add one callback to release any resources (optional) and another to re-acquire them (optional). Then we'll call these before and after our blocking wait on the preloader if they are set.

We'll set this in RvApp where we already initialize a bunch of other statics in RvSession. We'll use this to release the GIL (if we are holding it) and reacquire it (if we were holding it before). We'll use a `thread_local` variable for the GIL state to be correct, even though this shouldn't really ever be called outside of the main thread. 

### Describe the reason for the change.

To avoid deadlock when loading plugins.

### Describe what you have tested and on which operating system.
Mac OS 26.5.1

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.