### PR TITLE
fix: stage macOS brush assets under Contents/Resources for codesign

### DIFF
--- a/src/lib/ip/IPCore/BrushTextureManager.cpp
+++ b/src/lib/ip/IPCore/BrushTextureManager.cpp
@@ -122,7 +122,14 @@ namespace IPCore
             if (const char* env = std::getenv("RV_BRUSH_DIR"))
                 return env;
             if (TwkApp::Bundle* b = TwkApp::Bundle::mainBundle())
+            {
+#if defined(PLATFORM_DARWIN)
+                // DarwinBundle::top() is RV.app/; keep brush assets under Contents/Resources for codesign.
+                return b->top() + "/Contents/Resources/assets/brushes";
+#else
                 return b->top() + "/assets/brushes";
+#endif
+            }
             return "";
         }
 

--- a/src/lib/ip/IPCore/CMakeLists.txt
+++ b/src/lib/ip/IPCore/CMakeLists.txt
@@ -306,14 +306,14 @@ ENDIF()
 
 RV_STAGE(TYPE "LIBRARY" TARGET ${_target})
 
-# Stage brush tip assets from the OpenRV-annotation submodule so that BrushTextureManager can find them at Bundle::top()/assets/brushes at runtime. On macOS,
-# Bundle::top() returns RV.app/ (one level above Contents/), so the assets must land at RV.app/assets/brushes rather than RV.app/Contents/assets/brushes.
+# Stage brush tip assets from the OpenRV-annotation submodule so that BrushTextureManager can find them at runtime. On macOS, place them under
+# Contents/Resources so codesign can seal the bundle (files at RV.app/ root outside Contents trigger "unsealed contents present in the bundle root").
 SET(_brush_assets_src
     ${CMAKE_CURRENT_SOURCE_DIR}/../../geometry/twkpaint-src/assets/brushes
 )
 IF(RV_TARGET_DARWIN)
   SET(_brush_stage_dir
-      ${RV_STAGE_ROOT_DIR}/../assets/brushes
+      ${RV_STAGE_RESOURCES_DIR}/assets/brushes
   )
 ELSE()
   SET(_brush_stage_dir

--- a/src/lib/ip/IPCore/IPCore/BrushTextureManager.h
+++ b/src/lib/ip/IPCore/IPCore/BrushTextureManager.h
@@ -55,7 +55,7 @@ namespace IPCore
             bool isLoaded() const { return m_texturesLoaded; }
 
             /// Resolve the brush catalogue directory: RV_BRUSH_DIR env var, or the
-            /// assets/brushes directory inside the application bundle.
+            /// assets/brushes directory inside the application bundle (Contents/Resources on macOS).
             static std::string catalogueDir();
 
         private:


### PR DESCRIPTION
### fix: stage macOS brush assets under Contents/Resources for codesign

### Linked issues
NA

### Describe the reason for the change.

Mac only issue: 
The recently added brush PNGs at RV.app/assets/ broke codesign  with "unsealed contents present in the bundle root". 

### Summarize your change.

Mac only fix: 
Moved the same assets under Contents/Resources.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.