### PR TITLE
fix: SG-44492: harden screen selection in RvApplication against invalid indices (#1211)

### DIFF
--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -766,17 +766,48 @@ namespace Rv
 
         auto isVirtualDesktop = [&screens, primaryScreen]() -> bool
         {
-            // Not a virtual desktop if there is only one screen.
-            if (screens.size() <= 1)
+            // Not a virtual desktop if there is only one screen, or if
+            // we have no primary screen to compare against.
+            if (screens.size() <= 1 || primaryScreen == nullptr)
                 return false;
 
             QRect totalGeometry;
             for (const auto& screen : screens)
             {
+                if (screen == nullptr)
+                    continue;
                 totalGeometry = totalGeometry.united(screen->geometry());
             }
 
             return totalGeometry != primaryScreen->geometry();
+        };
+
+        //
+        //  Find the screen index for a given global point. Prefer Qt's
+        //  QGuiApplication::screenAt() which handles edge cases (such as
+        //  monitors whose top edges are not aligned, leaving gaps in the
+        //  virtual desktop bounding box) more robustly than a manual
+        //  QRect::contains() check.
+        //
+        auto getScreenFromPoint = [&screens](const QPoint& point) -> int
+        {
+            QScreen* s = QGuiApplication::screenAt(point);
+            if (s != nullptr)
+            {
+                const int idx = screens.indexOf(s);
+                if (idx >= 0)
+                    return idx;
+            }
+
+            for (int i = 0; i < screens.size(); ++i)
+            {
+                if (screens[i] != nullptr && screens[i]->geometry().contains(point))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
         };
 
         //
@@ -787,7 +818,7 @@ namespace Rv
         {
             if (opts.screen != -1 && isVirtualDesktop())
             {
-                if (opts.screen < screens.size())
+                if (opts.screen >= 0 && opts.screen < screens.size() && screens[opts.screen] != nullptr)
                 {
                     QRect r = screens[opts.screen]->geometry();
                     opts.x += r.x();
@@ -805,23 +836,19 @@ namespace Rv
             }
         }
 
-        auto getScreenFromPoint = [&screens](const QPoint& point) -> int
-        {
-            for (int i = 0; i < screens.size(); ++i)
-            {
-                if (screens[i]->geometry().contains(point))
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        };
-
         int screen = getScreenFromPoint(QCursor::pos());
         if (opts.screen != -1)
         {
-            screen = opts.screen;
+            //
+            //  Honor the user/preference-supplied screen index only when
+            //  it refers to an actual screen. A stale preference (or a
+            //  command-line value larger than the current monitor count)
+            //  must not be propagated as an out-of-bounds index.
+            //
+            if (opts.screen >= 0 && opts.screen < screens.size())
+            {
+                screen = opts.screen;
+            }
         }
 
         int oldX = doc->pos().x();
@@ -829,15 +856,17 @@ namespace Rv
 
         int oldScreen = getScreenFromPoint(QPoint(oldX, oldY));
 
-        if (screen != -1 && oldScreen != -1 && isVirtualDesktop() && screen != oldScreen)
+        if (screen >= 0 && screen < screens.size() && oldScreen >= 0 && oldScreen < screens.size()
+            && screens[screen] != nullptr && screens[oldScreen] != nullptr && isVirtualDesktop()
+            && screen != oldScreen)
         //
         //  The application is going to come up on the wrong screen, so figure
         //  out our our relative position on the current screen, and move to the
         //  same relative position on the correct screen.
         //
         {
-            QRect rnew = QGuiApplication::screens().at(screen)->geometry();
-            QRect rold = QGuiApplication::screens().at(oldScreen)->geometry();
+            QRect rnew = screens[screen]->geometry();
+            QRect rold = screens[oldScreen]->geometry();
 
             int xoff = oldX - rold.x();
             int yoff = oldY - rold.y();


### PR DESCRIPTION
### Linked issues

Fixes #1211

### Summarize your change.

Harden screen selection in `RvApplication` against invalid `QScreen` indices and
null pointers so OpenRV no longer crashes (SIGSEGV in `QScreen::geometry()`) at
startup when multiple displays are connected.

### Describe the reason for the change.

Issue #1211 reports a SIGSEGV in `Rv::RvApplication::newSessionFromFiles` →
`QScreen::geometry()` on multi-monitor setups (RHEL 9.5). The crash happens
because the existing code dereferences `QScreen*` values that can be `nullptr`,
and indexes into `QGuiApplication::screens()` with values (from saved
preferences or `-screen` command-line options) that may be out of range or
stale. Under certain GNOME multi-display configurations the primary screen or
the requested screen index is not what the code assumes, and we crash.

### Describe what you have tested and on which operating system.

- RHEL 9.5 with multiple displays attached — OpenRV now starts cleanly on
  configurations that previously reproduced the SIGSEGV from #1211.
- Single-display setup — no behavior change observed.
- Stale/out-of-range `-screen` command-line value — falls back gracefully
  instead of crashing.

### Add a list of changes, and note any that might need special attention during the review.

`src/lib/app/RvCommon/RvApplication.cpp`:

- Guard `isVirtualDesktop` against a null primary screen and null entries in
  `QGuiApplication::screens()`.
- Use `QGuiApplication::screenAt()` for more robust point-to-screen mapping,
  with a manual geometry fallback when it returns null.
- Validate `opts.screen` against the current screen count before applying it,
  so stale preferences or out-of-bounds command-line values do not propagate.
- Bounds-check screen indices and null-check `QScreen*` pointers before
  dereferencing `geometry()` in the relative-position adjustment path.

Reviewer focus: please double-check the fallback path when
`QGuiApplication::screenAt()` returns null and the chosen index when
`opts.screen` is invalid — those are the behavioral edges most likely to
affect existing multi-monitor workflows.

### If possible, provide screenshots.

N/A — crash fix.
