### PR TITLE
fix: SG-43388: RV leaks memory because of opened decoders

### DIFF
--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -446,7 +446,7 @@ namespace TwkMovie
     //  Global pool object:
     //
 
-    ContextPool* globalContextPool = 0;
+    std::unique_ptr<ContextPool> globalContextPool{nullptr};
 
     void ContextPool::flushContext(MovieFFMpegReader* reader, int streamIndex)
     {
@@ -5959,7 +5959,7 @@ namespace TwkMovie
                 poolSize = atoi(c);
             }
             if (poolSize > 0)
-                globalContextPool = new ContextPool(poolSize);
+                globalContextPool = std::make_unique<ContextPool>(poolSize);
             else
             {
                 report("Disabling mio_ffmpeg context thread pool.", true);

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -5958,7 +5958,8 @@ namespace TwkMovie
             {
                 poolSize = atoi(c);
             }
-            if (poolSize > 0) globalContextPool = new ContextPool(poolSize);
+            if (poolSize > 0)
+                globalContextPool = new ContextPool(poolSize);
             else
             {
                 report("Disabling mio_ffmpeg context thread pool.", true);

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -539,9 +539,15 @@ namespace TwkMovie
                 avcodec_free_context(&closeContext.avContext);
 
                 if (closeContext.vTrack)
+                {
+                    closeContext.vTrack->avCodecContext = nullptr;
                     closeContext.vTrack->isOpen = false;
+                }
                 if (closeContext.aTrack)
+                {
+                    closeContext.aTrack->avCodecContext = nullptr;
                     closeContext.aTrack->isOpen = false;
+                }
             }
         }
     }
@@ -1154,11 +1160,11 @@ namespace TwkMovie
         for (unsigned int i = 0; i < m_audioTracks.size(); i++)
         {
             AudioTrack* track = m_audioTracks[i];
+            ContextPool::flushContext(this, track->number);
             if (track->isOpen)
             {
                 avcodec_free_context(&track->avCodecContext);
             }
-            ContextPool::flushContext(this, track->number);
             delete track;
         }
         m_audioTracks.resize(0);
@@ -1166,11 +1172,11 @@ namespace TwkMovie
         for (unsigned int i = 0; i < m_videoTracks.size(); i++)
         {
             VideoTrack* track = m_videoTracks[i];
+            ContextPool::flushContext(this, track->number);
             if (track->isOpen)
             {
                 avcodec_free_context(&track->avCodecContext);
             }
-            ContextPool::flushContext(this, track->number);
             delete track;
         }
         m_videoTracks.resize(0);
@@ -2741,7 +2747,8 @@ namespace TwkMovie
             audioChannels = idAudioChannels(layout, numChannels);
 
             // XXX Assume this thread will never decode audio
-            avcodec_free_context(&audioCodecContext);
+            ContextPool::flushContext(this, track->number);
+            avcodec_free_context(&track->avCodecContext);
             track->isOpen = false;
         }
 
@@ -5944,28 +5951,19 @@ namespace TwkMovie
             addType(formatsItr->first, formatsItr->second.first, formatsItr->second.second, video, audio, separams, sdparams);
         }
 
-        // Note : No longer using the global context pool (since FFmpeg 6.0)
-        // Rationale: The global context pool was based on the premise that a
-        // context could be opened and closed multiple times. However, with
-        // FFmpeg 6.0, this premise is no longer valid and was causing crashes.
-        // As per the FFmpeg 6 documentation:
-        // https://ffmpeg.org/doxygen/trunk/deprecated.html: "Opening and
-        // closing a codec context multiple times is not supported anymore – use
-        // multiple codec contexts instead."
-
-        // if (!globalContextPool)
-        // {
-        //     int poolSize = 500;
-        //     if (const char* c = getenv("TWK_MOVIEFFMPEG_CONTEXT_POOL_SIZE"))
-        //     {
-        //         int poolSize = atoi(c);
-        //     }
-        //     if (poolSize > 0) globalContextPool = new ContextPool(poolSize);
-        //     else
-        //     {
-        //         report("Disabling mio_ffmpeg context thread pool.", true);
-        //     }
-        // }
+        if (!globalContextPool)
+        {
+            int poolSize = 500;
+            if (const char* c = getenv("TWK_MOVIEFFMPEG_CONTEXT_POOL_SIZE"))
+            {
+                poolSize = atoi(c);
+            }
+            if (poolSize > 0) globalContextPool = new ContextPool(poolSize);
+            else
+            {
+                report("Disabling mio_ffmpeg context thread pool.", true);
+            }
+        }
     }
 
     MovieFFMpegIO::~MovieFFMpegIO()

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -2725,7 +2725,6 @@ namespace TwkMovie
             AVChannelLayout layout = audioCodecContext->ch_layout;
             audioChannels = idAudioChannels(layout, numChannels);
 
