### PR TITLE
fix: handle unknown schema in otio import more robustly

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -94,6 +94,12 @@ def hook_function(in_timeline: otio.schemadef.Annotation.Annotation, argument_ma
         logging.warning("Unable to set Hold and Ghost properties")
 
     for layer in in_timeline.layers:
+        if layer.is_unknown_schema:
+            logging.warning(
+                f"Skipping unsupported annotation layer type '{layer.schema_name()}' "
+                "(no schema registered in this version of RV)"
+            )
+            continue
         if isinstance(layer.layer_range, otio.opentime.TimeRange):
             time_range = layer.layer_range
         else:

--- a/src/plugins/rv-packages/otio_reader/otio_reader.py
+++ b/src/plugins/rv-packages/otio_reader/otio_reader.py
@@ -561,6 +561,9 @@ def _create_movieproc(time_range, kind="blank"):
 
 def _add_effects(it, last_result, context=None):
     for effect in it.effects:
+        if effect.is_unknown_schema:
+            logging.warning(f"Skipping unknown effect schema '{effect.schema_name()}'")
+            continue
         with set_context(context, effect_metadata=effect.metadata):
             result = create_rv_node_from_otio(effect, context)
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Handle unknown effects/annotations in OTIO import

### Summarize your change.

This branch will handle unknown effect schemas and unknown schemas nested inside known annotations. Instead of erroring out on these schemas, we will now simply ignore them logging an error instead. This will at least allow the import to continue with the rest of the structure that it does understand.

### Describe the reason for the change.

This is intended to improve backward compatibility, where a newer version of OpenRV might support schemas that an older one does not. 

### Describe what you have tested and on which operating system.

Mac OS 26.5.1.