-            // XXX Assume this thread will never decode audio
             ContextPool::flushContext(this, track->number);
             avcodec_free_context(&track->avCodecContext);
             track->isOpen = false;

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -20,7 +20,6 @@
 #include <TwkUtil/PathConform.h>
 #include <TwkUtil/File.h>
 #include <TwkUtil/sgcHop.h>
-#include <cstddef>
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
@@ -413,7 +412,7 @@ namespace TwkMovie
         class Reservation
         {
         public:
-            Reservation(MovieFFMpegReader* reader, int streamIndex, VideoTrack* vTrack=nullptr, AudioTrack* aTrack=nullptr);
+            Reservation(MovieFFMpegReader* reader, int streamIndex);
             ~Reservation();
 
         private:
@@ -474,7 +473,7 @@ namespace TwkMovie
         gcp.m_contextMap.erase(i);
     }
 
-    ContextPool::Reservation::Reservation(MovieFFMpegReader* reader, int streamIndex, VideoTrack* vTrack, AudioTrack* aTrack)
+    ContextPool::Reservation::Reservation(MovieFFMpegReader* reader, int streamIndex)
         : m_context(0)
         , m_dbline(0)
         , m_dblline(0)
@@ -497,13 +496,6 @@ namespace TwkMovie
         context.reserved = true;
         context.reader = reader;
         context.streamIndex = streamIndex;
-
-        if (vTrack) {
-            context.vTrack = vTrack;
-        }
-        if (aTrack) {
-            context.aTrack = aTrack;
-        }
 
         //
         //  If it's already in the list move it to the front now.
@@ -592,6 +584,7 @@ namespace TwkMovie
         {
             AVStream* avStream = context.reader->m_avFormatContext->streams[context.streamIndex];
 
+            context.reader->trackFromStreamIndex(context.streamIndex, context.vTrack, context.aTrack);
             if (context.vTrack)
             {
                 context.avContext = context.vTrack->avCodecContext;
@@ -2323,14 +2316,15 @@ namespace TwkMovie
                 if (heroVideoTracks[i])
                 {
                     VideoTrack* track = new VideoTrack;
-                    ContextPool::Reservation reserve(this, i, track);
+                    ContextPool::Reservation reserve(this, i);
                     track->useOpenJPH = isJ2K;
 #if defined(RV_USE_APPLE_PRORES_SDK)
                     track->useAppleProRes = isProRes;
 #endif
                     if (isJ2K)
                     {
-                        if (openAVCodec(i, &track->avCodecContext, &track->hardwareContext)) {
+                        if (openAVCodec(i, &track->avCodecContext, &track->hardwareContext))
+                        {
                             track->number = i;
                             ostringstream trackName;
                             trackName << "track " << m_videoTracks.size() + 1;
@@ -2338,7 +2332,8 @@ namespace TwkMovie
                             track->isOpen = true;
                             m_videoTracks.push_back(track);
                         }
-                        else {
+                        else
+                        {
                             delete track;
                         }
                     }
@@ -2450,7 +2445,7 @@ namespace TwkMovie
                 if (heroAudioTracks[i])
                 {
                     AudioTrack* track = new AudioTrack;
-                    ContextPool::Reservation reserve(this, i, nullptr, track);
+                    ContextPool::Reservation reserve(this, i);
                     if (openAVCodec(i, &track->avCodecContext))
                     {
                         track->number = i;
@@ -3220,7 +3215,7 @@ namespace TwkMovie
             if (start < 0)
                 continue;
             AudioTrack* track = m_audioTracks[i];
-            ContextPool::Reservation reserve(this, track->number, nullptr, track);
+            ContextPool::Reservation reserve(this, track->number);
             track->isOpen = openAVCodec(track->number, &track->avCodecContext);
             if (!track->isOpen)
             {
@@ -4096,7 +4091,7 @@ namespace TwkMovie
         for (unsigned int i = 0; i < m_videoTracks.size(); i++)
         {
             VideoTrack* track = m_videoTracks[i];
-            ContextPool::Reservation reserve(this, track->number, track);
+            ContextPool::Reservation reserve(this, track->number);
             track->isOpen = openAVCodec(track->number, &track->avCodecContext, &track->hardwareContext);
             if (!track->isOpen)
             {

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -2508,7 +2508,7 @@ namespace TwkMovie
 
         // Capture video metadata information for the frame buffer attributes
         if (m_videoTracks.size() > 0) {
-            std::vector<ContextPool::Reservation> reservations;
+            std::list<ContextPool::Reservation> reservations;
 
             for (const auto* const &track: m_videoTracks)
             {
@@ -2546,7 +2546,7 @@ namespace TwkMovie
         // Capture audio metadata information for the frame buffer attributes
         if (m_audioTracks.size() > 0)
         {
-            std::vector<ContextPool::Reservation> reservations;
+            std::list<ContextPool::Reservation> reservations;
 
             for (const auto* const &track: m_audioTracks)
             {

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -2306,6 +2306,7 @@ namespace TwkMovie
 
         collectPlaybackTiming(heroVideoTracks, heroAudioTracks);
 
+        std::list<ContextPool::Reservation> reservations;
         for (int i = 0; i < m_avFormatContext->nb_streams; i++)
         {
             AVStream* tsStream = m_avFormatContext->streams[i];
@@ -2321,7 +2322,7 @@ namespace TwkMovie
                 if (heroVideoTracks[i])
                 {
                     VideoTrack* track = new VideoTrack;
-                    ContextPool::Reservation reserve(this, i);
+                    reservations.emplace_back(this, i);
                     track->useOpenJPH = isJ2K;
 #if defined(RV_USE_APPLE_PRORES_SDK)
                     track->useAppleProRes = isProRes;
@@ -2450,7 +2451,7 @@ namespace TwkMovie
                 if (heroAudioTracks[i])
                 {
                     AudioTrack* track = new AudioTrack;
-                    ContextPool::Reservation reserve(this, i);
+                    reservations.emplace_back(this, i);
                     if (openAVCodec(i, &track->avCodecContext))
                     {
                         track->number = i;
@@ -2501,14 +2502,8 @@ namespace TwkMovie
         m_info.uncropHeight = 120;
 
         // Capture video metadata information for the frame buffer attributes
-        if (m_videoTracks.size() > 0) {
-            std::list<ContextPool::Reservation> reservations;
-
-            for (const auto* const &track: m_videoTracks)
-            {
-                reservations.emplace_back(this, track->number);
-            }
-
+        if (m_videoTracks.size() > 0)
+        {
             initializeVideo(height, width);
         }
 
@@ -2540,12 +2535,6 @@ namespace TwkMovie
         // Capture audio metadata information for the frame buffer attributes
         if (m_audioTracks.size() > 0)
         {
-            std::list<ContextPool::Reservation> reservations;
-
-            for (const auto* const &track: m_audioTracks)
-            {
-                reservations.emplace_back(this, track->number);
-            }
             initializeAudio();
         }
         string hasAudio = string((m_audioTracks.size() > 0) ? "Yes" : "No");

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -1181,14 +1181,6 @@ namespace TwkMovie
         }
         m_videoTracks.resize(0);
 
-        for (map<int, int>::iterator i = m_subtitleMap.begin(); i != m_subtitleMap.end(); ++i)
-        {
-            if (i->second)
-                ContextPool::flushContext(this, i->first);
-            //  XXX We should be closing these streams too once we are opening
-            //  them
-        }
-
         if (m_avFormatContext)
             avformat_close_input(&m_avFormatContext);
     }
@@ -1258,7 +1250,6 @@ namespace TwkMovie
             }
             mov->m_timecodeTrack = m_timecodeTrack;
             mov->m_formatStartFrame = m_formatStartFrame;
-            mov->m_subtitleMap = m_subtitleMap;
             mov->m_multiTrackAudio = m_multiTrackAudio;
         }
         mov->m_cloning = false;
@@ -2324,21 +2315,25 @@ namespace TwkMovie
                 DBL(DB_METADATA, "Video Track: " << i);
                 if (heroVideoTracks[i])
                 {
-                    ContextPool::Reservation reserve(this, i);
                     VideoTrack* track = new VideoTrack;
+                    ContextPool::Reservation reserve(this, i);
                     track->useOpenJPH = isJ2K;
 #if defined(RV_USE_APPLE_PRORES_SDK)
                     track->useAppleProRes = isProRes;
 #endif
                     if (isJ2K)
                     {
-                        track->number = i;
-                        ostringstream trackName;
-                        trackName << "track " << m_videoTracks.size() + 1;
-                        track->name = trackName.str();
-                        track->isOpen = true;
-                        openAVCodec(i, &track->avCodecContext, &track->hardwareContext);
-                        m_videoTracks.push_back(track);
+                        if (openAVCodec(i, &track->avCodecContext, &track->hardwareContext)) {
+                            track->number = i;
+                            ostringstream trackName;
+                            trackName << "track " << m_videoTracks.size() + 1;
+                            track->name = trackName.str();
+                            track->isOpen = true;
+                            m_videoTracks.push_back(track);
+                        }
+                        else {
+                            delete track;
+                        }
                     }
 #if defined(RV_USE_APPLE_PRORES_SDK)
                     else if (isProRes)
@@ -2447,8 +2442,8 @@ namespace TwkMovie
                 DBL(DB_METADATA, "Audio Track: " << i);
                 if (heroAudioTracks[i])
                 {
-                    ContextPool::Reservation reserve(this, i);
                     AudioTrack* track = new AudioTrack;
+                    ContextPool::Reservation reserve(this, i);
                     if (openAVCodec(i, &track->avCodecContext))
                     {
                         track->number = i;
@@ -2476,16 +2471,6 @@ namespace TwkMovie
                 break;
             case AVMEDIA_TYPE_SUBTITLE:
                 DBL(DB_METADATA, "Subtitle Track: " << i);
-                {
-                    // TODO Need to allocate memory now in ffmpeg6
-                    // #if DB_LEVEL & DB_SUBTITLES
-                    //    ContextPool::Reservation reserve(this, i);
-                    //    if (openAVCodec(i))
-                    //    {
-                    //        m_subtitleMap[i] = 1;
-                    //    }
-                    // #endif
-                }
                 break;
             case AVMEDIA_TYPE_UNKNOWN:
             default:
@@ -2511,14 +2496,6 @@ namespace TwkMovie
         // Capture video metadata information for the frame buffer attributes
         if (m_videoTracks.size() > 0)
             initializeVideo(height, width);
-
-// Initialize subtitles
-#if DB_LEVEL & DB_SUBTITLES
-        if (m_subtitleMap.size() > 0)
-        {
-            m_info.proxy.newAttribute("SubtitleTracks", m_subtitleMap.size());
-        }
-#endif
 
         // Look for chapters
         m_info.chapters.resize(m_avFormatContext->nb_chapters);
@@ -2701,6 +2678,15 @@ namespace TwkMovie
 
         m_info.video = true;
     }
+    /*
+    context-> decoder
+
+    Each context has 1 Video track and/or 1 Audio track, 1 FFMPEG decoder
+
+
+    
+    
+    */
 
     void MovieFFMpegReader::initializeAudio()
     {
@@ -3595,13 +3581,6 @@ namespace TwkMovie
                     TWK_THROW_EXC_STREAM("av_read_frame failed in video stream.");
                 }
             }
-#if DB_LEVEL & DB_SUBTITLES
-            if (m_subtitleMap.find(track->videoPacket->stream_index) != m_subtitleMap.end()
-                && correctLang(track->videoPacket->stream_index))
-            {
-                readSubtitle(track);
-            }
-#endif
         } while ((track->videoPacket->stream_index != track->number) && !finalPacket);
 
         // If we get a valid timestamp here then we should add it to
@@ -4174,51 +4153,6 @@ namespace TwkMovie
 #endif
 
         DBL(DB_VIDEO, "Got a frame and buggin' out!!!\n");
-    }
-
-    void MovieFFMpegReader::readSubtitle(VideoTrack* track)
-    {
-        //    openAVCodec(track->videoPacket->stream_index);
-        //    AVCodecContext* subtitleCodecContext =
-        //        m_avFormatContext->streams[track->videoPacket->stream_index]->codec;
-        //    ASSSplitContext* assSplitContext = ff_ass_split(
-        //        (const char*) subtitleCodecContext->subtitle_header);
-        //    ASS* ass = (ASS*)assSplitContext;
-        //    AVSubtitle subtitle;
-        //    int subtitleFinished = 0;
-        //    if (0 < avcodec_decode_subtitle2(subtitleCodecContext,
-        //            &subtitle, &subtitleFinished, track->videoPacket))
-        //    {
-        //        ostringstream text;
-        //        for (int r = 0; r < subtitle.num_rects; r++)
-        //        {
-        //            AVSubtitleRect* rect = subtitle.rects[r];
-        //            switch (rect->type)
-        //            {
-        //                case SUBTITLE_ASS:
-        //                    {
-        //                        ASSDialog* dialog = ff_ass_split_dialog(
-        //                            assSplitContext, rect->ass, 0, NULL);
-        //                        DBL (DB_SUBTITLES, "'" << dialog->text <<
-        //                        "'"); text << dialog->text << " ";
-        //                    }
-        //                    break;
-        //                case SUBTITLE_TEXT:
-        //                    text << rect->text << " ";
-        //                    break;
-        //                default:
-        //                    ostringstream message;
-        //                    message << "Unhandled type of subtitle: '" <<
-        //                    rect->type << "'"; report(message.str(), true);
-        //                    break;
-        //            }
-        //        }
-        //        DBL (DB_SUBTITLES, "freeing subtitle");
-        //        avsubtitle_free(&subtitle);
-        //        track->fb.newAttribute("SubtitleText", text.str());
-        //        track->fb.newAttribute("SubtitleLanguage",
-        //            streamLang(track->videoPacket->stream_index));
-        //    }
     }
 
     void MovieFFMpegReader::identifiersAtFrame(const ReadRequest& request, IdentifierVector& ids)

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -394,6 +394,7 @@ namespace TwkMovie
             MovieFFMpegReader* reader;
             int streamIndex;
             AVCodecContext* avContext;
+            HardwareContext* hardwareContext;
             VideoTrack* vTrack;
             AudioTrack* aTrack;
 
@@ -528,7 +529,7 @@ namespace TwkMovie
         //  this context.
         //
 
-        while (gcp.m_currentOpenThreads >= gcp.m_maxOpenThreads)
+        while (gcp.m_currentOpenThreads >= gcp.m_maxOpenThreads && !gcp.m_openContexts.empty())
         {
             Context& closeContext = *gcp.m_openContexts.back();
             gcp.m_openContexts.pop_back();
@@ -543,7 +544,6 @@ namespace TwkMovie
                 //
 
                 cout << "ERROR: Attempted to reuse reserved context! (" << closeContext.reader->filename() << ")" << endl;
-                gcp.m_currentOpenThreads -= closeContext.avContext->thread_count;
             }
             else if (closeContext.avContext)
             {
@@ -1036,6 +1036,7 @@ namespace TwkMovie
             }
 
             codecContext->hw_device_ctx = av_buffer_ref(hardwareDeviceContext);
+            av_buffer_unref(&hardwareDeviceContext);
 
             return result;
         }
@@ -2506,8 +2507,16 @@ namespace TwkMovie
         m_info.uncropHeight = 120;
 
         // Capture video metadata information for the frame buffer attributes
-        if (m_videoTracks.size() > 0)
+        if (m_videoTracks.size() > 0) {
+            std::vector<ContextPool::Reservation> reservations;
+
+            for (const auto* const &track: m_videoTracks)
+            {
+                reservations.emplace_back(this, track->number);
+            }
+
             initializeVideo(height, width);
+        }
 
         // Look for chapters
         m_info.chapters.resize(m_avFormatContext->nb_chapters);
@@ -2536,7 +2545,15 @@ namespace TwkMovie
 
         // Capture audio metadata information for the frame buffer attributes
         if (m_audioTracks.size() > 0)
+        {
+            std::vector<ContextPool::Reservation> reservations;
+
+            for (const auto* const &track: m_audioTracks)
+            {
+                reservations.emplace_back(this, track->number);
+            }
             initializeAudio();
+        }
         string hasAudio = string((m_audioTracks.size() > 0) ? "Yes" : "No");
         m_info.proxy.newAttribute("Audio", hasAudio);
 
@@ -2554,6 +2571,8 @@ namespace TwkMovie
             for (unsigned int i = 0; i < m_videoTracks.size(); i++)
             {
                 VideoTrack* track = m_videoTracks[i];
+                auto reservation = ContextPool::Reservation(this, track->number);
+
                 m_info.proxy.appendAttributesAndPrefixTo(&track->fb, "");
                 addVideoFBAttrs(track);
             }
@@ -5899,7 +5918,7 @@ namespace TwkMovie
                 poolSize = atoi(c);
             }
             if (poolSize > 0)
-                globalContextPool = std::make_unique<ContextPool>(poolSize);
+                globalContextPool = new ContextPool(poolSize);
             else
             {
                 report("Disabling mio_ffmpeg context thread pool.", true);

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -20,6 +20,7 @@
 #include <TwkUtil/PathConform.h>
 #include <TwkUtil/File.h>
 #include <TwkUtil/sgcHop.h>
+#include <cstddef>
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
@@ -412,7 +413,7 @@ namespace TwkMovie
         class Reservation
         {
         public:
-            Reservation(MovieFFMpegReader* reader, int streamIndex);
+            Reservation(MovieFFMpegReader* reader, int streamIndex, VideoTrack* vTrack=nullptr, AudioTrack* aTrack=nullptr);
             ~Reservation();
 
         private:
@@ -473,7 +474,7 @@ namespace TwkMovie
         gcp.m_contextMap.erase(i);
     }
 
-    ContextPool::Reservation::Reservation(MovieFFMpegReader* reader, int streamIndex)
+    ContextPool::Reservation::Reservation(MovieFFMpegReader* reader, int streamIndex, VideoTrack* vTrack, AudioTrack* aTrack)
         : m_context(0)
         , m_dbline(0)
         , m_dblline(0)
@@ -496,6 +497,13 @@ namespace TwkMovie
         context.reserved = true;
         context.reader = reader;
         context.streamIndex = streamIndex;
+
+        if (vTrack) {
+            context.vTrack = vTrack;
+        }
+        if (aTrack) {
+            context.aTrack = aTrack;
+        }
 
         //
         //  If it's already in the list move it to the front now.
@@ -584,7 +592,6 @@ namespace TwkMovie
         {
             AVStream* avStream = context.reader->m_avFormatContext->streams[context.streamIndex];
 
-            context.reader->trackFromStreamIndex(context.streamIndex, context.vTrack, context.aTrack);
             if (context.vTrack)
             {
                 context.avContext = context.vTrack->avCodecContext;
@@ -2316,7 +2323,7 @@ namespace TwkMovie
                 if (heroVideoTracks[i])
                 {
                     VideoTrack* track = new VideoTrack;
-                    ContextPool::Reservation reserve(this, i);
+                    ContextPool::Reservation reserve(this, i, track);
                     track->useOpenJPH = isJ2K;
 #if defined(RV_USE_APPLE_PRORES_SDK)
                     track->useAppleProRes = isProRes;
@@ -2443,7 +2450,7 @@ namespace TwkMovie
                 if (heroAudioTracks[i])
                 {
                     AudioTrack* track = new AudioTrack;
-                    ContextPool::Reservation reserve(this, i);
+                    ContextPool::Reservation reserve(this, i, nullptr, track);
                     if (openAVCodec(i, &track->avCodecContext))
                     {
                         track->number = i;
@@ -3222,7 +3229,7 @@ namespace TwkMovie
             if (start < 0)
                 continue;
             AudioTrack* track = m_audioTracks[i];
-            ContextPool::Reservation reserve(this, track->number);
+            ContextPool::Reservation reserve(this, track->number, nullptr, track);
             track->isOpen = openAVCodec(track->number, &track->avCodecContext);
             if (!track->isOpen)
             {
@@ -4098,7 +4105,7 @@ namespace TwkMovie
         for (unsigned int i = 0; i < m_videoTracks.size(); i++)
         {
             VideoTrack* track = m_videoTracks[i];
-            ContextPool::Reservation reserve(this, track->number);
+            ContextPool::Reservation reserve(this, track->number, track);
             track->isOpen = openAVCodec(track->number, &track->avCodecContext, &track->hardwareContext);
             if (!track->isOpen)
             {

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -416,7 +416,16 @@ namespace TwkMovie
             ~Reservation();
 
         private:
-            Context* m_context;
+            //
+            //  The Context is looked up by key rather than held by pointer:
+            //  a stored Context* would dangle if the entry were erased (by
+            //  flushContext()) while this Reservation was alive, and the
+            //  destructor's "does my entry still exist" check could not
+            //  detect that without dereferencing the very node in question.
+            //
+
+            MovieFFMpegReader* m_reader;
+            int m_streamIndex;
             int m_dbline;
             int m_dblline;
         };
@@ -474,7 +483,8 @@ namespace TwkMovie
     }
 
     ContextPool::Reservation::Reservation(MovieFFMpegReader* reader, int streamIndex)
-        : m_context(0)
+        : m_reader(reader)
+        , m_streamIndex(streamIndex)
         , m_dbline(0)
         , m_dblline(0)
     {
@@ -491,7 +501,6 @@ namespace TwkMovie
         //
 
         Context& context = gcp.m_contextMap[ContextKey(reader, streamIndex)];
-        m_context = &context;
 
         context.reserved = true;
         context.reader = reader;
@@ -561,17 +570,13 @@ namespace TwkMovie
 
         LockGuard lock(gcp.m_mutex);
 
-        Context& context = *m_context;
+        ContextMap::iterator i = gcp.m_contextMap.find(ContextKey(m_reader, m_streamIndex));
+        if (i == gcp.m_contextMap.end())
+            return;
+
+        Context& context = i->second;
 
         context.reserved = false;
-
-        //
-        //  Make sure the context still exists and we aren't closing.
-        //
-
-        ContextKey key(context.reader, context.streamIndex);
-        if (gcp.m_contextMap.find(key) == gcp.m_contextMap.end())
-            return;
 
         //
         //  If this is the first time we've encountered this Context, it's only
@@ -582,8 +587,6 @@ namespace TwkMovie
 
         if (!context.avContext)
         {
-            AVStream* avStream = context.reader->m_avFormatContext->streams[context.streamIndex];
-
             context.reader->trackFromStreamIndex(context.streamIndex, context.vTrack, context.aTrack);
             if (context.vTrack)
             {

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -2139,12 +2139,6 @@ namespace TwkMovie
         return typeStr;
     }
 
-    bool MovieFFMpegReader::correctLang(int index)
-    {
-        string stmLang = streamLang(index);
-        return (stmLang == m_io->language() || stmLang == "und");
-    }
-
     string MovieFFMpegReader::streamLang(int index)
     {
         AVStream* avStream = m_avFormatContext->streams[index];

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -2685,15 +2685,6 @@ namespace TwkMovie
 
         m_info.video = true;
     }
-    /*
-    context-> decoder
-
-    Each context has 1 Video track and/or 1 Audio track, 1 FFMPEG decoder
-
-
-    
-    
-    */
 
     void MovieFFMpegReader::initializeAudio()
     {

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -461,7 +461,7 @@ namespace TwkMovie
     // when the pool evicts a context it frees it and nulls the owning track's
     // avCodecContext, so openAVCodec() allocates a fresh context on next use.
 
-    std::unique_ptr<ContextPool> globalContextPool{nullptr};
+    ContextPool* globalContextPool = 0;
 
     void ContextPool::flushContext(MovieFFMpegReader* reader, int streamIndex)
     {
@@ -2735,6 +2735,10 @@ namespace TwkMovie
             AVChannelLayout layout = audioCodecContext->ch_layout;
             audioChannels = idAudioChannels(layout, numChannels);
 
+            // The context was opened only to read the audio stream parameters above.
+            // Drop it from the pool before freeing so the pool does not retain a
+            // dangling AVCodecContext* and its open-thread count stays accurate.
+            // Decoding clones reopen their own context on demand in audioFillBuffer().
             ContextPool::flushContext(this, track->number);
             avcodec_free_context(&track->avCodecContext);
             track->isOpen = false;

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -454,6 +454,12 @@ namespace TwkMovie
     //
     //  Global pool object:
     //
+    // The global context pool caps the number of simultaneously-open decoder
+    // threads. It was disabled during the FFmpeg 6.0 migration because a context
+    // cannot be reopened after being closed
+    // (https://ffmpeg.org/doxygen/trunk/deprecated.html). That is now handled:
+    // when the pool evicts a context it frees it and nulls the owning track's
+    // avCodecContext, so openAVCodec() allocates a fresh context on next use.
 
     std::unique_ptr<ContextPool> globalContextPool{nullptr};
 
@@ -537,6 +543,7 @@ namespace TwkMovie
                 //
 
                 cout << "ERROR: Attempted to reuse reserved context! (" << closeContext.reader->filename() << ")" << endl;
+                gcp.m_currentOpenThreads -= closeContext.avContext->thread_count;
             }
             else if (closeContext.avContext)
             {

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg.cpp
@@ -2554,7 +2554,6 @@ namespace TwkMovie
             for (unsigned int i = 0; i < m_videoTracks.size(); i++)
             {
                 VideoTrack* track = m_videoTracks[i];
-                auto reservation = ContextPool::Reservation(this, track->number);
 
                 m_info.proxy.appendAttributesAndPrefixTo(&track->fb, "");
                 addVideoFBAttrs(track);

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
@@ -186,6 +186,12 @@ namespace TwkMovie
         void findStreamInfo();
 
         //
+        // Subtitle & Language Methods
+        //
+
+        std::string streamLang(int index);
+
+        //
         // Metadata & Lookup Methods
         //
 

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
@@ -191,7 +191,6 @@ namespace TwkMovie
 
         std::string streamLang(int index);
         bool correctLang(int index);
-        void readSubtitle(VideoTrack* track);
 
         //
         // Metadata & Lookup Methods

--- a/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
+++ b/src/lib/image/MovieFFMpeg/MovieFFMpeg/MovieFFMpeg.h
@@ -186,13 +186,6 @@ namespace TwkMovie
         void findStreamInfo();
 
         //
-        // Subtitle & Language Methods
-        //
-
-        std::string streamLang(int index);
-        bool correctLang(int index);
-
-        //
         // Metadata & Lookup Methods
         //
 
@@ -265,7 +258,6 @@ namespace TwkMovie
         AVFormatContext* m_avFormatContext;
         AudioTracks m_audioTracks;
         VideoTracks m_videoTracks;
-        std::map<int, int> m_subtitleMap;
         int m_timecodeTrack;
         int64_t m_formatStartFrame;
         TimingDetails* m_timingDetails;

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -335,6 +335,27 @@ namespace IPCore
         finishCachingThread();
         finishAudioThread();
 
+        //
+        //  Explicitly delete all nodes so that source nodes close their
+        //  decoders (e.g. MovieFFMpegReader::close()) before the graph is
+        //  destroyed. Session::clear() skips graph().reset() when being
+        //  deleted, so without this the nodes are never freed on exit.
+        //
+
+        for (auto& [name, node] : m_viewNodeMap)
+        {
+            node->willDelete();
+            node->disconnectInputs();
+        }
+
+        while (!m_viewNodeMap.empty())
+        {
+            IPNode* node = m_viewNodeMap.begin()->second;
+            delete node;
+        }
+
+        m_nodeMap.clear();
+
         pthread_mutex_destroy(&m_internalLock);
         pthread_mutex_destroy(&m_audioInternalLock);
         pthread_mutex_destroy(&m_audioFillLock);

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -322,19 +322,6 @@ namespace IPCore
 
     IPGraph::~IPGraph()
     {
-        if (m_jobDispatcher)
-        {
-            auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
-            jobDispatcher->stop();
-            delete jobDispatcher;
-        }
-
-        // m_fbcache.showCacheContents();
-
-        setCachingMode(NeverCache, 1, 2, 1, 2, 1, 1, 24.0);
-        finishCachingThread();
-        finishAudioThread();
-
         //
         //  Explicitly delete all nodes so that source nodes close their
         //  decoders (e.g. MovieFFMpegReader::close()) before the graph is
@@ -355,6 +342,19 @@ namespace IPCore
         }
 
         m_nodeMap.clear();
+
+        if (m_jobDispatcher)
+        {
+            auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
+            jobDispatcher->stop();
+            delete jobDispatcher;
+        }
+
+        // m_fbcache.showCacheContents();
+
+        setCachingMode(NeverCache, 1, 2, 1, 2, 1, 1, 24.0);
+        finishCachingThread();
+        finishAudioThread();
 
         pthread_mutex_destroy(&m_internalLock);
         pthread_mutex_destroy(&m_audioInternalLock);

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -322,6 +322,10 @@ namespace IPCore
 
     IPGraph::~IPGraph()
     {
+        setCachingMode(NeverCache, 1, 2, 1, 2, 1, 1, 24.0);
+        finishCachingThread();
+        finishAudioThread();
+
         //
         //  Explicitly delete all nodes so that source nodes close their
         //  decoders (e.g. MovieFFMpegReader::close()) before the graph is
@@ -348,13 +352,8 @@ namespace IPCore
             auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
             jobDispatcher->stop();
             delete jobDispatcher;
+            m_jobDispatcher = nullptr;
         }
-
-        // m_fbcache.showCacheContents();
-
-        setCachingMode(NeverCache, 1, 2, 1, 2, 1, 1, 24.0);
-        finishCachingThread();
-        finishAudioThread();
 
         pthread_mutex_destroy(&m_internalLock);
         pthread_mutex_destroy(&m_audioInternalLock);
@@ -3765,21 +3764,31 @@ IPGraph::findNodesByAbstractPath(int frame,
 
     IPGraph::WorkItemID IPGraph::addWorkItem(const VoidFunction& function, const char* tag)
     {
-        auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
+        if (tag)
+        {
+            auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
+            return (WorkItemID)jobDispatcher->addJob(WorkItem(function, tag));
+        }
 
-        return (WorkItemID)jobDispatcher->addJob(WorkItem(function, tag));
+        return 0;
     }
 
     void IPGraph::removeWorkItem(WorkItemID id)
     {
-        auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
-        jobDispatcher->removeJob(id);
+        if (id)
+        { 
+            auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
+            jobDispatcher->removeJob(id);
+        }
     }
 
     void IPGraph::waitWorkItem(WorkItemID id)
     {
-        auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
-        jobDispatcher->waitJob(id);
+        if (id) 
+        {
+            auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
+            jobDispatcher->waitJob(id);
+        }
     }
 
     void IPGraph::prioritizeWorkItem(WorkItemID id)

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -326,6 +326,12 @@ namespace IPCore
         finishCachingThread();
         finishAudioThread();
 
+        if (m_jobDispatcher)
+        {
+            auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
+            jobDispatcher->stop();
+        }
+
         //
         //  Explicitly delete all nodes so that source nodes close their
         //  decoders (e.g. MovieFFMpegReader::close()) before the graph is
@@ -350,7 +356,6 @@ namespace IPCore
         if (m_jobDispatcher)
         {
             auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
-            jobDispatcher->stop();
             delete jobDispatcher;
             m_jobDispatcher = nullptr;
         }
@@ -3764,7 +3769,7 @@ IPGraph::findNodesByAbstractPath(int frame,
 
     IPGraph::WorkItemID IPGraph::addWorkItem(const VoidFunction& function, const char* tag)
     {
-        if (tag)
+        if (m_jobDispatcher)
         {
             auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
             return (WorkItemID)jobDispatcher->addJob(WorkItem(function, tag));
@@ -3775,7 +3780,7 @@ IPGraph::findNodesByAbstractPath(int frame,
 
     void IPGraph::removeWorkItem(WorkItemID id)
     {
-        if (id)
+        if (m_jobDispatcher)
         { 
             auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
             jobDispatcher->removeJob(id);
@@ -3784,7 +3789,7 @@ IPGraph::findNodesByAbstractPath(int frame,
 
     void IPGraph::waitWorkItem(WorkItemID id)
     {
-        if (id) 
+        if (m_jobDispatcher)
         {
             auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
             jobDispatcher->waitJob(id);
@@ -3793,7 +3798,7 @@ IPGraph::findNodesByAbstractPath(int frame,
 
     void IPGraph::prioritizeWorkItem(WorkItemID id)
     {
-        if (id)
+        if (m_jobDispatcher)
         {
             auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
             jobDispatcher->prioritizeJob(id);

--- a/src/lib/ip/IPCore/IPGraph.cpp
+++ b/src/lib/ip/IPCore/IPGraph.cpp
@@ -3781,7 +3781,7 @@ IPGraph::findNodesByAbstractPath(int frame,
     void IPGraph::removeWorkItem(WorkItemID id)
     {
         if (m_jobDispatcher)
-        { 
+        {
             auto jobDispatcher = reinterpret_cast<JobDispatcher*>(m_jobDispatcher);
             jobDispatcher->removeJob(id);
         }


### PR DESCRIPTION
### fix: RV leaks memory because of opened decoders

### Summarize your change.
- Re-enable old context map that manages the number of open threads to decode videos

### Describe the reason for the change.
- Without the context map, the number of open decoder threads keeps increasing as we load more videos.
- RAM usage would increase a lot even by loading video clips without playing the video at all, and just staying on the first frame.

### Describe what you have tested and on which operating system.
Tested on CY 2025 on Rocky Linux 9.8 and Mac

Opened over 1000 clips with 1GB of caching, peaking at 9GB, but staying bounded.
RAM no longer increases when loading clips without playback being on.

### Add a list of changes, and note any that might need special attention during the review.
- After freeing the decoder with `avcodec_free_context`, nullify the tracked pointer to not point to freed memory
No regressions by adding the context map

### If possible, provide screenshots.
<img width="915" height="42" alt="Screenshot from 2026-06-25 08-44-08" src="https://github.com/user-attachments/assets/4fbfe716-395d-4199-b15c-1923af0837e6" />
<img width="852" height="648" alt="Screenshot from 2026-07-02 08-17-49" src="https://github.com/user-attachments/assets/46190902-a0ef-446b-870b-b1a654af1ae5" />

