### PR TITLE
feat: SG-42200: 10-bit Metal presentation

### DIFF
--- a/cmake/defaults/rv_options.cmake
+++ b/cmake/defaults/rv_options.cmake
@@ -1,15 +1,19 @@
 #
-# Copyright (C) 2022  Autodesk, Inc. All Rights Reserved.
+# Copyright (C) 2026  Autodesk, Inc. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
-#
 # Debugging options
 OPTION(RV_VERBOSE_INVOCATION "Show the compiler/link command invocation." OFF)
 OPTION(RV_SHOW_ALL_VARIABLES "Displays all build variables." ON)
 
-#
+# Metal rendering backend (macOS only). When ON, Open RV uses Apple Metal instead of OpenGL on macOS. This enables true 10-bit output, HDR/EDR, ProMotion, and
+# better GPU tooling. Pass -DUSE_METAL=ON to use the Metal path.
+IF(APPLE)
+  OPTION(USE_METAL "Use Metal rendering backend on macOS (replaces OpenGL)" OFF)
+ENDIF()
+
 # General build options
 SET(RV_DEPS_BASE_DIR
     "${CMAKE_BINARY_DIR}"

--- a/cmake/defaults/rv_options.cmake
+++ b/cmake/defaults/rv_options.cmake
@@ -8,12 +8,6 @@
 OPTION(RV_VERBOSE_INVOCATION "Show the compiler/link command invocation." OFF)
 OPTION(RV_SHOW_ALL_VARIABLES "Displays all build variables." ON)
 
-# Metal rendering backend (macOS only). When ON, Open RV uses Apple Metal instead of OpenGL on macOS. This enables true 10-bit output, HDR/EDR, ProMotion, and
-# better GPU tooling. Pass -DUSE_METAL=ON to use the Metal path.
-IF(APPLE)
-  OPTION(USE_METAL "Use Metal rendering backend on macOS (replaces OpenGL)" OFF)
-ENDIF()
-
 # General build options
 SET(RV_DEPS_BASE_DIR
     "${CMAKE_BINARY_DIR}"

--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -368,6 +368,15 @@ int utf8Main(int argc, char* argv[])
     // (RV Preferences/Rendering/Multithread GPU Upload)
     QApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
 
+    // Share resources across every QOpenGLContext in the process. The
+    // diagnostics tool is a QOpenGLWidget (ImGui OpenGL2) whose font atlas must
+    // share with the context that actually renders. On the Metal/Vulkan
+    // presentation backends that render context is an offscreen QOpenGLContext
+    // owned by the video device, so without a global share context the
+    // diagnostics font-texture uploads fail and the panel renders blank.
+    // Must be set before the QApplication is constructed.
+    QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
     TwkUtil::MemPool::initialize();
 
     string altPrefsPath;

--- a/src/lib/app/RvCommon/CMakeLists.txt
+++ b/src/lib/app/RvCommon/CMakeLists.txt
@@ -430,7 +430,7 @@ IF(RV_TARGET_DARWIN)
     TARGET_LINK_LIBRARIES(
       ${_target}
       PUBLIC TwkGLFCoreGraphics
-      PRIVATE "-framework CoreVideo" "-framework QuartzCore" "-framework IOSurface" "-framework AppKit"
+      PRIVATE "-framework CoreVideo" "-framework QuartzCore" "-framework IOSurface" "-framework AppKit" "-framework Metal"
     )
     TARGET_COMPILE_DEFINITIONS(
       ${_target}

--- a/src/lib/app/RvCommon/CMakeLists.txt
+++ b/src/lib/app/RvCommon/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022  Autodesk, Inc. All Rights Reserved.
+# Copyright (C) 2026  Autodesk, Inc. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -66,6 +66,13 @@ SET(_sources
 
 IF(RV_TARGET_DARWIN)
   LIST(APPEND _sources DisplayLink.cpp)
+  IF(USE_METAL)
+    LIST(APPEND _sources MetalView.mm QTMetalVideoDevice.mm)
+    SET_SOURCE_FILES_PROPERTIES(
+      MetalView.mm
+      PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+    )
+  ENDIF()
 ENDIF()
 
 IF(RV_TARGET_DARWIN)
@@ -146,7 +153,19 @@ FILE(
   RvCommon/*.h
 )
 IF(NOT RV_TARGET_DARWIN)
-  LIST(REMOVE_ITEM _files_to_moc "RvCommon/DisplayLink.h" "RvCommon/CGDesktopVideoDevice.h")
+  LIST(REMOVE_ITEM _files_to_moc "RvCommon/DisplayLink.h" "RvCommon/CGDesktopVideoDevice.h" "RvCommon/MetalView.h" "RvCommon/QTMetalVideoDevice.h")
+ENDIF()
+
+# Platform-specific defines to forward to the MOC executable so that platform-guarded Q_OBJECT declarations (e.g. MetalView.h, DisplayLink.h) are visible to
+# MOC.
+SET(_moc_platform_defines
+    ""
+)
+IF(RV_TARGET_DARWIN)
+  LIST(APPEND _moc_platform_defines "-DPLATFORM_DARWIN")
+  IF(USE_METAL)
+    LIST(APPEND _moc_platform_defines "-DUSE_METAL")
+  ENDIF()
 ENDIF()
 
 FOREACH(
@@ -162,14 +181,14 @@ FOREACH(
   IF(RV_VFX_PLATFORM STREQUAL CY2023)
     ADD_CUSTOM_COMMAND(
       OUTPUT ${outfile}
-      COMMAND ${Qt5Core_MOC_EXECUTABLE} -DRV_VFX_CY2023 -I ${CMAKE_CURRENT_SOURCE_DIR} -o ${outfile} ${infile}
+      COMMAND ${Qt5Core_MOC_EXECUTABLE} -DRV_VFX_CY2023 ${_moc_platform_defines} -I ${CMAKE_CURRENT_SOURCE_DIR} -o ${outfile} ${infile}
       MAIN_DEPENDENCY ${infile}
       VERBATIM
     )
   ELSEIF(RV_VFX_PLATFORM STRGREATER_EQUAL CY2024)
     ADD_CUSTOM_COMMAND(
       OUTPUT ${outfile}
-      COMMAND ${QT_MOC_EXECUTABLE} -DRV_VFX_${RV_VFX_PLATFORM} -I ${CMAKE_CURRENT_SOURCE_DIR} -o ${outfile} ${infile}
+      COMMAND ${QT_MOC_EXECUTABLE} -DRV_VFX_${RV_VFX_PLATFORM} ${_moc_platform_defines} -I ${CMAKE_CURRENT_SOURCE_DIR} -o ${outfile} ${infile}
       MAIN_DEPENDENCY ${infile}
       VERBATIM
     )
@@ -407,11 +426,23 @@ TARGET_LINK_LIBRARIES(
 )
 
 IF(RV_TARGET_DARWIN)
-  TARGET_LINK_LIBRARIES(
-    ${_target}
-    PUBLIC TwkGLFCoreGraphics
-    PRIVATE "-framework CoreVideo"
-  )
+  IF(USE_METAL)
+    TARGET_LINK_LIBRARIES(
+      ${_target}
+      PUBLIC TwkGLFCoreGraphics
+      PRIVATE "-framework CoreVideo" "-framework QuartzCore" "-framework IOSurface" "-framework AppKit"
+    )
+    TARGET_COMPILE_DEFINITIONS(
+      ${_target}
+      PUBLIC USE_METAL
+    )
+  ELSE()
+    TARGET_LINK_LIBRARIES(
+      ${_target}
+      PUBLIC TwkGLFCoreGraphics
+      PRIVATE "-framework CoreVideo"
+    )
+  ENDIF()
 ENDIF()
 
 # https://doc.qt.io/qt-6/extras-changes-qt6.html

--- a/src/lib/app/RvCommon/CMakeLists.txt
+++ b/src/lib/app/RvCommon/CMakeLists.txt
@@ -65,14 +65,11 @@ SET(_sources
 # IF(RV_TARGET_DARWIN) LIST(APPEND _sources CGDesktopVideoDevice.cpp CGDesktopVideoDeviceArm.cpp DisplayLink.cpp) ENDIF()
 
 IF(RV_TARGET_DARWIN)
-  LIST(APPEND _sources DisplayLink.cpp)
-  IF(USE_METAL)
-    LIST(APPEND _sources MetalView.mm QTMetalVideoDevice.mm)
-    SET_SOURCE_FILES_PROPERTIES(
-      MetalView.mm
-      PROPERTIES COMPILE_FLAGS "-fobjc-arc"
-    )
-  ENDIF()
+  LIST(APPEND _sources DisplayLink.cpp MetalView.mm QTMetalVideoDevice.mm)
+  SET_SOURCE_FILES_PROPERTIES(
+    MetalView.mm
+    PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+  )
 ENDIF()
 
 IF(RV_TARGET_DARWIN)
@@ -162,10 +159,7 @@ SET(_moc_platform_defines
     ""
 )
 IF(RV_TARGET_DARWIN)
-  LIST(APPEND _moc_platform_defines "-DPLATFORM_DARWIN")
-  IF(USE_METAL)
-    LIST(APPEND _moc_platform_defines "-DUSE_METAL")
-  ENDIF()
+  LIST(APPEND _moc_platform_defines "-DPLATFORM_DARWIN" "-DUSE_METAL")
 ENDIF()
 
 FOREACH(
@@ -426,23 +420,15 @@ TARGET_LINK_LIBRARIES(
 )
 
 IF(RV_TARGET_DARWIN)
-  IF(USE_METAL)
-    TARGET_LINK_LIBRARIES(
-      ${_target}
-      PUBLIC TwkGLFCoreGraphics
-      PRIVATE "-framework CoreVideo" "-framework QuartzCore" "-framework IOSurface" "-framework AppKit" "-framework Metal"
-    )
-    TARGET_COMPILE_DEFINITIONS(
-      ${_target}
-      PUBLIC USE_METAL
-    )
-  ELSE()
-    TARGET_LINK_LIBRARIES(
-      ${_target}
-      PUBLIC TwkGLFCoreGraphics
-      PRIVATE "-framework CoreVideo"
-    )
-  ENDIF()
+  TARGET_LINK_LIBRARIES(
+    ${_target}
+    PUBLIC TwkGLFCoreGraphics
+    PRIVATE "-framework CoreVideo" "-framework QuartzCore" "-framework IOSurface" "-framework AppKit" "-framework Metal"
+  )
+  TARGET_COMPILE_DEFINITIONS(
+    ${_target}
+    PUBLIC USE_METAL
+  )
 ENDIF()
 
 # https://doc.qt.io/qt-6/extras-changes-qt6.html

--- a/src/lib/app/RvCommon/DesktopVideoDevice.cpp
+++ b/src/lib/app/RvCommon/DesktopVideoDevice.cpp
@@ -157,10 +157,17 @@ namespace Rv
     {
         TWK_GLDEBUG;
 
-        QSurfaceFormat fmt = shareDevice()->widget()->format();
+        // shareDevice() is null when the primary window uses a non-OpenGL
+        // presentation backend (Metal/Vulkan), since there is no QTGLVideoDevice
+        // to share with. Fall back to the default surface format and no
+        // explicit share widget; Qt::AA_ShareOpenGLContexts (set in main) still
+        // shares GL resources via the process-wide global context, and
+        // ScreenView::initializeGL() already tolerates a null m_glViewShare.
+        QOpenGLWidget* shareWidget = shareDevice() ? shareDevice()->widget() : nullptr;
+        QSurfaceFormat fmt = shareWidget ? shareWidget->format() : QSurfaceFormat::defaultFormat();
         fmt.setSwapInterval(m_vsync ? 1 : 0);
 
-        ScreenView* vw = new ScreenView(fmt, 0, shareDevice()->widget(), Qt::Window);
+        ScreenView* vw = new ScreenView(fmt, 0, shareWidget, Qt::Window);
         setViewWidget(vw);
 
         QTGLVideoDevice* vd = new QTGLVideoDevice(0, "local view", vw);

--- a/src/lib/app/RvCommon/MetalCpuFallback.md
+++ b/src/lib/app/RvCommon/MetalCpuFallback.md
@@ -1,0 +1,155 @@
+# Metal 10-bit CPU fallback — implementation notes
+
+`syncBuffers()` in `QTMetalVideoDevice` has three present routes:
+
+1. **GPU fast path** — zero-copy GL → IOSurface blit (default)
+2. **New CPU fallback** — GPU-blit into a flip FBO, then packed `glReadPixels`
+3. ~~Old CPU fallback~~ — float readback + per-pixel CPU pack loop (removed)
+
+---
+
+## GPU fast path (zero-copy)
+
+```
+RGBA16F render FBO
+       │
+       │  glBlitFramebufferEXT (GPU: float→RGB10_A2, Y-flip)
+       ▼
+IOSurface-backed GL_RGB10_A2 FBO  ← backed by IOSurface memory directly
+       │
+       │  glColorMask(alpha) + glClear → force A=3 (opaque)
+       │  glFlush()  (no stall — CA reads the IOSurface asynchronously)
+       ▼
+CALayer compositor  (reads IOSurface, no CPU copy)
+```
+
+Nothing ever touches the CPU. The blit quantises float to 10-bit and
+Y-flips in one GPU pass. `glFlush()` (not `glFinish()`) is enough because
+IOSurface provides cross-context synchronisation — the compositor waits on
+the GPU fence itself.
+
+---
+
+## Old CPU fallback (removed)
+
+```
+RGBA16F render FBO
+       │
+       │  glFinish()  ← GPU fully idle, main thread stalls
+       │  glReadPixels(GL_RGBA, GL_FLOAT)  ← 16 MB/frame @ 1080p
+       ▼
+CPU float buffer  [w × h × 4 × 4 bytes]
+       │
+       │  nested for(y) for(x):
+       │    clamp(r,g,b to [0,1])
+       │    × 1023.0f + 0.5f → uint32 & 0x3FF
+       │    bit-pack: (3u<<30)|(ri<<20)|(gi<<10)|bi
+       │    explicit Y-flip via (h-1-y) row index
+       ▼
+CPU uint32 buffer  [w × h × 4 bytes]
+       │
+       │  presentPixelData() → memcpy into IOSurface
+       ▼
+CALayer compositor
+```
+
+**Cost:** ~8 MB float readback + ~8 M multiply/clamp/pack ops per frame at
+1080p; ~128 MB readback + ~130 M ops at 4K. Fully serialised on the main
+thread.
+
+---
+
+## New CPU fallback (current)
+
+```
+RGBA16F render FBO
+       │
+       │  glBlitFramebufferEXT (GPU: float→RGB10_A2, Y-flip)  ← same GPU op as fast path
+       ▼
+Persistent GL_RGB10_A2 flip FBO  (not IOSurface-backed)
+       │
+       │  glColorMask(alpha only) + glClear → force A=3 (opaque)
+       │  glFinish()  ← stalls, but only after GPU blit is done
+       │  glReadPixels(GL_BGRA, GL_UNSIGNED_INT_2_10_10_10_REV)
+       │    ← pixels are already packed; no CPU conversion
+       ▼
+CPU uint32 buffer  [w × h × 4 bytes]
+       │
+       │  presentPixelData() → memcpy into IOSurface
+       ▼
+CALayer compositor
+```
+
+**Cost:** ~8 MB readback (same as before), but **0** multiply/clamp/pack
+ops — the GPU packed the pixels during the blit. The main-thread stall is
+reduced to the GPU-drain time only.
+
+---
+
+## Side-by-side comparison
+
+| | GPU fast path | Old CPU fallback | New CPU fallback |
+| --- | --- | --- | --- |
+| Float readback | None | Yes — 4× larger buffer | None |
+| CPU pack loop | None | Yes — ~25 M ops @ 4K | None |
+| Y-flip | GPU (blit dest coords) | CPU (row index reversal) | GPU (blit dest coords) |
+| `glFinish()` | No — `glFlush()` suffices | Yes | Yes (GL-on-Metal requirement) |
+| Alpha fix | `glColorMask` + `glClear` | Hardcoded `(3u<<30)` | `glColorMask` + `glClear` |
+| `glReadPixels` format | N/A | `GL_RGBA, GL_FLOAT` | `GL_BGRA, GL_UNSIGNED_INT_2_10_10_10_REV` |
+| IOSurface backing | Direct (zero-copy) | Via `memcpy` | Via `memcpy` |
+| Main-thread stall | None | GPU drain + CPU work | GPU drain only |
+
+---
+
+## Why `GL_BGRA` and not `GL_RGBA`
+
+`GL_UNSIGNED_INT_2_10_10_10_REV` packs the **first listed component** into
+the **least significant bits**:
+
+- `GL_RGBA` → R→bits[9:0], G→bits[19:10], B→bits[29:20], A→bits[31:30]
+  = **A2B10G10R10** (Vulkan swapchain layout)
+- `GL_BGRA` → B→bits[9:0], G→bits[19:10], R→bits[29:20], A→bits[31:30]
+  = **A2R10G10B10** = `ARGB2101010LE` (IOSurface layout ✓)
+
+The Vulkan path (`QTVulkanVideoDevice`) uses `GL_RGBA` because its
+swapchain format is `VK_FORMAT_A2B10G10R10_UNORM_PACK32`. The Metal path
+uses `GL_BGRA` because IOSurface wants
+`kCVPixelFormatType_ARGB2101010LEPacked` — R and B are swapped between the
+two formats.
+
+---
+
+## Why `glFinish()` is still needed in the new fallback
+
+The fast path skips it because the CA compositor reads the IOSurface via a
+GPU fence and never touches pixels on the CPU. The new fallback still calls
+`glReadPixels`, which reads to CPU memory. On macOS's GL-on-Metal
+translation layer, `glReadPixels` does **not** automatically wait for the
+Metal command buffer that encoded the preceding blit to complete.
+`glFinish()` forces `[MTLCommandBuffer waitUntilCompleted]` through the
+GL→Metal bridge, ensuring the blit has landed before the readback samples
+the flip FBO.
+
+---
+
+## Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `RV_METAL_FORCE_CPU_PRESENT` | Force the CPU fallback on every frame regardless of IOSurface interop availability. Useful for testing the fallback path. |
+
+---
+
+## When does the CPU fallback trigger?
+
+`ensureIOSurfaceTextures()` returns `false` when:
+
+- `CGLTexImageIOSurface2D` fails (incompatible format, driver issue)
+- The IOSurface FBO is incomplete
+- The GL blit into the IOSurface FBO returns a GL error
+
+On failure, `latchInteropFailure()` disables interop and sets a
+`kInteropRetryFrames` (120 frame) cooldown before the next attempt. A
+one-shot log fires: `"presenting via CPU readback (WxH); zero-copy
+IOSurface interop unavailable — retrying periodically."` Recovery is
+logged when the fast path resumes.

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -458,7 +458,8 @@ namespace Rv
                 m_activationTimer.stop();
         }
 
-        if (event->type() != QEvent::Paint)
+        if (event->type() != QEvent::Paint
+            && event->type() != QEvent::UpdateRequest)
         {
             m_activityTimer.stop();
             m_activityTimer.start();

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -22,6 +22,7 @@
 #include <TwkApp/VideoDevice.h>
 
 #include <QtCore/QCoreApplication>
+#include <QtCore/QMetaObject>
 #include <QtGui/QResizeEvent>
 #include <QtGui/QShowEvent>
 #include <QtGui/QKeyEvent>
@@ -62,6 +63,7 @@ namespace Rv
         , m_ioSurfaceHeight(0)
         , m_lastPresentedSurface(nullptr)
         , m_updatePending(false)
+        , m_contextFailureCount(0)
     {
         // Ensure a native NSView is created immediately so winId() is valid
         // when initialize() is called from showEvent().
@@ -110,14 +112,59 @@ namespace Rv
 
     bool MetalView::supports10BitPresentation()
     {
-        // The 10-bit presentation path renders into an IOSurface with pixel
-        // format kCVPixelFormatType_ARGB2101010LEPacked (see presentPixelData)
-        // which the window server composites correctly on every Metal-capable
-        // Mac.  A Metal device is therefore the only requirement.
-        // This file is compiled with -fobjc-arc; ARC releases the device when it
-        // goes out of scope, so no explicit release is needed.
+        // Requirement 1: a Metal device must exist.  This file is compiled with
+        // -fobjc-arc; ARC releases the device when it goes out of scope, so no
+        // explicit release is needed.
         id<MTLDevice> device = MTLCreateSystemDefaultDevice();
-        return device != nil;
+        if (device == nil)
+        {
+            std::cerr << "INFO: [MetalView] no Metal device available; 10-bit "
+                         "Metal presentation unavailable.\n";
+            return false;
+        }
+
+        // Requirement 2: the OS must actually be able to create an IOSurface in
+        // the packed 10-bit format we present through
+        // (kCVPixelFormatType_ARGB2101010LEPacked).  The window server
+        // composites this format correctly on every Metal-capable Mac, but
+        // probing a tiny surface here catches any configuration where the format
+        // is unavailable *before* we commit the window to the Metal backend
+        // (mirrors the Vulkan side, which validates the real surface format
+        // before selecting Vulkan).  Side-effect-free: the probe is released
+        // immediately.
+        NSDictionary* probeProps = @{
+            (NSString*)kIOSurfaceWidth:           @(16),
+            (NSString*)kIOSurfaceHeight:          @(16),
+            (NSString*)kIOSurfaceBytesPerElement: @(4),
+            (NSString*)kIOSurfacePixelFormat:     @(kCVPixelFormatType_ARGB2101010LEPacked),
+        };
+        IOSurfaceRef probe = IOSurfaceCreate((__bridge CFDictionaryRef)probeProps);
+        if (probe == nullptr)
+        {
+            std::cerr << "INFO: [MetalView] IOSurface ARGB2101010 probe failed; "
+                         "10-bit Metal presentation unavailable.\n";
+            return false;
+        }
+        CFRelease(probe);
+
+        // Informational only: report whether the main display advertises a
+        // deep-color (>= 10 bit per component) depth.  10-bit IOSurface content
+        // is composited on every Metal-capable Mac, but on an SDR 8-bit panel
+        // the window server may dither/truncate at scanout — so this is logged,
+        // not enforced (the Vulkan side likewise presents 10-bit even on SDR
+        // displays).
+        if (NSScreen* screen = [NSScreen mainScreen])
+        {
+            const NSInteger bps = NSBitsPerSampleFromDepth([screen depth]);
+            std::cerr << "INFO: [MetalView] main display bits-per-sample = "
+                      << static_cast<long>(bps)
+                      << (bps >= 10
+                              ? " (deep color: 10-bit reaches the panel).\n"
+                              : " (SDR 8-bit: 10-bit content is composited but "
+                                "may be dithered/truncated at scanout).\n");
+        }
+
+        return true;
     }
 
     //--------------------------------------------------------------------------
@@ -321,7 +368,27 @@ namespace Rv
         {
             m_videoDevice->makeCurrent();
             if (!m_videoDevice->isGLContextReady())
+            {
+                // The offscreen GL context/FBO could not be established for this
+                // frame.  A single failure may be transient, but a persistent
+                // one means the Metal hybrid path cannot render — degrade to the
+                // 8-bit OpenGL GLView instead of leaving a permanently black
+                // view (mirrors the Vulkan branch's runtime fallback).  Defer
+                // the swap via a queued call so we never tear down this view
+                // from inside its own render().
+                if (++m_contextFailureCount == kContextFailureThreshold)
+                {
+                    std::cerr << "WARNING: [MetalView] offscreen GL context not "
+                                 "ready after " << kContextFailureThreshold
+                              << " attempts; falling back to OpenGL.\n";
+                    QMetaObject::invokeMethod(m_doc, "fallbackMetalToGLView",
+                                              Qt::QueuedConnection);
+                }
                 return;
+            }
+
+            // Context is healthy again; reset the failure streak.
+            m_contextFailureCount = 0;
 
             if (m_userActive && m_activityTimer.elapsed() > 1.0)
             {

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -24,6 +24,7 @@
 #include <QtGui/QResizeEvent>
 #include <QtGui/QShowEvent>
 #include <QtGui/QKeyEvent>
+#include <QtGui/QPaintEvent>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QWidget>
 
@@ -63,6 +64,13 @@ namespace Rv
         // when initialize() is called from showEvent().
         setAttribute(Qt::WA_NativeWindow);
         setAttribute(Qt::WA_NoSystemBackground);
+        // We deliver pixels through the CALayer/IOSurface ourselves, so take over
+        // the native surface (paintEngine() returns nullptr) and tell Qt the widget
+        // paints all of its pixels.  Without this, Qt's backing store repaints a
+        // black background over the layer on expose/alt-tab, causing a black flash
+        // until a later mouse event triggers a re-present.
+        setAttribute(Qt::WA_PaintOnScreen);
+        setAttribute(Qt::WA_OpaquePaintEvent);
         setAutoFillBackground(false);
 
         ostringstream str;
@@ -224,8 +232,23 @@ namespace Rv
 
         IOSurfaceUnlock(surf, 0, nullptr);
 
-        // Push to display: assign IOSurface as layer contents inside a
-        // CATransaction with animations disabled for immediate presentation.
+        // Push to display.
+        presentCachedSurface();
+    }
+
+    //--------------------------------------------------------------------------
+    // presentCachedSurface — (re)assign the cached IOSurface as layer contents
+    //--------------------------------------------------------------------------
+
+    void MetalView::presentCachedSurface()
+    {
+        CALayer*     layer = (__bridge CALayer*)m_caLayer;
+        IOSurfaceRef surf  = (IOSurfaceRef)m_ioSurface;
+        if (!layer || !surf)
+            return;
+
+        // Assign IOSurface as layer contents inside a CATransaction with
+        // animations disabled for immediate presentation.
         [CATransaction begin];
         [CATransaction setDisableActions:YES];
         layer.contents = (__bridge id)surf;
@@ -327,6 +350,19 @@ namespace Rv
             m_doc->viewSizeChanged(event->size().width(), event->size().height());
 
         QWidget::resizeEvent(event);
+    }
+
+    void MetalView::paintEvent(QPaintEvent* /*event*/)
+    {
+        // WA_PaintOnScreen means Qt won't repaint this native surface itself, so
+        // when the OS re-exposes the window (alt-tab, uncover) we must restore the
+        // image.  Re-present the last cached IOSurface — cheap, no GL readback —
+        // which is the Metal analog of VulkanView::paintEvent -> syncBuffers.  If
+        // nothing has been rendered yet, produce a frame.
+        if (m_ioSurface)
+            presentCachedSurface();
+        else
+            render();
     }
 
     //--------------------------------------------------------------------------

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -1,0 +1,556 @@
+//
+//  Copyright (c) 2026 Autodesk, Inc. All Rights Reserved.
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+#ifdef PLATFORM_DARWIN
+
+#import <QuartzCore/QuartzCore.h>
+#import <AppKit/AppKit.h>
+#import <IOSurface/IOSurface.h>
+#import <CoreVideo/CoreVideo.h>
+
+#include <RvCommon/MetalView.h>
+#include <RvCommon/QTMetalVideoDevice.h>
+#include <RvCommon/RvDocument.h>
+#include <RvApp/Options.h>
+#include <RvApp/RvSession.h>
+#include <IPCore/Session.h>
+#include <TwkApp/Event.h>
+#include <TwkApp/VideoDevice.h>
+
+#include <QtCore/QCoreApplication>
+#include <QtGui/QResizeEvent>
+#include <QtGui/QShowEvent>
+#include <QtGui/QKeyEvent>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QWidget>
+
+#include <iostream>
+#include <sstream>
+
+namespace Rv
+{
+    using namespace std;
+    using namespace TwkApp;
+    using namespace IPCore;
+
+    //--------------------------------------------------------------------------
+    // MetalView implementation
+    //--------------------------------------------------------------------------
+
+    MetalView::MetalView(RvDocument* doc, QWidget* parent, bool noResize)
+        : QWidget(parent)
+        , m_doc(doc)
+        , m_videoDevice(nullptr)
+        , m_initialized(false)
+        , m_firstPaintCompleted(false)
+        , m_postFirstNonEmptyRender(noResize)
+        , m_stopProcessingEvents(false)
+        , m_userActive(true)
+        , m_csize(1024, 576)
+        , m_msize(128, 128)
+        , m_eventWidget(nullptr)
+        , m_lastKey(0)
+        , m_lastKeyType(QEvent::None)
+        , m_caLayer(nullptr)
+        , m_ioSurface(nullptr)
+        , m_ioSurfaceWidth(0)
+        , m_ioSurfaceHeight(0)
+    {
+        // Ensure a native NSView is created immediately so winId() is valid
+        // when initialize() is called from showEvent().
+        setAttribute(Qt::WA_NativeWindow);
+        setAttribute(Qt::WA_NoSystemBackground);
+        setAutoFillBackground(false);
+
+        ostringstream str;
+        str << UI_APPLICATION_NAME " Main Window (Metal)" << "/" << m_doc;
+        m_videoDevice = new QTMetalVideoDevice(nullptr, str.str(), this, nullptr);
+
+        m_activityTimer.start();
+
+        m_eventProcessingTimer.setSingleShot(true);
+        connect(&m_eventProcessingTimer, SIGNAL(timeout()), this, SLOT(eventProcessingTimeout()));
+    }
+
+    MetalView::~MetalView()
+    {
+        delete m_videoDevice;
+
+        // Release IOSurface
+        if (m_ioSurface)
+        {
+            CFRelease((IOSurfaceRef)m_ioSurface);
+            m_ioSurface = nullptr;
+        }
+
+        // Release CALayer (balance the __bridge_retained in initialize())
+        if (m_caLayer)
+        {
+            CALayer* layer = (__bridge_transfer CALayer*)m_caLayer;
+            (void)layer;
+            m_caLayer = nullptr;
+        }
+    }
+
+    //--------------------------------------------------------------------------
+
+    void MetalView::setEventWidget(QWidget* widget)
+    {
+        m_eventWidget = widget;
+        if (m_videoDevice)
+            m_videoDevice->setEventWidget(widget);
+    }
+
+    void MetalView::stopProcessingEvents() { m_stopProcessingEvents = true; }
+
+    void MetalView::absolutePosition(int& x, int& y) const
+    {
+        QPoint gp = mapToGlobal(QPoint(0, 0));
+        x = gp.x();
+        y = gp.y();
+    }
+
+    float MetalView::devicePixelRatio() const
+    {
+        return static_cast<float>(devicePixelRatioF());
+    }
+
+    //--------------------------------------------------------------------------
+    // Initialisation
+    //--------------------------------------------------------------------------
+
+    void MetalView::initialize()
+    {
+        if (m_initialized)
+            return;
+        m_initialized = true;
+
+        // Create a plain CALayer — IOSurface content is uploaded to it each frame
+        // by presentPixelData().  We use IOSurface (not CAMetalLayer) for pixel
+        // delivery because CAMetalLayer with BGR10A2Unorm is mishandled by the CA
+        // compositor on macOS: it treats 4-byte packed pixels as 1 byte, producing
+        // 4× horizontal tiling.  IOSurface + kCVPixelFormatType_ARGB2101010LEPacked
+        // is composited natively and correctly for the 10-bit format.
+        CALayer* caLayer = [CALayer layer];
+        caLayer.opaque          = YES;
+        caLayer.contentsGravity = kCAGravityResize;  // IOSurface fills layer exactly
+
+        // Attach directly to the widget's NSView.  Since we use IOSurface (not a
+        // Metal drawable), _NSOpenGLViewBackingLayer does not intercept or tile the
+        // content — the CA render server composites IOSurface data independently.
+        NSView* nsView = (__bridge NSView*)reinterpret_cast<void*>(winId());
+        [nsView setLayer:caLayer];
+        [nsView setWantsLayer:YES];
+
+        CGFloat scale = static_cast<CGFloat>(devicePixelRatioF());
+        if (scale < 1.0) scale = 1.0;
+        caLayer.contentsScale = scale;
+
+        m_caLayer = (__bridge_retained void*)caLayer;
+
+        // Kick off session initialization (equivalent to GLView::initializeGL)
+        if (m_doc)
+            m_doc->initializeSession();
+    }
+
+    //--------------------------------------------------------------------------
+    // presentPixelData — called by QTMetalVideoDevice::syncBuffers()
+    //--------------------------------------------------------------------------
+
+    void MetalView::presentPixelData(const void* pixels, int w, int h)
+    {
+        CALayer* layer = (__bridge CALayer*)m_caLayer;
+        if (!layer || w <= 0 || h <= 0)
+            return;
+
+        // Create/recreate IOSurface if size changed
+        if (!m_ioSurface
+            || m_ioSurfaceWidth  != w
+            || m_ioSurfaceHeight != h)
+        {
+            if (m_ioSurface)
+            {
+                CFRelease((IOSurfaceRef)m_ioSurface);
+                m_ioSurface = nullptr;
+            }
+
+            // kCVPixelFormatType_ARGB2101010LEPacked ('l30r') = 0x6C333072:
+            //   32-bit word, big-endian bit order: A[31:30] R[29:20] G[19:10] B[9:0]
+            //   Stored little-endian in memory; CA handles this format natively
+            //   for 10-bit wide-color display.
+            NSDictionary* props = @{
+                (NSString*)kIOSurfaceWidth:           @(w),
+                (NSString*)kIOSurfaceHeight:          @(h),
+                (NSString*)kIOSurfaceBytesPerElement: @(4),
+                (NSString*)kIOSurfacePixelFormat:     @(kCVPixelFormatType_ARGB2101010LEPacked),
+            };
+            IOSurfaceRef surf = IOSurfaceCreate((__bridge CFDictionaryRef)props);
+            if (!surf)
+            {
+                std::cerr << "[MetalView::presentPixelData] IOSurfaceCreate failed "
+                          << w << "x" << h << "\n";
+                return;
+            }
+
+            m_ioSurface       = surf;
+            m_ioSurfaceWidth  = w;
+            m_ioSurfaceHeight = h;
+        }
+
+        IOSurfaceRef surf = (IOSurfaceRef)m_ioSurface;
+
+        // Lock the IOSurface for CPU write
+        IOSurfaceLock(surf, 0, nullptr);
+
+        void*  base   = IOSurfaceGetBaseAddress(surf);
+        size_t bpr    = IOSurfaceGetBytesPerRow(surf);
+        size_t srcBpr = (size_t)w * 4;
+
+        if (bpr == srcBpr)
+        {
+            memcpy(base, pixels, (size_t)h * bpr);
+        }
+        else
+        {
+            // IOSurface may add row padding — copy row by row
+            const uint8_t* src = static_cast<const uint8_t*>(pixels);
+            uint8_t*       dst = static_cast<uint8_t*>(base);
+            for (int row = 0; row < h; ++row, src += srcBpr, dst += bpr)
+                memcpy(dst, src, srcBpr);
+        }
+
+        IOSurfaceUnlock(surf, 0, nullptr);
+
+        // Push to display: assign IOSurface as layer contents inside a
+        // CATransaction with animations disabled for immediate presentation.
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        layer.contents = (__bridge id)surf;
+        [CATransaction commit];
+    }
+
+    //--------------------------------------------------------------------------
+
+    void MetalView::render()
+    {
+        IPCore::Session* session = m_doc ? m_doc->session() : nullptr;
+        if (!session)
+            return;
+
+        if (m_doc && session && m_videoDevice)
+        {
+            m_videoDevice->makeCurrent();
+
+            if (m_userActive && m_activityTimer.elapsed() > 1.0)
+            {
+                if (m_doc->mainPopup() && !m_doc->mainPopup()->isVisible()
+                    && m_eventWidget && m_eventWidget->hasFocus())
+                {
+                    TwkApp::ActivityChangeEvent aevent("user-inactive", m_videoDevice);
+                    m_videoDevice->sendEvent(aevent);
+                    m_userActive = false;
+                }
+            }
+
+            int x = 0, y = 0;
+            absolutePosition(x, y);
+            m_videoDevice->setAbsolutePosition(x, y);
+
+            session->render();
+
+            // Mirror GLView::paintGL(): on the first non-empty render, resize the
+            // window to fit the media content and center it on screen.
+            if (!m_postFirstNonEmptyRender && session->postFirstNonEmptyRender())
+            {
+                m_postFirstNonEmptyRender = true;
+                if (!session->isFullScreen())
+                {
+                    m_doc->resizeToFit(false, false);
+                    m_doc->center();
+                }
+            }
+
+            m_firstPaintCompleted = true;
+        }
+
+        if (m_stopProcessingEvents)
+            return;
+
+        if (session)
+        {
+            if (session->outputVideoDevice() != videoDevice())
+                session->outputVideoDevice()->syncBuffers();
+            else
+                m_videoDevice->syncBuffers();
+        }
+
+        if (session)
+        {
+            session->addSyncSample();
+            session->postRender();
+        }
+
+        m_eventProcessingTimer.start();
+    }
+
+    //--------------------------------------------------------------------------
+    // QWidget overrides
+    //--------------------------------------------------------------------------
+
+    void MetalView::showEvent(QShowEvent* event)
+    {
+        if (!m_initialized)
+            initialize();
+        // Post an UpdateRequest so the first render fires from the event loop
+        // after the widget is fully laid out (same pattern as QOpenGLWindow).
+        QCoreApplication::postEvent(this, new QEvent(QEvent::UpdateRequest));
+        QWidget::showEvent(event);
+    }
+
+    void MetalView::resizeEvent(QResizeEvent* event)
+    {
+        // Update the layer's contentsScale to match the current DPR.
+        // The NSView layer frame is managed automatically by AppKit as the
+        // widget is resized — no manual frame update required.
+        CALayer* layer = (__bridge CALayer*)m_caLayer;
+        if (layer)
+        {
+            CGFloat scale = static_cast<CGFloat>(devicePixelRatioF());
+            if (scale < 1.0) scale = 1.0;
+            layer.contentsScale = scale;
+        }
+
+        if (m_doc)
+            m_doc->viewSizeChanged(event->size().width(), event->size().height());
+
+        QWidget::resizeEvent(event);
+    }
+
+    //--------------------------------------------------------------------------
+    // eventProcessingTimeout slot
+    //--------------------------------------------------------------------------
+
+    void MetalView::eventProcessingTimeout()
+    {
+        if (m_doc && m_doc->session())
+            m_doc->session()->userGenericEvent("per-render-event-processing", "");
+    }
+
+    //--------------------------------------------------------------------------
+    // event() — mirrors GLView::event() exactly
+    //--------------------------------------------------------------------------
+
+    bool MetalView::event(QEvent* event)
+    {
+        bool keyevent = false;
+        Rv::Session* session = m_doc ? m_doc->session() : nullptr;
+
+        if (m_stopProcessingEvents)
+        {
+            event->accept();
+            return true;
+        }
+
+        if (event->type() == QEvent::WindowActivate)
+            m_activationTimer.start();
+
+        float activationTime = 0.0f;
+        if (m_activationTimer.isRunning())
+        {
+            if (event->type() == QEvent::MouseButtonPress)
+            {
+                activationTime = m_activationTimer.elapsed();
+                m_activationTimer.stop();
+            }
+            if (event->type() == QEvent::MouseMove)
+                m_activationTimer.stop();
+        }
+
+        if (event->type() != QEvent::Paint)
+        {
+            m_activityTimer.stop();
+            m_activityTimer.start();
+
+            if (!m_userActive)
+            {
+                TwkApp::ActivityChangeEvent aevent("user-active", m_videoDevice);
+                m_userActive = true;
+                m_videoDevice->sendEvent(aevent);
+            }
+        }
+
+        if (QKeyEvent* kevent = dynamic_cast<QKeyEvent*>(event))
+        {
+            keyevent = true;
+            if (m_lastKey == kevent->key()
+                && (m_lastKeyType == QEvent::ShortcutOverride
+                        && (kevent->type() == QEvent::KeyPress)
+                    || (m_lastKeyType == kevent->type())))
+            {
+                m_lastKey     = kevent->key();
+                m_lastKeyType = kevent->type();
+                event->accept();
+                return true;
+            }
+            m_lastKeyType = kevent->type();
+            m_lastKey     = kevent->key();
+        }
+
+        switch (event->type())
+        {
+        case QEvent::FocusIn:
+            m_videoDevice->translator().resetModifiers();
+            // fall-through
+        case QEvent::Enter:
+            if (m_eventWidget)
+                m_eventWidget->setFocus(Qt::MouseFocusReason);
+            break;
+        default:
+            break;
+        }
+
+        if (event->type() == QEvent::Resize)
+        {
+            QResizeEvent* e = static_cast<QResizeEvent*>(event);
+            if (!isVisible())
+                return true;
+            if (e->oldSize().width() != -1 && e->oldSize().height() != -1)
+            {
+                ostringstream contents;
+                contents << e->oldSize().width() << " " << e->oldSize().height()
+                         << "|" << e->size().width() << " " << e->size().height();
+                if (m_doc && session)
+                    session->userGenericEvent("view-resized", contents.str());
+            }
+            return QWidget::event(event);
+        }
+
+        if (event->type() == QEvent::UpdateRequest)
+        {
+            render();
+            return true;
+        }
+
+        // Guard: translator may not be initialized yet (e.g. events fired
+        // during construction before setEventWidget() is called).
+        if (!m_videoDevice || !m_videoDevice->hasTranslator())
+            return QWidget::event(event);
+
+        if (session && session->outputVideoDevice()
+            && session->outputVideoDevice()->displayMode()
+                   == TwkApp::VideoDevice::MirrorDisplayMode)
+        {
+            if (const TwkApp::VideoDevice* cdv = session->controlVideoDevice())
+            {
+                const TwkApp::VideoDevice* odv = session->outputVideoDevice();
+                if (odv && cdv != odv && cdv == videoDevice())
+                {
+                    const float w  = static_cast<float>(width());
+                    const float h  = static_cast<float>(height());
+                    const float ow = static_cast<float>(odv->width());
+                    const float oh = static_cast<float>(odv->height());
+                    const float aspect  = w / h;
+                    const float oaspect = ow / oh;
+
+                    m_videoDevice->translator().setRelativeDomain(ow, oh);
+
+                    if (aspect >= oaspect)
+                    {
+                        const float yscale  = oh / h;
+                        const float yoffset = 0.0f;
+                        const float xscale  = yscale;
+                        const float xoffset = -(w * yscale - ow) / 2.0f;
+                        m_videoDevice->translator().setScaleAndOffset(
+                            xoffset, yoffset, xscale, yscale);
+                    }
+                    else
+                    {
+                        const float xscale  = ow / w;
+                        const float xoffset = 0.0f;
+                        const float yscale  = xscale;
+                        const float yoffset = -(xscale * h - oh) / 2.0f;
+                        m_videoDevice->translator().setScaleAndOffset(
+                            xoffset, yoffset, xscale, yscale);
+                    }
+                }
+                else
+                {
+                    m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0f, 1.0f);
+                    m_videoDevice->translator().setRelativeDomain(width(), height());
+                }
+            }
+            else
+            {
+                m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0f, 1.0f);
+                m_videoDevice->translator().setRelativeDomain(width(), height());
+            }
+        }
+        else
+        {
+            m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0f, 1.0f);
+            m_videoDevice->translator().setRelativeDomain(width(), height());
+        }
+
+        if (session)
+            session->setEventVideoDevice(videoDevice());
+
+        if (m_videoDevice->translator().sendQTEvent(event, activationTime))
+        {
+            event->accept();
+            return true;
+        }
+        else
+        {
+            return QWidget::event(event);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // eventFilter() — mirrors GLView::eventFilter()
+    //--------------------------------------------------------------------------
+
+    bool MetalView::eventFilter(QObject* object, QEvent* event)
+    {
+        if (event->type() == QEvent::KeyPress    || event->type() == QEvent::KeyRelease
+            || event->type() == QEvent::Shortcut || event->type() == QEvent::ShortcutOverride)
+        {
+            if (QKeyEvent* kevent = dynamic_cast<QKeyEvent*>(event))
+            {
+                if (m_lastKey == kevent->key()
+                    && (m_lastKeyType == QEvent::ShortcutOverride
+                            && (kevent->type() == QEvent::KeyPress)
+                        || (m_lastKeyType == kevent->type())))
+                {
+                    m_lastKey     = kevent->key();
+                    m_lastKeyType = kevent->type();
+                    event->accept();
+                    return true;
+                }
+                m_lastKeyType = kevent->type();
+                m_lastKey     = kevent->key();
+            }
+
+            Session* session = m_doc ? m_doc->session() : nullptr;
+            if (session)
+            {
+                session->setEventVideoDevice(videoDevice());
+                if (m_videoDevice->translator().sendQTEvent(event))
+                {
+                    event->accept();
+                    return true;
+                }
+            }
+
+            event->accept();
+            return true;
+        }
+
+        return false;
+    }
+
+} // namespace Rv
+
+#endif // PLATFORM_DARWIN

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -214,8 +214,8 @@ namespace Rv
         // Metal drawable), _NSOpenGLViewBackingLayer does not intercept or tile the
         // content — the CA render server composites IOSurface data independently.
         NSView* nsView = (__bridge NSView*)reinterpret_cast<void*>(winId());
-        [nsView setLayer:caLayer];
         [nsView setWantsLayer:YES];
+        [nsView setLayer:caLayer];
 
         CGFloat scale = static_cast<CGFloat>(devicePixelRatioF());
         if (scale < 1.0) scale = 1.0;
@@ -238,36 +238,33 @@ namespace Rv
         if (!layer || w <= 0 || h <= 0)
             return;
 
-        // Create/recreate IOSurface if size changed
+        // Create/recreate IOSurface if size changed.  Allocate the replacement
+        // before releasing the old surface so a failed recreate keeps the last
+        // good IOSurface for display.
         if (!m_ioSurface
             || m_ioSurfaceWidth  != w
             || m_ioSurfaceHeight != h)
         {
-            if (m_ioSurface)
-            {
-                CFRelease((IOSurfaceRef)m_ioSurface);
-                m_ioSurface = nullptr;
-            }
-
-            // kCVPixelFormatType_ARGB2101010LEPacked ('l30r') = 0x6C333072:
-            //   32-bit word, big-endian bit order: A[31:30] R[29:20] G[19:10] B[9:0]
-            //   Stored little-endian in memory; CA handles this format natively
-            //   for 10-bit wide-color display.
             NSDictionary* props = @{
                 (NSString*)kIOSurfaceWidth:           @(w),
                 (NSString*)kIOSurfaceHeight:          @(h),
                 (NSString*)kIOSurfaceBytesPerElement: @(4),
                 (NSString*)kIOSurfacePixelFormat:     @(kCVPixelFormatType_ARGB2101010LEPacked),
             };
-            IOSurfaceRef surf = IOSurfaceCreate((__bridge CFDictionaryRef)props);
-            if (!surf)
+            IOSurfaceRef newSurf = IOSurfaceCreate((__bridge CFDictionaryRef)props);
+            if (!newSurf)
             {
                 std::cerr << "[MetalView::presentPixelData] IOSurfaceCreate failed "
                           << w << "x" << h << "\n";
                 return;
             }
 
-            m_ioSurface       = surf;
+            if (m_ioSurface)
+            {
+                CFRelease((IOSurfaceRef)m_ioSurface);
+            }
+
+            m_ioSurface       = newSurf;
             m_ioSurfaceWidth  = w;
             m_ioSurfaceHeight = h;
         }
@@ -370,10 +367,6 @@ namespace Rv
 
     void MetalView::render()
     {
-        // A render is now happening, so any coalesced UpdateRequest is satisfied;
-        // allow the next redraw() to post a fresh one.
-        m_updatePending = false;
-
         IPCore::Session* session = m_doc ? m_doc->session() : nullptr;
         if (!session)
             return;
@@ -441,10 +434,21 @@ namespace Rv
 
         if (session)
         {
-            if (session->outputVideoDevice() != videoDevice())
-                session->outputVideoDevice()->syncBuffers();
+            if (const TwkApp::VideoDevice* output = session->outputVideoDevice())
+            {
+                if (output != videoDevice())
+                {
+                    output->syncBuffers();
+                }
+                else
+                {
+                    m_videoDevice->syncBuffers();
+                }
+            }
             else
+            {
                 m_videoDevice->syncBuffers();
+            }
         }
 
         if (session)
@@ -504,7 +508,10 @@ namespace Rv
         if (m_lastPresentedSurface)
             presentCachedSurface();
         else
+        {
+            m_updatePending = false;
             render();
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -615,6 +622,7 @@ namespace Rv
 
         if (event->type() == QEvent::UpdateRequest)
         {
+            m_updatePending = false;
             render();
             return true;
         }
@@ -719,7 +727,7 @@ namespace Rv
             }
 
             Session* session = m_doc ? m_doc->session() : nullptr;
-            if (session)
+            if (session && m_videoDevice && m_videoDevice->hasTranslator())
             {
                 session->setEventVideoDevice(videoDevice());
                 if (m_videoDevice->translator().sendQTEvent(event))

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -398,6 +398,11 @@ namespace Rv
             m_doc->viewSizeChanged(event->size().width(), event->size().height());
 
         QWidget::resizeEvent(event);
+
+        // QOpenGLWidget schedules a paintGL() after every resizeGL(); as a plain
+        // QWidget we must request a fresh render ourselves so the FBO/IOSurface
+        // rebuild at the new size (e.g. when dragging the Live Review panel).
+        requestUpdate();
     }
 
     void MetalView::paintEvent(QPaintEvent* /*event*/)

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -299,6 +299,12 @@ namespace Rv
         QCoreApplication::postEvent(this, new QEvent(QEvent::UpdateRequest));
     }
 
+    void MetalView::renderImmediately()
+    {
+        m_updatePending = false;
+        render();
+    }
+
     //--------------------------------------------------------------------------
 
     void MetalView::render()
@@ -314,6 +320,8 @@ namespace Rv
         if (m_doc && session && m_videoDevice)
         {
             m_videoDevice->makeCurrent();
+            if (!m_videoDevice->isGLContextReady())
+                return;
 
             if (m_userActive && m_activityTimer.elapsed() > 1.0)
             {

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -59,6 +59,8 @@ namespace Rv
         , m_ioSurface(nullptr)
         , m_ioSurfaceWidth(0)
         , m_ioSurfaceHeight(0)
+        , m_lastPresentedSurface(nullptr)
+        , m_updatePending(false)
     {
         // Ensure a native NSView is created immediately so winId() is valid
         // when initialize() is called from showEvent().
@@ -233,17 +235,17 @@ namespace Rv
         IOSurfaceUnlock(surf, 0, nullptr);
 
         // Push to display.
-        presentCachedSurface();
+        presentIOSurface(m_ioSurface);
     }
 
     //--------------------------------------------------------------------------
-    // presentCachedSurface — (re)assign the cached IOSurface as layer contents
+    // presentIOSurface — assign an IOSurface as the CALayer contents
     //--------------------------------------------------------------------------
 
-    void MetalView::presentCachedSurface()
+    void MetalView::presentIOSurface(void* ioSurfaceRef)
     {
         CALayer*     layer = (__bridge CALayer*)m_caLayer;
-        IOSurfaceRef surf  = (IOSurfaceRef)m_ioSurface;
+        IOSurfaceRef surf  = (IOSurfaceRef)ioSurfaceRef;
         if (!layer || !surf)
             return;
 
@@ -253,12 +255,43 @@ namespace Rv
         [CATransaction setDisableActions:YES];
         layer.contents = (__bridge id)surf;
         [CATransaction commit];
+
+        // Remember for re-present on expose.  The CALayer holds its own retain
+        // on the contents, so this raw pointer stays valid as long as the layer
+        // references it.
+        m_lastPresentedSurface = ioSurfaceRef;
+    }
+
+    //--------------------------------------------------------------------------
+    // presentCachedSurface — re-present the last IOSurface (no GL readback)
+    //--------------------------------------------------------------------------
+
+    void MetalView::presentCachedSurface()
+    {
+        if (m_lastPresentedSurface)
+            presentIOSurface(m_lastPresentedSurface);
+    }
+
+    //--------------------------------------------------------------------------
+    // requestUpdate — coalesced UpdateRequest post
+    //--------------------------------------------------------------------------
+
+    void MetalView::requestUpdate()
+    {
+        if (m_updatePending)
+            return;
+        m_updatePending = true;
+        QCoreApplication::postEvent(this, new QEvent(QEvent::UpdateRequest));
     }
 
     //--------------------------------------------------------------------------
 
     void MetalView::render()
     {
+        // A render is now happening, so any coalesced UpdateRequest is satisfied;
+        // allow the next redraw() to post a fresh one.
+        m_updatePending = false;
+
         IPCore::Session* session = m_doc ? m_doc->session() : nullptr;
         if (!session)
             return;
@@ -329,7 +362,7 @@ namespace Rv
             initialize();
         // Post an UpdateRequest so the first render fires from the event loop
         // after the widget is fully laid out (same pattern as QOpenGLWindow).
-        QCoreApplication::postEvent(this, new QEvent(QEvent::UpdateRequest));
+        requestUpdate();
         QWidget::showEvent(event);
     }
 
@@ -359,7 +392,7 @@ namespace Rv
         // image.  Re-present the last cached IOSurface — cheap, no GL readback —
         // which is the Metal analog of VulkanView::paintEvent -> syncBuffers.  If
         // nothing has been rendered yet, produce a frame.
-        if (m_ioSurface)
+        if (m_lastPresentedSurface)
             presentCachedSurface();
         else
             render();

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -274,12 +274,26 @@ namespace Rv
 
         IOSurfaceRef surf = (IOSurfaceRef)m_ioSurface;
 
-        // Lock the IOSurface for CPU write
-        IOSurfaceLock(surf, 0, nullptr);
+        // Lock the IOSurface for CPU write.  Bail out if the lock fails or the
+        // base address is null — writing through a null/garbage pointer would
+        // corrupt memory or crash.
+        if (IOSurfaceLock(surf, 0, nullptr) != KERN_SUCCESS)
+        {
+            std::cerr << "[MetalView::presentPixelData] IOSurfaceLock failed\n";
+            return;
+        }
 
         void*  base   = IOSurfaceGetBaseAddress(surf);
         size_t bpr    = IOSurfaceGetBytesPerRow(surf);
         size_t srcBpr = (size_t)w * 4;
+
+        if (!base)
+        {
+            std::cerr << "[MetalView::presentPixelData] IOSurface base address "
+                         "is null\n";
+            IOSurfaceUnlock(surf, 0, nullptr);
+            return;
+        }
 
         if (bpr == srcBpr)
         {
@@ -567,7 +581,13 @@ namespace Rv
         switch (event->type())
         {
         case QEvent::FocusIn:
-            m_videoDevice->translator().resetModifiers();
+            // The translator is created lazily by setEventWidget(); a focus
+            // event arriving before that would otherwise dereference a null
+            // translator (the general guard below runs only after this switch).
+            if (m_videoDevice && m_videoDevice->hasTranslator())
+            {
+                m_videoDevice->translator().resetModifiers();
+            }
             // fall-through
         case QEvent::Enter:
             if (m_eventWidget)

--- a/src/lib/app/RvCommon/MetalView.mm
+++ b/src/lib/app/RvCommon/MetalView.mm
@@ -10,6 +10,7 @@
 #import <AppKit/AppKit.h>
 #import <IOSurface/IOSurface.h>
 #import <CoreVideo/CoreVideo.h>
+#import <Metal/Metal.h>
 
 #include <RvCommon/MetalView.h>
 #include <RvCommon/QTMetalVideoDevice.h>
@@ -103,6 +104,20 @@ namespace Rv
             (void)layer;
             m_caLayer = nullptr;
         }
+    }
+
+    //--------------------------------------------------------------------------
+
+    bool MetalView::supports10BitPresentation()
+    {
+        // The 10-bit presentation path renders into an IOSurface with pixel
+        // format kCVPixelFormatType_ARGB2101010LEPacked (see presentPixelData)
+        // which the window server composites correctly on every Metal-capable
+        // Mac.  A Metal device is therefore the only requirement.
+        // This file is compiled with -fobjc-arc; ARC releases the device when it
+        // goes out of scope, so no explicit release is needed.
+        id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+        return device != nil;
     }
 
     //--------------------------------------------------------------------------

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -473,7 +473,7 @@ namespace Rv
 
         s->receivingEvents(false);
 
-        QPoint p = rvDoc->view()->mapToGlobal(location);
+        QPoint p = rvDoc->viewWidget()->mapToGlobal(location);
 
         if (array)
         {
@@ -500,11 +500,11 @@ namespace Rv
 
         if (const TwkApp::PointerEvent* pevent = dynamic_cast<const TwkApp::PointerEvent*>(e->event))
         {
-            lp = QPoint(pevent->x(), rvDoc->view()->height() - pevent->y() - 1);
+            lp = QPoint(pevent->x(), rvDoc->viewWidget()->height() - pevent->y() - 1);
         }
         else
         {
-            lp = QPoint(0, rvDoc->view()->height() - 1);
+            lp = QPoint(0, rvDoc->viewWidget()->height() - 1);
         }
 
         popupMenuInternal(array, lp);
@@ -518,7 +518,7 @@ namespace Rv
         int y = NODE_ARG(1, int);
         DynamicArray* array = NODE_ARG_OBJECT(2, DynamicArray);
 
-        QPoint lp(x, rvDoc->view()->height() - y - 1);
+        QPoint lp(x, rvDoc->viewWidget()->height() - y - 1);
 
         popupMenuInternal(array, lp);
     }
@@ -653,7 +653,7 @@ namespace Rv
 
         rvDoc->setDocumentDisabled(false, true);
         bool result = dialog.exec();
-        rvDoc->view()->setFocus(Qt::OtherFocusReason);
+        rvDoc->viewWidget()->setFocus(Qt::OtherFocusReason);
         rvDoc->setDocumentDisabled(false, false);
 
         if (result)
@@ -776,7 +776,7 @@ namespace Rv
 
         rvDoc->setDocumentDisabled(false, true);
         bool result = dialog.exec();
-        rvDoc->view()->setFocus(Qt::OtherFocusReason);
+        rvDoc->viewWidget()->setFocus(Qt::OtherFocusReason);
         rvDoc->setDocumentDisabled(false, false);
 
         if (result)
@@ -885,7 +885,7 @@ namespace Rv
         {
             rvDoc->setDocumentDisabled(false, true);
             bool result = dialog.exec();
-            rvDoc->view()->setFocus(Qt::OtherFocusReason);
+            rvDoc->viewWidget()->setFocus(Qt::OtherFocusReason);
             rvDoc->setDocumentDisabled(false, false);
 
             if (result)
@@ -955,7 +955,7 @@ namespace Rv
     {
         Session* s = Session::currentSession();
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
-        rvDoc->view()->setCursor(QCursor(Qt::CursorShape(NODE_ARG(0, int))));
+        rvDoc->viewWidget()->setCursor(QCursor(Qt::CursorShape(NODE_ARG(0, int))));
     }
 
     NODE_IMPLEMENTATION(alertPanel, int)
@@ -1026,7 +1026,7 @@ namespace Rv
         else if (box.clickedButton() == q3 && b3)
             result = 2;
 
-        doc->view()->setFocus(Qt::OtherFocusReason);
+        doc->viewWidget()->setFocus(Qt::OtherFocusReason);
         NODE_RETURN(result);
     }
 
@@ -2154,9 +2154,9 @@ namespace Rv
         const Session* s = Session::currentSession();
         const RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
 
-        if (doc != nullptr && doc->view() != nullptr)
+        if (doc != nullptr && doc->viewWidget() != nullptr)
         {
-            devicePixelRatio = doc->view()->devicePixelRatio();
+            devicePixelRatio = static_cast<float>(doc->viewWidget()->devicePixelRatioF());
         }
 
         NODE_RETURN(devicePixelRatio);

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -473,7 +473,14 @@ namespace Rv
 
         s->receivingEvents(false);
 
-        QPoint p = rvDoc->viewWidget()->mapToGlobal(location);
+        // viewWidget() is briefly null while the presentation view is being (re)built
+        QWidget* view = rvDoc->viewWidget();
+        if (!view)
+        {
+            return;
+        }
+
+        QPoint p = view->mapToGlobal(location);
 
         if (array)
         {
@@ -498,13 +505,19 @@ namespace Rv
         DynamicArray* array = NODE_ARG_OBJECT(1, DynamicArray);
         QPoint lp;
 
+        QWidget* view = rvDoc->viewWidget();
+        if (!view)
+        {
+            return;
+        }
+
         if (const TwkApp::PointerEvent* pevent = dynamic_cast<const TwkApp::PointerEvent*>(e->event))
         {
-            lp = QPoint(pevent->x(), rvDoc->viewWidget()->height() - pevent->y() - 1);
+            lp = QPoint(pevent->x(), view->height() - pevent->y() - 1);
         }
         else
         {
-            lp = QPoint(0, rvDoc->viewWidget()->height() - 1);
+            lp = QPoint(0, view->height() - 1);
         }
 
         popupMenuInternal(array, lp);
@@ -518,7 +531,13 @@ namespace Rv
         int y = NODE_ARG(1, int);
         DynamicArray* array = NODE_ARG_OBJECT(2, DynamicArray);
 
-        QPoint lp(x, rvDoc->viewWidget()->height() - y - 1);
+        QWidget* view = rvDoc->viewWidget();
+        if (!view)
+        {
+            return;
+        }
+
+        QPoint lp(x, view->height() - y - 1);
 
         popupMenuInternal(array, lp);
     }

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -672,7 +672,10 @@ namespace Rv
 
         rvDoc->setDocumentDisabled(false, true);
         bool result = dialog.exec();
-        rvDoc->viewWidget()->setFocus(Qt::OtherFocusReason);
+        if (QWidget* view = rvDoc->viewWidget())
+        {
+            view->setFocus(Qt::OtherFocusReason);
+        }
         rvDoc->setDocumentDisabled(false, false);
 
         if (result)
@@ -795,7 +798,10 @@ namespace Rv
 
         rvDoc->setDocumentDisabled(false, true);
         bool result = dialog.exec();
-        rvDoc->viewWidget()->setFocus(Qt::OtherFocusReason);
+        if (QWidget* view = rvDoc->viewWidget())
+        {
+            view->setFocus(Qt::OtherFocusReason);
+        }
         rvDoc->setDocumentDisabled(false, false);
 
         if (result)
@@ -904,7 +910,10 @@ namespace Rv
         {
             rvDoc->setDocumentDisabled(false, true);
             bool result = dialog.exec();
-            rvDoc->viewWidget()->setFocus(Qt::OtherFocusReason);
+            if (QWidget* view = rvDoc->viewWidget())
+            {
+                view->setFocus(Qt::OtherFocusReason);
+            }
             rvDoc->setDocumentDisabled(false, false);
 
             if (result)
@@ -974,7 +983,10 @@ namespace Rv
     {
         Session* s = Session::currentSession();
         RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
-        rvDoc->viewWidget()->setCursor(QCursor(Qt::CursorShape(NODE_ARG(0, int))));
+        if (QWidget* view = rvDoc->viewWidget())
+        {
+            view->setCursor(QCursor(Qt::CursorShape(NODE_ARG(0, int))));
+        }
     }
 
     NODE_IMPLEMENTATION(alertPanel, int)
@@ -1045,7 +1057,10 @@ namespace Rv
         else if (box.clickedButton() == q3 && b3)
             result = 2;
 
-        doc->viewWidget()->setFocus(Qt::OtherFocusReason);
+        if (QWidget* view = doc->viewWidget())
+        {
+            view->setFocus(Qt::OtherFocusReason);
+        }
         NODE_RETURN(result);
     }
 
@@ -1054,6 +1069,12 @@ namespace Rv
         Session* s = Session::currentSession();
         RvDocument* doc = (RvDocument*)s->opaquePointer();
 
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        // Hardware stereo needs a stereo QSurfaceFormat on QOpenGLWidget; the
+        // Metal path presents via CALayer/IOSurface and has no GL window surface.
+        if (doc->metalView() && !doc->view())
+            NODE_RETURN(false);
+#endif
         NODE_RETURN(true);
     }
 

--- a/src/lib/app/RvCommon/MuUICommands.cpp
+++ b/src/lib/app/RvCommon/MuUICommands.cpp
@@ -1731,7 +1731,13 @@ namespace Rv
         MuLangContext* c = static_cast<MuLangContext*>(p->context());
         Session* s = Session::currentSession();
         RvDocument* doc = reinterpret_cast<RvDocument*>(s->opaquePointer());
-        QWidget* w = doc->view();
+        // Use viewWidget() (the active presentation widget) rather than view()
+        // (the legacy GLView). On the Metal/Vulkan backends m_glView is null while
+        // the active view is a MetalView/VulkanView, so view() would return null.
+        QWidget* w = doc->viewWidget();
+
+        if (w == nullptr)
+            NODE_RETURN(Pointer(0));
 
         const QWidgetType* type = c->findSymbolOfTypeByQualifiedName<QWidgetType>(c->internName("qt.QWidget"), false);
 

--- a/src/lib/app/RvCommon/PyUICommands.cpp
+++ b/src/lib/app/RvCommon/PyUICommands.cpp
@@ -241,7 +241,7 @@ namespace Rv
 
         s->receivingEvents(false);
 
-        QPoint p = rvDoc->view()->mapToGlobal(location);
+        QPoint p = rvDoc->viewWidget()->mapToGlobal(location);
 
         if (pylist)
         {
@@ -273,11 +273,11 @@ namespace Rv
 
         if (const TwkApp::PointerEvent* pevent = dynamic_cast<const TwkApp::PointerEvent*>(event->event))
         {
-            lp = QPoint(pevent->x(), rvDoc->view()->height() - pevent->y() - 1);
+            lp = QPoint(pevent->x(), rvDoc->viewWidget()->height() - pevent->y() - 1);
         }
         else
         {
-            lp = QPoint(0, rvDoc->view()->height() - 1);
+            lp = QPoint(0, rvDoc->viewWidget()->height() - 1);
         }
 
         popupMenuInternal(pylist, lp);
@@ -299,7 +299,7 @@ namespace Rv
             return NULL;
         }
 
-        QPoint lp(x, rvDoc->view()->height() - y - 1);
+        QPoint lp(x, rvDoc->viewWidget()->height() - y - 1);
 
         popupMenuInternal(pylist, lp);
 

--- a/src/lib/app/RvCommon/PyUICommands.cpp
+++ b/src/lib/app/RvCommon/PyUICommands.cpp
@@ -241,7 +241,14 @@ namespace Rv
 
         s->receivingEvents(false);
 
-        QPoint p = rvDoc->viewWidget()->mapToGlobal(location);
+        // viewWidget() is briefly null while the presentation view is being (re)built
+        QWidget* view = rvDoc->viewWidget();
+        if (!view)
+        {
+            return;
+        }
+
+        QPoint p = view->mapToGlobal(location);
 
         if (pylist)
         {
@@ -271,13 +278,20 @@ namespace Rv
 
         QPoint lp;
 
+        QWidget* view = rvDoc->viewWidget();
+        if (!view)
+        {
+            Py_XINCREF(Py_None);
+            return Py_None;
+        }
+
         if (const TwkApp::PointerEvent* pevent = dynamic_cast<const TwkApp::PointerEvent*>(event->event))
         {
-            lp = QPoint(pevent->x(), rvDoc->viewWidget()->height() - pevent->y() - 1);
+            lp = QPoint(pevent->x(), view->height() - pevent->y() - 1);
         }
         else
         {
-            lp = QPoint(0, rvDoc->viewWidget()->height() - 1);
+            lp = QPoint(0, view->height() - 1);
         }
 
         popupMenuInternal(pylist, lp);
@@ -299,7 +313,14 @@ namespace Rv
             return NULL;
         }
 
-        QPoint lp(x, rvDoc->viewWidget()->height() - y - 1);
+        QWidget* view = rvDoc->viewWidget();
+        if (!view)
+        {
+            Py_XINCREF(Py_None);
+            return Py_None;
+        }
+
+        QPoint lp(x, view->height() - y - 1);
 
         popupMenuInternal(pylist, lp);
 

--- a/src/lib/app/RvCommon/QTGLVideoDevice.cpp
+++ b/src/lib/app/RvCommon/QTGLVideoDevice.cpp
@@ -138,29 +138,7 @@ namespace Rv
     {
         if (!isWorkerDevice())
         {
-            if (m_view->isVisible())
-            {
-#ifdef PLATFORM_DARWIN
-                // Make sure that the QGLWidget gets redrawn by updateGL() even
-                // when completely overlapped by another window.
-                // Note that on macOS, Qt correctly detects when the QGLWidget
-                // is completely overlapped by another window and in which case
-                // resets the Qt::WA_Mapped attribute. This will prevent the
-                // GLView::paintGL() operation from being called by
-                // m_view->updateGL(), which will result in automatically
-                // interrupting any video playback that might be in progress
-                // while the RV window is completely overlapped. This is an
-                // undesirable behaviour during a review session, especially if
-                // an external video output device is used.
-                m_view->setAttribute(Qt::WA_Mapped);
-#endif
-
-                m_view->update();
-            }
-            else
-            {
-                redraw();
-            }
+            redraw();
         }
     }
 

--- a/src/lib/app/RvCommon/QTGLVideoDevice.cpp
+++ b/src/lib/app/RvCommon/QTGLVideoDevice.cpp
@@ -138,7 +138,29 @@ namespace Rv
     {
         if (!isWorkerDevice())
         {
-            redraw();
+            if (m_view->isVisible())
+            {
+#ifdef PLATFORM_DARWIN
+                // Make sure that the QGLWidget gets redrawn by updateGL() even
+                // when completely overlapped by another window.
+                // Note that on macOS, Qt correctly detects when the QGLWidget
+                // is completely overlapped by another window and in which case
+                // resets the Qt::WA_Mapped attribute. This will prevent the
+                // GLView::paintGL() operation from being called by
+                // m_view->updateGL(), which will result in automatically
+                // interrupting any video playback that might be in progress
+                // while the RV window is completely overlapped. This is an
+                // undesirable behaviour during a review session, especially if
+                // an external video output device is used.
+                m_view->setAttribute(Qt::WA_Mapped);
+#endif
+
+                m_view->update();
+            }
+            else
+            {
+                redraw();
+            }
         }
     }
 

--- a/src/lib/app/RvCommon/QTGLVideoDevice.cpp
+++ b/src/lib/app/RvCommon/QTGLVideoDevice.cpp
@@ -141,13 +141,13 @@ namespace Rv
             if (m_view->isVisible())
             {
 #ifdef PLATFORM_DARWIN
-                // Make sure that the QGLWidget gets redrawn by updateGL() even
+                // Make sure that the view gets redrawn by update() even
                 // when completely overlapped by another window.
-                // Note that on macOS, Qt correctly detects when the QGLWidget
+                // Note that on macOS, Qt correctly detects when the view
                 // is completely overlapped by another window and in which case
                 // resets the Qt::WA_Mapped attribute. This will prevent the
                 // GLView::paintGL() operation from being called by
-                // m_view->updateGL(), which will result in automatically
+                // m_view->update(), which will result in automatically
                 // interrupting any video playback that might be in progress
                 // while the RV window is completely overlapped. This is an
                 // undesirable behaviour during a review session, especially if

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -1,0 +1,455 @@
+//
+//  Copyright (c) 2026 Autodesk, Inc. All Rights Reserved.
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+#ifdef PLATFORM_DARWIN
+
+#import <AppKit/AppKit.h>
+
+#include <RvCommon/QTMetalVideoDevice.h>
+#include <RvCommon/MetalView.h>
+#include <RvCommon/DesktopVideoDevice.h>
+#include <TwkApp/Application.h>
+#include <TwkApp/VideoModule.h>
+#include <TwkApp/Event.h>
+#include <IPCore/Session.h>
+#include <TwkGLF/GLFBO.h>
+
+#include <QScreen>
+#include <QGuiApplication>
+#include <QSurfaceFormat>
+
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+namespace Rv
+{
+    using namespace std;
+    using namespace TwkApp;
+
+    QTMetalVideoDevice::QTMetalVideoDevice(VideoModule* module,
+                                           const string& name,
+                                           MetalView* view,
+                                           QWidget* eventWidget)
+        : TwkGLF::GLVideoDevice(module, name,
+                                 VideoDevice::ImageOutput | VideoDevice::ProvidesSync | VideoDevice::SubWindow)
+        , m_view(view)
+        , m_eventWidget(eventWidget)
+        , m_translator(eventWidget ? new QTTranslator(this, eventWidget) : nullptr)
+    {
+        assert(view);
+    }
+
+    QTMetalVideoDevice::~QTMetalVideoDevice()
+    {
+        // Delete the FBO and its colour texture while the GL context is current.
+        // GLFBO::attachColorTexture passes owner=false so GLFBO does NOT delete
+        // the colour texture — we must do it explicitly here.
+        if (m_glContext && (m_fbo || m_fboColorTex))
+        {
+            m_glContext->makeCurrent(m_offscreenSurface);
+            delete m_fbo;
+            m_fbo = nullptr;
+            if (m_fboColorTex)
+            {
+                glDeleteTextures(1, &m_fboColorTex);
+                m_fboColorTex = 0;
+            }
+            m_glContext->doneCurrent();
+        }
+
+        delete m_offscreenSurface;
+        m_offscreenSurface = nullptr;
+
+        delete m_glContext;
+        m_glContext = nullptr;
+
+        delete m_translator;
+    }
+
+    void QTMetalVideoDevice::setEventWidget(QWidget* widget)
+    {
+        m_eventWidget = widget;
+        delete m_translator;
+        m_translator = widget ? new QTTranslator(this, widget) : nullptr;
+    }
+
+    //--------------------------------------------------------------------------
+
+    void QTMetalVideoDevice::ensureGLContext() const
+    {
+        if (!m_glContext)
+        {
+            //
+            // Create a QOpenGLContext with the same format that GLView uses
+            // (GL 2.1, no profile).  On macOS, Qt backs QOffscreenSurface with
+            // a hidden NSView, so the context gets a real native surface —
+            // required for GL-on-Metal on Apple Silicon where a raw
+            // NSOpenGLContext without a view silently fails to become current.
+            //
+            QSurfaceFormat fmt;
+            fmt.setRenderableType(QSurfaceFormat::OpenGL);
+            // Use GL 2.1 Compatibility profile — the existing IPCore pipeline
+            // calls legacy APIs (glPushAttrib, GL_LIGHTING, GL_MAX_TEXTURE_UNITS,
+            // etc.) that are absent in Core profile.  With GL 2.1, GLSL is 1.20
+            // and ShaderFunction::initGLSLVersion() is hardcoded to 1.20 on the
+            // USE_METAL path, so replaceTextureCalls() uses texture2DRect() which
+            // is available with GL_ARB_texture_rectangle.
+            fmt.setMajorVersion(2);
+            fmt.setMinorVersion(1);
+            // No setProfile() — defaults to NoProfile (Compatibility) on macOS.
+
+            m_glContext = new QOpenGLContext();
+            m_glContext->setFormat(fmt);
+
+            if (!m_glContext->create())
+            {
+                std::cerr << "[QTMetalVideoDevice] QOpenGLContext::create() failed\n";
+                delete m_glContext;
+                m_glContext = nullptr;
+                return;
+            }
+
+            // Surface format MUST be set from the *actual* context format, not
+            // the requested one, to guarantee compatibility.
+            m_offscreenSurface = new QOffscreenSurface();
+            m_offscreenSurface->setFormat(m_glContext->format());
+            m_offscreenSurface->create();
+
+            if (!m_offscreenSurface->isValid())
+            {
+                std::cerr << "[QTMetalVideoDevice] QOffscreenSurface::create() failed\n";
+                delete m_offscreenSurface;
+                m_offscreenSurface = nullptr;
+                delete m_glContext;
+                m_glContext = nullptr;
+                return;
+            }
+        }
+
+        if (!m_glContext->makeCurrent(m_offscreenSurface))
+        {
+            std::cerr << "[QTMetalVideoDevice] makeCurrent() failed\n";
+            return;
+        }
+
+        // Size the FBO in PHYSICAL pixels so it matches the IOSurface
+        // (which is sized at bounds × contentsScale = bounds × DPR).
+        // IPCore receives width()/height() in physical pixels and renders at
+        // that resolution.  Event coordinates from Qt are in logical pixels
+        // and are mapped through setRelativeDomain(QWindow::width(), height())
+        // which uses logical dimensions — so input handling is unaffected.
+        const float dpr = m_view ? m_view->devicePixelRatio() : 1.0f;
+        int newW = m_view ? static_cast<int>(m_view->width()  * dpr + 0.5f) : 128;
+        int newH = m_view ? static_cast<int>(m_view->height() * dpr + 0.5f) : 128;
+        if (newW < 1) newW = 128;
+        if (newH < 1) newH = 128;
+
+        if (!m_fbo || m_fboWidth != newW || m_fboHeight != newH)
+        {
+            // Destroy the old FBO.  GLFBO::attachColorTexture passes owner=false
+            // so GLFBO does NOT delete the attached texture — we must do it here.
+            delete m_fbo;
+            m_fbo = nullptr;
+            if (m_fboColorTex)
+            {
+                glDeleteTextures(1, &m_fboColorTex);
+                m_fboColorTex = 0;
+            }
+
+            // Use a texture attachment for the colour buffer.
+            // GL_RGBA16F_ARB is supported for *textures* (with ARB_texture_float)
+            // on macOS GL 2.1, but is NOT a valid renderbuffer internal format on
+            // that profile — an incomplete FBO would silently swallow all draws.
+            // A GL_TEXTURE_RECTANGLE_ARB attachment gives us full float precision
+            // and guarantees a complete FBO.
+            glGenTextures(1, &m_fboColorTex);
+            glBindTexture(GL_TEXTURE_RECTANGLE_ARB, m_fboColorTex);
+            glTexImage2D(GL_TEXTURE_RECTANGLE_ARB, 0, GL_RGBA16F_ARB,
+                         newW, newH, 0, GL_RGBA, GL_FLOAT, nullptr);
+            glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+            m_fbo = new TwkGLF::GLFBO(newW, newH, GL_RGBA16F_ARB);
+            m_fbo->attachColorTexture(GL_TEXTURE_RECTANGLE_ARB, m_fboColorTex);
+            // attachColorTexture stores owner=false; we retain the texID and
+            // delete it ourselves on the next resize or in the destructor.
+
+            GLenum status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+            if (status != GL_FRAMEBUFFER_COMPLETE_EXT)
+                std::cerr << "[QTMetalVideoDevice] FBO incomplete: 0x"
+                          << std::hex << status << std::dec << "\n";
+
+            m_fboWidth  = newW;
+            m_fboHeight = newH;
+        }
+
+        // Bind FBO so all GL rendering goes into it
+        m_fbo->bind();
+
+        // Let GLVideoDevice do its bookkeeping (GLtext context, etc.)
+        GLVideoDevice::makeCurrent();
+    }
+
+    //--------------------------------------------------------------------------
+
+    void QTMetalVideoDevice::setAbsolutePosition(int x, int y)
+    {
+        if (x != m_x || y != m_y || m_refresh == -1.0f)
+        {
+            float refresh = -1.0f;
+
+            int w  = m_view ? m_view->width()  : 0;
+            int h  = m_view ? m_view->height() : 0;
+            int tx = x + w / 2;
+            int ty = y + h / 2;
+
+            if (const TwkApp::VideoModule* mod = TwkApp::App()->primaryVideoModule())
+            {
+                if (TwkApp::VideoDevice* d = mod->deviceFromPosition(tx, ty))
+                {
+                    setPhysicalDevice(d);
+                    refresh = d->timing().hz;
+
+                    VideoDeviceContextChangeEvent event("video-device-changed", this, this, d);
+                    sendEvent(event);
+                }
+            }
+
+            if (refresh != m_refresh)
+            {
+                if (refresh > 0)
+                    m_refresh = refresh;
+                else if (IPCore::debugPlayback)
+                    cout << "WARNING: ignoring intended desktop refresh rate = " << refresh << endl;
+
+                if (IPCore::debugPlayback)
+                    cout << "INFO: new desktop refresh rate " << m_refresh << endl;
+            }
+        }
+        m_x = x;
+        m_y = y;
+    }
+
+    void QTMetalVideoDevice::setPhysicalDevice(VideoDevice* d)
+    {
+        TwkApp::VideoDevice::setPhysicalDevice(d);
+
+        m_devicePixelRatio = 1.0f;
+
+        static bool noQtHighDPISupport = (getenv("RV_NO_QT_HDPI_SUPPORT") != nullptr);
+        if (noQtHighDPISupport)
+            return;
+
+        if (const DesktopVideoDevice* desktopDev = dynamic_cast<const DesktopVideoDevice*>(d))
+        {
+            const QList<QScreen*> screens = QGuiApplication::screens();
+            if (desktopDev->qtScreen() < screens.size())
+                m_devicePixelRatio = screens[desktopDev->qtScreen()]->devicePixelRatio();
+        }
+    }
+
+    float QTMetalVideoDevice::devicePixelRatio() const
+    {
+        // Always read from the widget's actual screen DPR rather than the
+        // cached m_devicePixelRatio, which is 1.0 until setPhysicalDevice() is
+        // first called.  This guarantees the FBO and IPCore viewport agree from
+        // the very first frame.
+        if (m_view)
+            return static_cast<float>(m_view->devicePixelRatio());
+        return m_devicePixelRatio;  // fallback when no view
+    }
+
+    //--------------------------------------------------------------------------
+    // GLVideoDevice API
+    //--------------------------------------------------------------------------
+
+    void QTMetalVideoDevice::makeCurrent() const
+    {
+        // Ensure QOpenGLContext + FBO exist, make GL context current, bind FBO
+        ensureGLContext();
+    }
+
+    TwkGLF::GLFBO* QTMetalVideoDevice::defaultFBO()
+    {
+        ensureGLContext();
+        return m_fbo;
+    }
+
+    const TwkGLF::GLFBO* QTMetalVideoDevice::defaultFBO() const
+    {
+        ensureGLContext();
+        return m_fbo;
+    }
+
+    std::string QTMetalVideoDevice::hardwareIdentification() const
+    {
+        return "metal-hybrid";
+    }
+
+    //--------------------------------------------------------------------------
+    // syncBuffers — GL FBO readback → CPU format conversion → IOSurface present
+    //--------------------------------------------------------------------------
+
+    void QTMetalVideoDevice::syncBuffers() const
+    {
+        if (!m_view)
+            return;
+
+        if (!m_glContext || !m_fbo)
+            return;  // Nothing rendered yet
+
+        TwkGLF::GLFBO* fbo = m_fbo;
+        const int w = static_cast<int>(fbo->width());
+        const int h = static_cast<int>(fbo->height());
+
+        if (w <= 0 || h <= 0)
+            return;
+
+        // Make the GL context current before calling GL functions
+        if (!m_glContext->makeCurrent(m_offscreenSurface))
+            return;
+
+        fbo->bind();
+
+        // Force the GPU to complete all pending GL commands before reading back.
+        // On macOS (GL-on-Metal), glReadPixels does not implicitly synchronise
+        // the Metal command stream, so without glFinish() the FBO content is
+        // still uninitialised/zero when we sample it.
+        glFinish();
+
+        // --- GL readback ---
+        // Read as 32-bit float RGBA — safe regardless of the FBO's internal
+        // format (GL_RGBA16F).  We do the y-flip and format conversion in CPU.
+        const size_t floatCount = static_cast<size_t>(w) * h * 4;
+        std::vector<float> floatPx(floatCount);
+        glReadPixels(0, 0, w, h, GL_RGBA, GL_FLOAT, floatPx.data());
+
+        fbo->unbind();
+
+        // --- Format conversion + y-flip ---
+        //
+        // Pack as ARGB2101010LE — (A<<30)|(R<<20)|(G<<10)|B
+        //   where A=3 (fully opaque, 2-bit), R/G/B are 10-bit [0..1023].
+        //   This is kCVPixelFormatType_ARGB2101010LEPacked = 'l30r' = 0x6C333072.
+        //
+        // GL origin is bottom-left; IOSurface/CALayer origin is top-left.
+        // We y-flip by iterating src rows in reverse.
+
+        std::vector<uint32_t> packed(static_cast<size_t>(w) * h);
+
+        for (int y = 0; y < h; ++y)
+        {
+            // src row: y-flip (GL origin is bottom-left)
+            const float* src = floatPx.data() + (size_t)(h - 1 - y) * w * 4;
+            uint32_t*    dst = packed.data()  + (size_t)y * w;
+
+            for (int x = 0; x < w; ++x, src += 4)
+            {
+                const float r = std::max(0.f, std::min(1.f, src[0]));
+                const float g = std::max(0.f, std::min(1.f, src[1]));
+                const float b = std::max(0.f, std::min(1.f, src[2]));
+                const uint32_t ri = static_cast<uint32_t>(r * 1023.f + 0.5f) & 0x3FF;
+                const uint32_t gi = static_cast<uint32_t>(g * 1023.f + 0.5f) & 0x3FF;
+                const uint32_t bi = static_cast<uint32_t>(b * 1023.f + 0.5f) & 0x3FF;
+                // ARGB2101010LE: bits[31:30]=A(2), bits[29:20]=R(10),
+                //                bits[19:10]=G(10), bits[9:0]=B(10)
+                // Alpha always opaque: A=3 (= 0b11, max 2-bit value).
+                dst[x] = (3u << 30) | (ri << 20) | (gi << 10) | bi;
+            }
+        }
+
+        m_view->presentPixelData(packed.data(), w, h);
+    }
+
+    //--------------------------------------------------------------------------
+    // VideoDevice API
+    //--------------------------------------------------------------------------
+
+    void QTMetalVideoDevice::redraw() const
+    {
+        if (m_view)
+            QCoreApplication::postEvent(m_view, new QEvent(QEvent::UpdateRequest));
+    }
+
+    void QTMetalVideoDevice::redrawImmediately() const
+    {
+        redraw();
+    }
+
+    void QTMetalVideoDevice::clearCaches() const
+    {
+        // No device-level cache to clear.
+    }
+
+    VideoDevice::Resolution QTMetalVideoDevice::resolution() const
+    {
+        if (!m_view)
+            return Resolution(0, 0, 1.0f, 1.0f);
+        const float dpr = m_view->devicePixelRatio();
+        return Resolution(static_cast<int>(m_view->width()  * dpr + 0.5f),
+                          static_cast<int>(m_view->height() * dpr + 0.5f),
+                          1.0f, 1.0f);
+    }
+
+    VideoDevice::Offset QTMetalVideoDevice::offset() const
+    {
+        return Offset(m_x, m_y);
+    }
+
+    VideoDevice::Timing QTMetalVideoDevice::timing() const
+    {
+        return Timing((m_refresh != -1.0f) ? m_refresh : 0.0f);
+    }
+
+    VideoDevice::VideoFormat QTMetalVideoDevice::format() const
+    {
+        if (!m_view)
+            return VideoFormat(0, 0, 1.0, 1.0, 0.0, hardwareIdentification());
+        const float dpr = m_view->devicePixelRatio();
+        return VideoFormat(static_cast<int>(m_view->width()  * dpr + 0.5f),
+                           static_cast<int>(m_view->height() * dpr + 0.5f),
+                           1.0, 1.0,
+                           (m_refresh != -1.0f) ? m_refresh : 0.0f,
+                           hardwareIdentification());
+    }
+
+    size_t QTMetalVideoDevice::width() const
+    {
+        if (!m_view) return 0;
+        return static_cast<size_t>(m_view->width() * m_view->devicePixelRatio() + 0.5f);
+    }
+
+    size_t QTMetalVideoDevice::height() const
+    {
+        if (!m_view) return 0;
+        return static_cast<size_t>(m_view->height() * m_view->devicePixelRatio() + 0.5f);
+    }
+
+    void QTMetalVideoDevice::open(const StringVector& /*args*/)
+    {
+        if (m_view)
+            m_view->show();
+        m_isOpen = true;
+    }
+
+    void QTMetalVideoDevice::close()
+    {
+        if (m_view)
+            m_view->hide();
+        m_isOpen = false;
+    }
+
+    bool QTMetalVideoDevice::isOpen() const
+    {
+        if (m_view)
+            return m_view->isVisible();
+        return false;
+    }
+
+} // namespace Rv
+
+#endif // PLATFORM_DARWIN

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -85,8 +85,10 @@ namespace Rv
 
     //--------------------------------------------------------------------------
 
-    void QTMetalVideoDevice::ensureGLContext() const
+    bool QTMetalVideoDevice::ensureGLContext() const
     {
+        m_glContextReady = false;
+
         if (!m_glContext)
         {
             //
@@ -101,8 +103,7 @@ namespace Rv
             // Use GL 2.1 Compatibility profile — the existing IPCore pipeline
             // calls legacy APIs (glPushAttrib, GL_LIGHTING, GL_MAX_TEXTURE_UNITS,
             // etc.) that are absent in Core profile.  With GL 2.1, GLSL is 1.20
-            // and ShaderFunction::initGLSLVersion() is hardcoded to 1.20 on the
-            // USE_METAL path, so replaceTextureCalls() uses texture2DRect() which
+            // and replaceTextureCalls() uses texture2DRect() which
             // is available with GL_ARB_texture_rectangle.
             fmt.setMajorVersion(2);
             fmt.setMinorVersion(1);
@@ -122,7 +123,7 @@ namespace Rv
                 std::cerr << "[QTMetalVideoDevice] QOpenGLContext::create() failed\n";
                 delete m_glContext;
                 m_glContext = nullptr;
-                return;
+                return false;
             }
 
             // Surface format MUST be set from the *actual* context format, not
@@ -138,14 +139,14 @@ namespace Rv
                 m_offscreenSurface = nullptr;
                 delete m_glContext;
                 m_glContext = nullptr;
-                return;
+                return false;
             }
         }
 
         if (!m_glContext->makeCurrent(m_offscreenSurface))
         {
             std::cerr << "[QTMetalVideoDevice] makeCurrent() failed\n";
-            return;
+            return false;
         }
 
         // Size the FBO in PHYSICAL pixels so it matches the IOSurface
@@ -191,18 +192,39 @@ namespace Rv
 
             GLenum status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
             if (status != GL_FRAMEBUFFER_COMPLETE_EXT)
+            {
                 std::cerr << "[QTMetalVideoDevice] FBO incomplete: 0x"
                           << std::hex << status << std::dec << "\n";
+                delete m_fbo;
+                m_fbo = nullptr;
+                if (m_fboColorTex)
+                {
+                    glDeleteTextures(1, &m_fboColorTex);
+                    m_fboColorTex = 0;
+                }
+                m_fboWidth  = 0;
+                m_fboHeight = 0;
+                return false;
+            }
 
             m_fboWidth  = newW;
             m_fboHeight = newH;
+            // IOSurface interop ring must be rebuilt at the new size; allow a
+            // fresh attempt even if a prior transient failure latched interop off.
+            m_interopDisabled = false;
         }
+
+        if (!m_fbo)
+            return false;
 
         // Bind FBO so all GL rendering goes into it
         m_fbo->bind();
 
         // Let GLVideoDevice do its bookkeeping (GLtext context, etc.)
         GLVideoDevice::makeCurrent();
+
+        m_glContextReady = true;
+        return true;
     }
 
     //--------------------------------------------------------------------------
@@ -281,18 +303,21 @@ namespace Rv
     void QTMetalVideoDevice::makeCurrent() const
     {
         // Ensure QOpenGLContext + FBO exist, make GL context current, bind FBO
-        ensureGLContext();
+        if (!ensureGLContext())
+            return;
     }
 
     TwkGLF::GLFBO* QTMetalVideoDevice::defaultFBO()
     {
-        ensureGLContext();
+        if (!ensureGLContext())
+            return nullptr;
         return m_fbo;
     }
 
     const TwkGLF::GLFBO* QTMetalVideoDevice::defaultFBO() const
     {
-        ensureGLContext();
+        if (!ensureGLContext())
+            return nullptr;
         return m_fbo;
     }
 
@@ -307,6 +332,9 @@ namespace Rv
 
     bool QTMetalVideoDevice::ensureIOSurfaceTextures(int w, int h) const
     {
+        if (m_sharedWidth != w || m_sharedHeight != h)
+            m_interopDisabled = false;
+
         if (m_interopDisabled)
             return false;
 
@@ -564,7 +592,22 @@ namespace Rv
 
     void QTMetalVideoDevice::redrawImmediately() const
     {
-        redraw();
+        if (!m_view)
+            return;
+
+        if (m_view->isVisible())
+        {
+#ifdef PLATFORM_DARWIN
+            // Keep playback alive when the window is fully occluded (mirrors
+            // QTGLVideoDevice::redrawImmediately()).
+            m_view->setAttribute(Qt::WA_Mapped);
+#endif
+            m_view->renderImmediately();
+        }
+        else
+        {
+            redraw();
+        }
     }
 
     void QTMetalVideoDevice::clearCaches() const

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -44,6 +44,11 @@ namespace
     // render thread.  Deliberately does not reuse QTMetalVideoDevice itself —
     // that class builds a view-sized FBO/IOSurface ring that the upload thread
     // has no use for.
+    //
+    // Qt requires QOffscreenSurface::create() on the GUI thread. The worker
+    // QOpenGLContext is also created there (before the upload thread starts);
+    // only makeCurrent() runs on the upload thread
+    // (AA_DontCheckOpenGLContextThreadAffinity in main.cpp).
     //--------------------------------------------------------------------------
     class QTMetalSharedContextWorkerDevice : public TwkGLF::GLVideoDevice
     {
@@ -56,6 +61,17 @@ namespace
                 return;
             }
 
+            m_surface = new QOffscreenSurface();
+            m_surface->setFormat(shareContext->format());
+            m_surface->create();
+            if (!m_surface->isValid())
+            {
+                std::cerr << "[QTMetalVideoDevice] worker QOffscreenSurface::create() failed\n";
+                delete m_surface;
+                m_surface = nullptr;
+                return;
+            }
+
             m_context = new QOpenGLContext();
             m_context->setFormat(shareContext->format());
             m_context->setShareContext(shareContext);
@@ -64,36 +80,41 @@ namespace
                 std::cerr << "[QTMetalVideoDevice] worker QOpenGLContext::create() failed\n";
                 delete m_context;
                 m_context = nullptr;
-                return;
-            }
-
-            m_surface = new QOffscreenSurface();
-            m_surface->setFormat(m_context->format());
-            m_surface->create();
-            if (!m_surface->isValid())
-            {
-                std::cerr << "[QTMetalVideoDevice] worker QOffscreenSurface::create() failed\n";
                 delete m_surface;
                 m_surface = nullptr;
-                delete m_context;
-                m_context = nullptr;
             }
         }
 
         ~QTMetalSharedContextWorkerDevice() override
         {
-            delete m_surface;
+            // Surface lifetime is tied to ImageRenderer on the GUI/render thread.
             delete m_context;
+            delete m_surface;
         }
+
+        bool isValid() const { return m_surface && m_context; }
 
         // Deliberately does NOT call GLVideoDevice::makeCurrent() (text-context
         // bookkeeping there is not meant to be touched concurrently from a
         // background thread) — mirrors QTGLVideoDevice's isWorkerDevice() guard.
         void makeCurrent() const override
         {
-            if (m_context && m_surface)
+            if (!m_context || !m_surface)
             {
-                m_context->makeCurrent(m_surface);
+                return;
+            }
+
+            m_context->makeCurrent(m_surface);
+
+            if (!m_versionChecked)
+            {
+                m_versionChecked = true;
+                const char* ver = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+                m_glValid = (ver && *ver);
+                if (!m_glValid)
+                {
+                    std::cerr << "[QTMetalVideoDevice] worker GL context has no version string\n";
+                }
             }
         }
 
@@ -102,8 +123,10 @@ namespace
         size_t height() const override { return 0; }
 
     private:
-        QOpenGLContext* m_context = nullptr;
+        mutable QOpenGLContext* m_context = nullptr;
         QOffscreenSurface* m_surface = nullptr;
+        mutable bool m_versionChecked = false;
+        mutable bool m_glValid = false;
     };
 } // namespace
 
@@ -396,7 +419,13 @@ namespace Rv
                          "offscreen GL context unavailable\n";
             return nullptr;
         }
-        return new QTMetalSharedContextWorkerDevice(name() + "-workerContextDevice", m_glContext);
+        auto* worker = new QTMetalSharedContextWorkerDevice(name() + "-workerContextDevice", m_glContext);
+        if (!worker->isValid())
+        {
+            delete worker;
+            return nullptr;
+        }
+        return worker;
     }
 
     TwkGLF::GLFBO* QTMetalVideoDevice::defaultFBO()

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -460,6 +460,10 @@ namespace Rv
 
     bool QTMetalVideoDevice::ensureIOSurfaceTextures(int w, int h) const
     {
+        static const bool forceCpu = getenv("RV_METAL_FORCE_CPU_PRESENT") != nullptr;
+        if (forceCpu)
+            return false;
+
         // A size change always warrants a fresh attempt (the ring is rebuilt at
         // the new size anyway).
         if (m_sharedWidth != w || m_sharedHeight != h)

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -28,7 +28,84 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
-#include <vector>
+#include <new>
+
+namespace
+{
+    //--------------------------------------------------------------------------
+    // QTMetalSharedContextWorkerDevice
+    //
+    // Minimal GLVideoDevice for ImageRenderer's threaded-upload path (see
+    // ImageRenderer::uploadThreadTrampoline()), which only ever calls
+    // makeCurrent() on the device returned by newSharedContextWorkerDevice().
+    // It owns its own QOpenGLContext + QOffscreenSurface, sharing GL resources
+    // (textures, etc.) with the QTMetalVideoDevice's offscreen context that
+    // created it, so textures uploaded on the worker thread are visible to the
+    // render thread.  Deliberately does not reuse QTMetalVideoDevice itself —
+    // that class builds a view-sized FBO/IOSurface ring that the upload thread
+    // has no use for.
+    //--------------------------------------------------------------------------
+    class QTMetalSharedContextWorkerDevice : public TwkGLF::GLVideoDevice
+    {
+    public:
+        QTMetalSharedContextWorkerDevice(const std::string& name, QOpenGLContext* shareContext)
+            : TwkGLF::GLVideoDevice(nullptr, name, TwkApp::VideoDevice::NoCapabilities)
+        {
+            if (!shareContext)
+            {
+                return;
+            }
+
+            m_context = new QOpenGLContext();
+            m_context->setFormat(shareContext->format());
+            m_context->setShareContext(shareContext);
+            if (!m_context->create())
+            {
+                std::cerr << "[QTMetalVideoDevice] worker QOpenGLContext::create() failed\n";
+                delete m_context;
+                m_context = nullptr;
+                return;
+            }
+
+            m_surface = new QOffscreenSurface();
+            m_surface->setFormat(m_context->format());
+            m_surface->create();
+            if (!m_surface->isValid())
+            {
+                std::cerr << "[QTMetalVideoDevice] worker QOffscreenSurface::create() failed\n";
+                delete m_surface;
+                m_surface = nullptr;
+                delete m_context;
+                m_context = nullptr;
+            }
+        }
+
+        ~QTMetalSharedContextWorkerDevice() override
+        {
+            delete m_surface;
+            delete m_context;
+        }
+
+        // Deliberately does NOT call GLVideoDevice::makeCurrent() (text-context
+        // bookkeeping there is not meant to be touched concurrently from a
+        // background thread) — mirrors QTGLVideoDevice's isWorkerDevice() guard.
+        void makeCurrent() const override
+        {
+            if (m_context && m_surface)
+            {
+                m_context->makeCurrent(m_surface);
+            }
+        }
+
+        size_t width() const override { return 0; }
+
+        size_t height() const override { return 0; }
+
+    private:
+        QOpenGLContext* m_context = nullptr;
+        QOffscreenSurface* m_surface = nullptr;
+    };
+} // namespace
 
 namespace Rv
 {
@@ -307,6 +384,21 @@ namespace Rv
             return;
     }
 
+    TwkGLF::GLVideoDevice* QTMetalVideoDevice::newSharedContextWorkerDevice() const
+    {
+        // Make sure our own offscreen context exists before sharing with it.
+        // ImageRenderer::setupUploadThread() calls this from the render thread
+        // before spawning the upload thread, and immediately re-establishes its
+        // own makeCurrent() afterward, so it's safe to (re)bind our context here.
+        if (!ensureGLContext())
+        {
+            std::cerr << "[QTMetalVideoDevice] newSharedContextWorkerDevice: "
+                         "offscreen GL context unavailable\n";
+            return nullptr;
+        }
+        return new QTMetalSharedContextWorkerDevice(name() + "-workerContextDevice", m_glContext);
+    }
+
     TwkGLF::GLFBO* QTMetalVideoDevice::defaultFBO()
     {
         if (!ensureGLContext())
@@ -499,6 +591,7 @@ namespace Rv
         {
             const int slot = m_ringIndex;
             TwkGLF::GLFBO* ioFbo = m_ioFbos[slot];
+            bool blitOk = true;
 
             // GPU blit from the RGBA16F render FBO into the IOSurface-backed
             // RGB10_A2 texture.  The GPU does the float->10-bit conversion.
@@ -509,44 +602,54 @@ namespace Rv
             glBlitFramebufferEXT(0, 0, w, h,
                                  0, h, w, 0,
                                  GL_COLOR_BUFFER_BIT, GL_NEAREST);
-
-            // Force the IOSurface alpha channel to fully opaque.  IPCore clears
-            // the viewport background with alpha 0 (ImageRenderer::
-            // clearBackgroundToBlack), and the blit copies that through; the CA
-            // compositor honours the IOSurface's per-pixel alpha (despite the
-            // layer's opaque=YES hint), so a transparent background would be
-            // blended against the gray window backdrop instead of showing black.
-            // glClear respects glColorMask, so this writes only alpha (2-bit ->
-            // 3 = opaque) and leaves the blitted RGB untouched — the GPU analog
-            // of the CPU fallback's hard-coded (3u << 30) alpha.
-            glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
-            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-            glClear(GL_COLOR_BUFFER_BIT);
-            glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-
-            // Restore the render FBO as the active target.
-            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fbo->fboID());
-
-            // Publish the GL writes to the CA render server.  glFlush (not
-            // glFinish) is enough — it does not stall the main thread waiting for
-            // the GPU to go idle, and IOSurface provides the cross-context
-            // synchronisation the compositor needs.  This is what removes the
-            // per-frame main-thread stall behind menus and keyboard shortcuts.
-            glFlush();
-
-            m_view->presentIOSurface(m_ioSurfaces[slot]);
-
-            m_ringIndex = (slot + 1) % kRingSize;
-
-            // Recovery telemetry: report once when the zero-copy path resumes
-            // after a stretch of CPU-readback presents.
-            if (m_cpuFallbackLogged)
+            if (glGetError() != GL_NO_ERROR)
             {
-                std::cerr << "INFO: [QTMetalVideoDevice] zero-copy IOSurface "
-                             "interop restored.\n";
-                m_cpuFallbackLogged = false;
+                std::cerr << "[QTMetalVideoDevice] glBlitFramebufferEXT failed — "
+                             "falling back to CPU readback\n";
+                latchInteropFailure();
+                blitOk = false;
             }
-            return;
+
+            if (blitOk)
+            {
+                // Force the IOSurface alpha channel to fully opaque.  IPCore clears
+                // the viewport background with alpha 0 (ImageRenderer::
+                // clearBackgroundToBlack), and the blit copies that through; the CA
+                // compositor honours the IOSurface's per-pixel alpha (despite the
+                // layer's opaque=YES hint), so a transparent background would be
+                // blended against the gray window backdrop instead of showing black.
+                // glClear respects glColorMask, so this writes only alpha (2-bit ->
+                // 3 = opaque) and leaves the blitted RGB untouched — the GPU analog
+                // of the CPU fallback's hard-coded (3u << 30) alpha.
+                glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+                glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+                glClear(GL_COLOR_BUFFER_BIT);
+                glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
+                // Restore the render FBO as the active target.
+                glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fbo->fboID());
+
+                // Publish the GL writes to the CA render server.  glFlush (not
+                // glFinish) is enough — it does not stall the main thread waiting for
+                // the GPU to go idle, and IOSurface provides the cross-context
+                // synchronisation the compositor needs.  This is what removes the
+                // per-frame main-thread stall behind menus and keyboard shortcuts.
+                glFlush();
+
+                m_view->presentIOSurface(m_ioSurfaces[slot]);
+
+                m_ringIndex = (slot + 1) % kRingSize;
+
+                // Recovery telemetry: report once when the zero-copy path resumes
+                // after a stretch of CPU-readback presents.
+                if (m_cpuFallbackLogged)
+                {
+                    std::cerr << "INFO: [QTMetalVideoDevice] zero-copy IOSurface "
+                                 "interop restored.\n";
+                    m_cpuFallbackLogged = false;
+                }
+                return;
+            }
         }
 
         // --- Fallback: GL readback -> CPU pack -> IOSurface upload ---
@@ -572,8 +675,30 @@ namespace Rv
         // Read as 32-bit float RGBA — safe regardless of the FBO's internal
         // format (GL_RGBA16F).  We do the y-flip and format conversion in CPU.
         const size_t floatCount = static_cast<size_t>(w) * h * 4;
-        std::vector<float> floatPx(floatCount);
-        glReadPixels(0, 0, w, h, GL_RGBA, GL_FLOAT, floatPx.data());
+        const size_t pixelCount = static_cast<size_t>(w) * h;
+        try
+        {
+            if (m_cpuReadbackFloat.size() != floatCount)
+            {
+                m_cpuReadbackFloat.resize(floatCount);
+            }
+            if (m_cpuReadbackPacked.size() != pixelCount)
+            {
+                m_cpuReadbackPacked.resize(pixelCount);
+            }
+        }
+        catch (const std::bad_alloc&)
+        {
+            if (!m_cpuReadbackAllocLogged)
+            {
+                std::cerr << "ERROR: [QTMetalVideoDevice] CPU readback buffer "
+                             "allocation failed for " << w << "x" << h << "\n";
+                m_cpuReadbackAllocLogged = true;
+            }
+            return;
+        }
+
+        glReadPixels(0, 0, w, h, GL_RGBA, GL_FLOAT, m_cpuReadbackFloat.data());
 
         fbo->unbind();
 
@@ -586,13 +711,11 @@ namespace Rv
         // GL origin is bottom-left; IOSurface/CALayer origin is top-left.
         // We y-flip by iterating src rows in reverse.
 
-        std::vector<uint32_t> packed(static_cast<size_t>(w) * h);
-
         for (int y = 0; y < h; ++y)
         {
             // src row: y-flip (GL origin is bottom-left)
-            const float* src = floatPx.data() + (size_t)(h - 1 - y) * w * 4;
-            uint32_t*    dst = packed.data()  + (size_t)y * w;
+            const float* src = m_cpuReadbackFloat.data() + (size_t)(h - 1 - y) * w * 4;
+            std::uint32_t* dst = m_cpuReadbackPacked.data() + (size_t)y * w;
 
             for (int x = 0; x < w; ++x, src += 4)
             {
@@ -609,7 +732,7 @@ namespace Rv
             }
         }
 
-        m_view->presentPixelData(packed.data(), w, h);
+        m_view->presentPixelData(m_cpuReadbackPacked.data(), w, h);
     }
 
     //--------------------------------------------------------------------------
@@ -647,7 +770,7 @@ namespace Rv
 
     void QTMetalVideoDevice::clearCaches() const
     {
-        // No device-level cache to clear.
+        GLVideoDevice::clearCaches();
     }
 
     VideoDevice::Resolution QTMetalVideoDevice::resolution() const
@@ -698,14 +821,12 @@ namespace Rv
     {
         if (m_view)
             m_view->show();
-        m_isOpen = true;
     }
 
     void QTMetalVideoDevice::close()
     {
         if (m_view)
             m_view->hide();
-        m_isOpen = false;
     }
 
     bool QTMetalVideoDevice::isOpen() const

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -7,6 +7,10 @@
 #ifdef PLATFORM_DARWIN
 
 #import <AppKit/AppKit.h>
+#import <IOSurface/IOSurface.h>
+#import <CoreVideo/CoreVideo.h>
+#import <OpenGL/OpenGL.h>       // CGLGetCurrentContext, CGLError
+#import <OpenGL/CGLIOSurface.h> // CGLTexImageIOSurface2D
 
 #include <RvCommon/QTMetalVideoDevice.h>
 #include <RvCommon/MetalView.h>
@@ -49,7 +53,7 @@ namespace Rv
         // Delete the FBO and its colour texture while the GL context is current.
         // GLFBO::attachColorTexture passes owner=false so GLFBO does NOT delete
         // the colour texture — we must do it explicitly here.
-        if (m_glContext && (m_fbo || m_fboColorTex))
+        if (m_glContext && (m_fbo || m_fboColorTex || m_ioFbos[0]))
         {
             m_glContext->makeCurrent(m_offscreenSurface);
             delete m_fbo;
@@ -59,6 +63,7 @@ namespace Rv
                 glDeleteTextures(1, &m_fboColorTex);
                 m_fboColorTex = 0;
             }
+            cleanupIOSurfaceTextures();
             m_glContext->doneCurrent();
         }
 
@@ -291,7 +296,133 @@ namespace Rv
     }
 
     //--------------------------------------------------------------------------
-    // syncBuffers — GL FBO readback → CPU format conversion → IOSurface present
+    // ensureIOSurfaceTextures — (re)build the zero-copy IOSurface present ring
+    //--------------------------------------------------------------------------
+
+    bool QTMetalVideoDevice::ensureIOSurfaceTextures(int w, int h) const
+    {
+        if (m_interopDisabled)
+            return false;
+
+        if (m_sharedWidth == w && m_sharedHeight == h && m_ioFbos[0])
+            return true;  // ring already matches the current size
+
+        cleanupIOSurfaceTextures();
+
+        // The Qt context is current (caller does makeCurrent first); its native
+        // CGL context is what CGLTexImageIOSurface2D binds the IOSurface into.
+        CGLContextObj cgl = CGLGetCurrentContext();
+        if (!cgl)
+        {
+            std::cerr << "[QTMetalVideoDevice] CGLGetCurrentContext() returned null "
+                         "— falling back to CPU readback\n";
+            m_interopDisabled = true;
+            return false;
+        }
+
+        for (int i = 0; i < kRingSize; ++i)
+        {
+            // IOSurface pixel format must match the GL (format,type) below.
+            // ARGB2101010LE matches GL_BGRA + GL_UNSIGNED_INT_2_10_10_10_REV.
+            NSDictionary* props = @{
+                (NSString*)kIOSurfaceWidth:           @(w),
+                (NSString*)kIOSurfaceHeight:          @(h),
+                (NSString*)kIOSurfaceBytesPerElement: @(4),
+                (NSString*)kIOSurfacePixelFormat:     @(kCVPixelFormatType_ARGB2101010LEPacked),
+            };
+            IOSurfaceRef surf = IOSurfaceCreate((__bridge CFDictionaryRef)props);
+            if (!surf)
+            {
+                std::cerr << "[QTMetalVideoDevice] IOSurfaceCreate failed "
+                          << w << "x" << h << " — CPU fallback\n";
+                cleanupIOSurfaceTextures();
+                m_interopDisabled = true;
+                return false;
+            }
+
+            GLuint tex = 0;
+            glGenTextures(1, &tex);
+            glBindTexture(GL_TEXTURE_RECTANGLE_ARB, tex);
+            glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+            // Alias the IOSurface's memory as the texture's storage — GPU writes
+            // to this texture land directly in the IOSurface the CALayer shows.
+            CGLError cglErr = CGLTexImageIOSurface2D(
+                cgl, GL_TEXTURE_RECTANGLE_ARB, GL_RGB10_A2,
+                w, h, GL_BGRA, GL_UNSIGNED_INT_2_10_10_10_REV,
+                surf, 0);
+            glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+            if (cglErr != kCGLNoError)
+            {
+                std::cerr << "[QTMetalVideoDevice] CGLTexImageIOSurface2D failed: "
+                          << CGLErrorString(cglErr) << " — CPU fallback\n";
+                glDeleteTextures(1, &tex);
+                CFRelease(surf);
+                cleanupIOSurfaceTextures();
+                m_interopDisabled = true;
+                return false;
+            }
+
+            // Wrap the IOSurface-backed texture in a GLFBO so we can blit into it.
+            // owner=false (attachColorTexture) — we delete the texture ourselves.
+            TwkGLF::GLFBO* iofbo = new TwkGLF::GLFBO(w, h, GL_RGB10_A2);
+            iofbo->attachColorTexture(GL_TEXTURE_RECTANGLE_ARB, tex);
+
+            GLenum status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+            if (status != GL_FRAMEBUFFER_COMPLETE_EXT)
+            {
+                std::cerr << "[QTMetalVideoDevice] IOSurface FBO incomplete: 0x"
+                          << std::hex << status << std::dec << " — CPU fallback\n";
+                delete iofbo;
+                glDeleteTextures(1, &tex);
+                CFRelease(surf);
+                cleanupIOSurfaceTextures();
+                m_interopDisabled = true;
+                return false;
+            }
+
+            m_ioSurfaces[i] = (void*)surf;  // retained; released in cleanup
+            m_ioTextures[i] = tex;
+            m_ioFbos[i]     = iofbo;
+        }
+
+        m_sharedWidth  = w;
+        m_sharedHeight = h;
+        m_ringIndex    = 0;
+        return true;
+    }
+
+    void QTMetalVideoDevice::cleanupIOSurfaceTextures() const
+    {
+        // Must be called with the GL context current (GLFBO / glDeleteTextures).
+        for (int i = 0; i < kRingSize; ++i)
+        {
+            delete m_ioFbos[i];
+            m_ioFbos[i] = nullptr;
+
+            if (m_ioTextures[i])
+            {
+                glDeleteTextures(1, &m_ioTextures[i]);
+                m_ioTextures[i] = 0;
+            }
+            if (m_ioSurfaces[i])
+            {
+                CFRelease((IOSurfaceRef)m_ioSurfaces[i]);
+                m_ioSurfaces[i] = nullptr;
+            }
+        }
+        m_sharedWidth  = 0;
+        m_sharedHeight = 0;
+        m_ringIndex    = 0;
+    }
+
+    //--------------------------------------------------------------------------
+    // syncBuffers — zero-copy GL FBO -> IOSurface blit -> CALayer present
+    //               (CPU readback retained only as a fallback)
     //--------------------------------------------------------------------------
 
     void QTMetalVideoDevice::syncBuffers() const
@@ -313,6 +444,54 @@ namespace Rv
         if (!m_glContext->makeCurrent(m_offscreenSurface))
             return;
 
+        // --- Fast path: zero-copy GL -> IOSurface (no glFinish, no readback) ---
+        if (ensureIOSurfaceTextures(w, h))
+        {
+            const int slot = m_ringIndex;
+            TwkGLF::GLFBO* ioFbo = m_ioFbos[slot];
+
+            // GPU blit from the RGBA16F render FBO into the IOSurface-backed
+            // RGB10_A2 texture.  The GPU does the float->10-bit conversion.
+            // Swapped destination Y (h -> 0) flips GL's bottom-left origin to the
+            // IOSurface/CALayer top-left origin — no CPU y-flip needed.
+            glBindFramebufferEXT(GL_READ_FRAMEBUFFER_EXT, fbo->fboID());
+            glBindFramebufferEXT(GL_DRAW_FRAMEBUFFER_EXT, ioFbo->fboID());
+            glBlitFramebufferEXT(0, 0, w, h,
+                                 0, h, w, 0,
+                                 GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+            // Force the IOSurface alpha channel to fully opaque.  IPCore clears
+            // the viewport background with alpha 0 (ImageRenderer::
+            // clearBackgroundToBlack), and the blit copies that through; the CA
+            // compositor honours the IOSurface's per-pixel alpha (despite the
+            // layer's opaque=YES hint), so a transparent background would be
+            // blended against the gray window backdrop instead of showing black.
+            // glClear respects glColorMask, so this writes only alpha (2-bit ->
+            // 3 = opaque) and leaves the blitted RGB untouched — the GPU analog
+            // of the CPU fallback's hard-coded (3u << 30) alpha.
+            glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+            glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
+            // Restore the render FBO as the active target.
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fbo->fboID());
+
+            // Publish the GL writes to the CA render server.  glFlush (not
+            // glFinish) is enough — it does not stall the main thread waiting for
+            // the GPU to go idle, and IOSurface provides the cross-context
+            // synchronisation the compositor needs.  This is what removes the
+            // per-frame main-thread stall behind menus and keyboard shortcuts.
+            glFlush();
+
+            m_view->presentIOSurface(m_ioSurfaces[slot]);
+
+            m_ringIndex = (slot + 1) % kRingSize;
+            return;
+        }
+
+        // --- Fallback: GL readback -> CPU pack -> IOSurface upload ---
+        // Used only when IOSurface GL interop is unavailable on this system.
         fbo->bind();
 
         // Force the GPU to complete all pending GL commands before reading back.
@@ -321,7 +500,6 @@ namespace Rv
         // still uninitialised/zero when we sample it.
         glFinish();
 
-        // --- GL readback ---
         // Read as 32-bit float RGBA — safe regardless of the FBO's internal
         // format (GL_RGBA16F).  We do the y-flip and format conversion in CPU.
         const size_t floatCount = static_cast<size_t>(w) * h * 4;
@@ -371,8 +549,11 @@ namespace Rv
 
     void QTMetalVideoDevice::redraw() const
     {
+        // Coalesced: collapses a burst of redraw requests into a single render
+        // per event-loop cycle (the GL path gets this for free from QWidget::
+        // update()).  Without this each request ran a separate present.
         if (m_view)
-            QCoreApplication::postEvent(m_view, new QEvent(QEvent::UpdateRequest));
+            m_view->requestUpdate();
     }
 
     void QTMetalVideoDevice::redrawImmediately() const

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -111,6 +111,12 @@ namespace Rv
             m_glContext = new QOpenGLContext();
             m_glContext->setFormat(fmt);
 
+            // Share with the process-wide global context (enabled via
+            // Qt::AA_ShareOpenGLContexts in main) so the diagnostics
+            // QOpenGLWidget can use the textures uploaded by this offscreen
+            // render context.
+            m_glContext->setShareContext(QOpenGLContext::globalShareContext());
+
             if (!m_glContext->create())
             {
                 std::cerr << "[QTMetalVideoDevice] QOpenGLContext::create() failed\n";

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -153,7 +153,7 @@ namespace Rv
         // Delete the FBO and its colour texture while the GL context is current.
         // GLFBO::attachColorTexture passes owner=false so GLFBO does NOT delete
         // the colour texture — we must do it explicitly here.
-        if (m_glContext && (m_fbo || m_fboColorTex || m_ioFbos[0]))
+        if (m_glContext && (m_fbo || m_fboColorTex || m_ioFbos[0] || m_cpuFlipFbo))
         {
             m_glContext->makeCurrent(m_offscreenSurface);
             delete m_fbo;
@@ -164,6 +164,7 @@ namespace Rv
                 m_fboColorTex = 0;
             }
             cleanupIOSurfaceTextures();
+            cleanupCpuFallbackTarget();
             m_glContext->doneCurrent();
         }
 
@@ -592,6 +593,54 @@ namespace Rv
     }
 
     //--------------------------------------------------------------------------
+    // CPU-fallback flip FBO helpers
+    //--------------------------------------------------------------------------
+
+    void QTMetalVideoDevice::ensureCpuFallbackTarget(int w, int h) const
+    {
+        if (m_cpuFlipFbo && m_cpuFlipWidth == w && m_cpuFlipHeight == h)
+            return;
+
+        cleanupCpuFallbackTarget();
+
+        // GL_RGB10_A2 target: GPU Y-flip blit quantises RGBA16F → 10-bit.
+        // glReadPixels(GL_BGRA, GL_UNSIGNED_INT_2_10_10_10_REV) reads
+        // ARGB2101010LE directly — matching kCVPixelFormatType_ARGB2101010LEPacked.
+        glGenTextures(1, &m_cpuFlipTex);
+        glBindTexture(GL_TEXTURE_2D, m_cpuFlipTex);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB10_A2, w, h, 0,
+                     GL_BGRA, GL_UNSIGNED_INT_2_10_10_10_REV, nullptr);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glBindTexture(GL_TEXTURE_2D, 0);
+
+        glGenFramebuffersEXT(1, &m_cpuFlipFbo);
+        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, m_cpuFlipFbo);
+        glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT,
+                                  GL_TEXTURE_2D, m_cpuFlipTex, 0);
+        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
+
+        m_cpuFlipWidth  = w;
+        m_cpuFlipHeight = h;
+    }
+
+    void QTMetalVideoDevice::cleanupCpuFallbackTarget() const
+    {
+        if (m_cpuFlipFbo)
+        {
+            glDeleteFramebuffersEXT(1, &m_cpuFlipFbo);
+            m_cpuFlipFbo = 0;
+        }
+        if (m_cpuFlipTex)
+        {
+            glDeleteTextures(1, &m_cpuFlipTex);
+            m_cpuFlipTex = 0;
+        }
+        m_cpuFlipWidth  = 0;
+        m_cpuFlipHeight = 0;
+    }
+
+    //--------------------------------------------------------------------------
     // syncBuffers — zero-copy GL FBO -> IOSurface blit -> CALayer present
     //               (CPU readback retained only as a fallback)
     //--------------------------------------------------------------------------
@@ -693,75 +742,47 @@ namespace Rv
             m_cpuFallbackLogged = true;
         }
 
-        fbo->bind();
+        ensureCpuFallbackTarget(w, h);
 
-        // Force the GPU to complete all pending GL commands before reading back.
-        // On macOS (GL-on-Metal), glReadPixels does not implicitly synchronise
-        // the Metal command stream, so without glFinish() the FBO content is
-        // still uninitialised/zero when we sample it.
+        // Y-flip blit (GL bottom-left → IOSurface top-left) into the RGB10_A2
+        // target. The GPU does the RGBA16F → 10-bit quantisation in one pass.
+        glBindFramebufferEXT(GL_READ_FRAMEBUFFER_EXT, fbo->fboID());
+        glBindFramebufferEXT(GL_DRAW_FRAMEBUFFER_EXT, m_cpuFlipFbo);
+        glBlitFramebufferEXT(0, 0, w, h,  0, h, w, 0,  GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+        // Force alpha to fully opaque (A=3, 2-bit max). IPCore clears the render
+        // FBO with alpha=0 (ImageRenderer::clearBackgroundToBlack); the blit copies
+        // that through. The CA compositor honours per-pixel alpha on IOSurface, so
+        // without this the background is transparent. Mirrors the fast path.
+        glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
+        // On macOS GL-on-Metal, glReadPixels does not implicitly synchronise the
+        // Metal command stream — glFinish() is required to commit the blit before
+        // the readback samples the flip FBO.
+        glBindFramebufferEXT(GL_READ_FRAMEBUFFER_EXT, m_cpuFlipFbo);
         glFinish();
 
-        // Read as 32-bit float RGBA — safe regardless of the FBO's internal
-        // format (GL_RGBA16F).  We do the y-flip and format conversion in CPU.
-        const size_t floatCount = static_cast<size_t>(w) * h * 4;
-        const size_t pixelCount = static_cast<size_t>(w) * h;
+        // GL_BGRA + GL_UNSIGNED_INT_2_10_10_10_REV packs A(31:30)|R(29:20)|G(19:10)|B(9:0)
+        // = kCVPixelFormatType_ARGB2101010LEPacked. No per-pixel CPU work.
         try
         {
-            if (m_cpuReadbackFloat.size() != floatCount)
-            {
-                m_cpuReadbackFloat.resize(floatCount);
-            }
-            if (m_cpuReadbackPacked.size() != pixelCount)
-            {
-                m_cpuReadbackPacked.resize(pixelCount);
-            }
+            m_cpuPackedScratch.resize(static_cast<size_t>(w) * h);
         }
         catch (const std::bad_alloc&)
         {
-            if (!m_cpuReadbackAllocLogged)
-            {
-                std::cerr << "ERROR: [QTMetalVideoDevice] CPU readback buffer "
-                             "allocation failed for " << w << "x" << h << "\n";
-                m_cpuReadbackAllocLogged = true;
-            }
+            std::cerr << "ERROR: [QTMetalVideoDevice] bad_alloc in CPU fallback ("
+                      << w << "x" << h << ")\n";
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fbo->fboID());
             return;
         }
+        glReadPixels(0, 0, w, h, GL_BGRA, GL_UNSIGNED_INT_2_10_10_10_REV,
+                     m_cpuPackedScratch.data());
 
-        glReadPixels(0, 0, w, h, GL_RGBA, GL_FLOAT, m_cpuReadbackFloat.data());
-
-        fbo->unbind();
-
-        // --- Format conversion + y-flip ---
-        //
-        // Pack as ARGB2101010LE — (A<<30)|(R<<20)|(G<<10)|B
-        //   where A=3 (fully opaque, 2-bit), R/G/B are 10-bit [0..1023].
-        //   This is kCVPixelFormatType_ARGB2101010LEPacked = 'l30r' = 0x6C333072.
-        //
-        // GL origin is bottom-left; IOSurface/CALayer origin is top-left.
-        // We y-flip by iterating src rows in reverse.
-
-        for (int y = 0; y < h; ++y)
-        {
-            // src row: y-flip (GL origin is bottom-left)
-            const float* src = m_cpuReadbackFloat.data() + (size_t)(h - 1 - y) * w * 4;
-            std::uint32_t* dst = m_cpuReadbackPacked.data() + (size_t)y * w;
-
-            for (int x = 0; x < w; ++x, src += 4)
-            {
-                const float r = std::max(0.f, std::min(1.f, src[0]));
-                const float g = std::max(0.f, std::min(1.f, src[1]));
-                const float b = std::max(0.f, std::min(1.f, src[2]));
-                const uint32_t ri = static_cast<uint32_t>(r * 1023.f + 0.5f) & 0x3FF;
-                const uint32_t gi = static_cast<uint32_t>(g * 1023.f + 0.5f) & 0x3FF;
-                const uint32_t bi = static_cast<uint32_t>(b * 1023.f + 0.5f) & 0x3FF;
-                // ARGB2101010LE: bits[31:30]=A(2), bits[29:20]=R(10),
-                //                bits[19:10]=G(10), bits[9:0]=B(10)
-                // Alpha always opaque: A=3 (= 0b11, max 2-bit value).
-                dst[x] = (3u << 30) | (ri << 20) | (gi << 10) | bi;
-            }
-        }
-
-        m_view->presentPixelData(m_cpuReadbackPacked.data(), w, h);
+        glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fbo->fboID());
+        m_view->presentPixelData(m_cpuPackedScratch.data(), w, h);
     }
 
     //--------------------------------------------------------------------------

--- a/src/lib/app/RvCommon/QTMetalVideoDevice.mm
+++ b/src/lib/app/RvCommon/QTMetalVideoDevice.mm
@@ -330,13 +330,29 @@ namespace Rv
     // ensureIOSurfaceTextures — (re)build the zero-copy IOSurface present ring
     //--------------------------------------------------------------------------
 
+    void QTMetalVideoDevice::latchInteropFailure() const
+    {
+        m_interopDisabled = true;
+        m_interopRetryCountdown = kInteropRetryFrames;
+    }
+
     bool QTMetalVideoDevice::ensureIOSurfaceTextures(int w, int h) const
     {
+        // A size change always warrants a fresh attempt (the ring is rebuilt at
+        // the new size anyway).
         if (m_sharedWidth != w || m_sharedHeight != h)
             m_interopDisabled = false;
 
         if (m_interopDisabled)
-            return false;
+        {
+            // Don't disable the zero-copy path for the lifetime of the window:
+            // the failure may have been transient.  Count down and retry once
+            // the cooldown elapses instead of falling back to CPU readback
+            // forever.
+            if (--m_interopRetryCountdown > 0)
+                return false;
+            m_interopDisabled = false;
+        }
 
         if (m_sharedWidth == w && m_sharedHeight == h && m_ioFbos[0])
             return true;  // ring already matches the current size
@@ -350,7 +366,7 @@ namespace Rv
         {
             std::cerr << "[QTMetalVideoDevice] CGLGetCurrentContext() returned null "
                          "— falling back to CPU readback\n";
-            m_interopDisabled = true;
+            latchInteropFailure();
             return false;
         }
 
@@ -370,7 +386,7 @@ namespace Rv
                 std::cerr << "[QTMetalVideoDevice] IOSurfaceCreate failed "
                           << w << "x" << h << " — CPU fallback\n";
                 cleanupIOSurfaceTextures();
-                m_interopDisabled = true;
+                latchInteropFailure();
                 return false;
             }
 
@@ -397,7 +413,7 @@ namespace Rv
                 glDeleteTextures(1, &tex);
                 CFRelease(surf);
                 cleanupIOSurfaceTextures();
-                m_interopDisabled = true;
+                latchInteropFailure();
                 return false;
             }
 
@@ -415,7 +431,7 @@ namespace Rv
                 glDeleteTextures(1, &tex);
                 CFRelease(surf);
                 cleanupIOSurfaceTextures();
-                m_interopDisabled = true;
+                latchInteropFailure();
                 return false;
             }
 
@@ -521,11 +537,30 @@ namespace Rv
             m_view->presentIOSurface(m_ioSurfaces[slot]);
 
             m_ringIndex = (slot + 1) % kRingSize;
+
+            // Recovery telemetry: report once when the zero-copy path resumes
+            // after a stretch of CPU-readback presents.
+            if (m_cpuFallbackLogged)
+            {
+                std::cerr << "INFO: [QTMetalVideoDevice] zero-copy IOSurface "
+                             "interop restored.\n";
+                m_cpuFallbackLogged = false;
+            }
             return;
         }
 
         // --- Fallback: GL readback -> CPU pack -> IOSurface upload ---
         // Used only when IOSurface GL interop is unavailable on this system.
+        // Log once on entry (not every frame) so the slow path is visible
+        // without spamming; the recovery message above closes the loop.
+        if (!m_cpuFallbackLogged)
+        {
+            std::cerr << "INFO: [QTMetalVideoDevice] presenting via CPU readback "
+                         "(" << w << "x" << h << "); zero-copy IOSurface interop "
+                         "unavailable — retrying periodically.\n";
+            m_cpuFallbackLogged = true;
+        }
+
         fbo->bind();
 
         // Force the GPU to complete all pending GL commands before reading back.

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -857,11 +857,19 @@ namespace Rv
 
         if (videoModules().empty())
         {
-            doc->view()->makeCurrent();
+            // With a non-OpenGL presentation backend view() returns null — no
+            // GL context to make current; presentation handles it per-frame.
+            if (doc->view())
+                doc->view()->makeCurrent();
 
             try
             {
-                addVideoModule(m_desktopModule = new DesktopVideoModule(0, doc->view()->videoDevice()));
+                // With a non-OpenGL presentation backend view() is null — pass
+                // nullptr as the GL share device.  DesktopVideoDevice can still
+                // be created; it only needs the share device when open() is
+                // called later.
+                QTGLVideoDevice* shareDevice = doc->view() ? doc->view()->videoDevice() : nullptr;
+                addVideoModule(m_desktopModule = new DesktopVideoModule(0, shareDevice));
             }
             catch (...)
             {
@@ -887,7 +895,8 @@ namespace Rv
         //  we're on (video device) so make sure the primary display group is
         //  correct.
         //
-        doc->session()->graph().setPrimaryDisplayGroup(doc->view()->videoDevice());
+        // Use the session's control device — valid for any presentation backend.
+        doc->session()->graph().setPrimaryDisplayGroup(doc->session()->controlVideoDevice());
 
         if (RvApp()->documents().size() == 1 && opts.present)
         {
@@ -927,7 +936,10 @@ namespace Rv
         if (!m->isOpen())
         {
             RvDocument* doc = reinterpret_cast<RvDocument*>(documents().front()->opaquePointer());
-            doc->view()->makeCurrent();
+            // With a non-OpenGL presentation backend view() is null — no GL
+            // context to make current.
+            if (doc->view())
+                doc->view()->makeCurrent();
             m->open();
             //
             //  The open() may have added video devices, so make sure each
@@ -1672,7 +1684,9 @@ namespace Rv
 #endif
 
                 string optionArgs = setVideoDeviceStateFromSettings(d);
-                rvDoc->view()->videoDevice()->makeCurrent();
+                // With a non-OpenGL presentation backend view() is null — skip GL makeCurrent.
+                if (rvDoc->view())
+                    rvDoc->view()->videoDevice()->makeCurrent();
 
                 try
                 {

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -896,7 +896,13 @@ namespace Rv
         //  correct.
         //
         // Use the session's control device — valid for any presentation backend.
-        doc->session()->graph().setPrimaryDisplayGroup(doc->session()->controlVideoDevice());
+        // setPrimaryDisplayGroup() dereferences the device (->physicalDevice())
+        // with no null check, and controlVideoDevice() is briefly null while a
+        // view is being (re)built, so guard against it here.
+        if (const TwkApp::VideoDevice* controlDevice = doc->session()->controlVideoDevice())
+        {
+            doc->session()->graph().setPrimaryDisplayGroup(controlDevice);
+        }
 
         if (RvApp()->documents().size() == 1 && opts.present)
         {

--- a/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
@@ -18,6 +18,7 @@
 #include <RvCommon/QTGLVideoDevice.h>
 #include <QtWidgets/QWidget>
 #include <QOpenGLWidget>
+#include <QOpenGLContext>
 #include <QGuiApplication>
 
 namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/MetalView.h
+++ b/src/lib/app/RvCommon/RvCommon/MetalView.h
@@ -173,6 +173,13 @@ namespace Rv
 
         //  Coalescing flag for requestUpdate(); cleared at the start of render().
         bool m_updatePending;
+
+        //  Count of consecutive render() attempts where the offscreen GL context
+        //  was not ready.  When it reaches kContextFailureThreshold the view
+        //  requests a one-time fallback to the OpenGL GLView; reset to 0 on any
+        //  successful render.
+        int m_contextFailureCount;
+        static constexpr int kContextFailureThreshold = 30;
     };
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/MetalView.h
+++ b/src/lib/app/RvCommon/RvCommon/MetalView.h
@@ -55,6 +55,10 @@ namespace Rv
 
         QTMetalVideoDevice* videoDevice() const { return m_videoDevice; }
 
+        //  We own pixel delivery via the CALayer/IOSurface; tell Qt not to use a
+        //  backing store for this widget (see WA_PaintOnScreen in the .mm).
+        QPaintEngine* paintEngine() const override { return nullptr; }
+
         void setEventWidget(QWidget* widget);
 
         void stopProcessingEvents();
@@ -86,6 +90,12 @@ namespace Rv
         //
         void presentPixelData(const void* pixels, int w, int h);
 
+        //
+        //  Re-assign the cached IOSurface to the CALayer (a lightweight
+        //  re-present of the last frame, with no GL readback).  Used on expose.
+        //
+        void presentCachedSurface();
+
         bool isInitialized() const { return m_initialized; }
 
     public slots:
@@ -100,6 +110,7 @@ namespace Rv
 
         void showEvent(QShowEvent* event) override;
         void resizeEvent(QResizeEvent* event) override;
+        void paintEvent(QPaintEvent* event) override;
 
     private:
         RvDocument* m_doc;

--- a/src/lib/app/RvCommon/RvCommon/MetalView.h
+++ b/src/lib/app/RvCommon/RvCommon/MetalView.h
@@ -1,0 +1,133 @@
+//
+//  Copyright (c) 2026 Autodesk, Inc. All Rights Reserved.
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#ifdef PLATFORM_DARWIN
+
+#include <QWidget>
+#include <QtCore/QSize>
+#include <QtCore/QEvent>
+#include <QtCore/QTimer>
+#include <TwkUtil/Timer.h>
+
+namespace Rv
+{
+    class RvDocument;
+    class QTMetalVideoDevice;
+
+    //
+    //  MetalView
+    //
+    //  A QWidget subclass that attaches a CALayer backed by an IOSurface to its
+    //  native NSView for true 10-bit display on macOS.  All IPCore image
+    //  processing runs in OpenGL via a separate QOpenGLContext+QOffscreenSurface;
+    //  the IOSurface path is used only for final pixel delivery.
+    //
+    //  Why IOSurface (not CAMetalLayer):
+    //    CAMetalLayer with MTLPixelFormatBGR10A2Unorm is mishandled by the CA
+    //    compositor — it treats 4-byte packed pixels as 1 byte, resulting in an
+    //    effective texture width of 1920÷4=480 which is then tiled 4× to fill the
+    //    display.  Using a plain CALayer backed by an IOSurface with pixel format
+    //    kCVPixelFormatType_ARGB2101010LEPacked bypasses this CA bug: the window
+    //    server composites IOSurface content natively and correctly for both 10-bit
+    //    and 8-bit formats.
+    //
+    //  Why QWidget (not QWindow):
+    //    Qt manages layout, positioning, and event routing for QWidget automatically.
+    //    We attach a CALayer directly to the widget's NSView; Qt's backing-store does
+    //    not affect IOSurface layer contents (those are composited independently by
+    //    the CA render server at the layer's native resolution).
+    //
+    //  Use this class only when USE_METAL is defined.
+    //
+    class MetalView : public QWidget
+    {
+        Q_OBJECT
+
+    public:
+        typedef TwkUtil::Timer Timer;
+
+        explicit MetalView(RvDocument* doc, QWidget* parent = nullptr, bool noResize = true);
+        ~MetalView();
+
+        QTMetalVideoDevice* videoDevice() const { return m_videoDevice; }
+
+        void setEventWidget(QWidget* widget);
+
+        void stopProcessingEvents();
+
+        virtual bool event(QEvent* event) override;
+        virtual bool eventFilter(QObject* object, QEvent* event) override;
+
+        bool firstPaintCompleted() const { return m_firstPaintCompleted; }
+
+        void setContentSize(int w, int h) { m_csize = QSize(w, h); }
+
+        void setMinimumContentSize(int w, int h) { m_msize = QSize(w, h); }
+
+        QSize sizeHint() const override { return m_csize; }
+
+        QSize minimumSizeHint() const override { return m_msize; }
+
+        void absolutePosition(int& x, int& y) const;
+
+        float devicePixelRatio() const;
+
+        //
+        //  IOSurface presentation — called by QTMetalVideoDevice::syncBuffers().
+        //
+        //  pixels: packed ARGB2101010LE row-major, y=0 is TOP row (IOSurface
+        //          convention; caller must y-flip from GL bottom-left origin).
+        //  Format: (3<<30)|(R<<20)|(G<<10)|B per pixel.
+        //  w,h: physical pixel dimensions (FBO size = view.size × DPR).
+        //
+        void presentPixelData(const void* pixels, int w, int h);
+
+        bool isInitialized() const { return m_initialized; }
+
+    public slots:
+        void eventProcessingTimeout();
+
+    protected:
+        //  Called once when the widget is first shown.
+        void initialize();
+
+        //  Called each time a new frame should be rendered.
+        void render();
+
+        void showEvent(QShowEvent* event) override;
+        void resizeEvent(QResizeEvent* event) override;
+
+    private:
+        RvDocument* m_doc;
+        QTMetalVideoDevice* m_videoDevice;
+
+        bool m_initialized;
+        bool m_firstPaintCompleted;
+        bool m_postFirstNonEmptyRender; // mirrors GLView::m_postFirstNonEmptyRender
+        bool m_stopProcessingEvents;
+        bool m_userActive;
+
+        QSize m_csize;
+        QSize m_msize;
+        QWidget* m_eventWidget;
+
+        unsigned int m_lastKey;
+        QEvent::Type m_lastKeyType;
+        Timer m_activityTimer;
+        Timer m_activationTimer;
+        QTimer m_eventProcessingTimer;
+
+        //  Presentation objects — stored as void* to keep header pure C++.
+        void* m_caLayer;   // CALayer*
+        void* m_ioSurface; // IOSurfaceRef
+        int m_ioSurfaceWidth;
+        int m_ioSurfaceHeight;
+    };
+
+} // namespace Rv
+
+#endif // PLATFORM_DARWIN

--- a/src/lib/app/RvCommon/RvCommon/MetalView.h
+++ b/src/lib/app/RvCommon/RvCommon/MetalView.h
@@ -171,7 +171,9 @@ namespace Rv
         //  expose.  Not owned here; the CALayer retains its own contents.
         void* m_lastPresentedSurface;
 
-        //  Coalescing flag for requestUpdate(); cleared at the start of render().
+        //  Coalescing flag for requestUpdate(); cleared when the pending
+        //  UpdateRequest is handled, on renderImmediately(), or when paintEvent
+        //  falls through to a full render().
         bool m_updatePending;
 
         //  Count of consecutive render() attempts where the offscreen GL context

--- a/src/lib/app/RvCommon/RvCommon/MetalView.h
+++ b/src/lib/app/RvCommon/RvCommon/MetalView.h
@@ -121,6 +121,9 @@ namespace Rv
         //
         void requestUpdate();
 
+        // Synchronous render (used by redrawImmediately); bypasses UpdateRequest coalescing.
+        void renderImmediately();
+
         bool isInitialized() const { return m_initialized; }
 
     public slots:

--- a/src/lib/app/RvCommon/RvCommon/MetalView.h
+++ b/src/lib/app/RvCommon/RvCommon/MetalView.h
@@ -55,6 +55,16 @@ namespace Rv
 
         QTMetalVideoDevice* videoDevice() const { return m_videoDevice; }
 
+        //
+        //  Returns true when the platform can present 10-bit content through the
+        //  Metal/IOSurface path (i.e. a Metal device is available).  Static and
+        //  side-effect-free so RvDocument can query it before constructing any
+        //  view, to decide between the Metal (10-bit) and OpenGL (8-bit) backends.
+        //  Mirrors VulkanView::supports10BitPresentation() so the call site stays
+        //  backend-agnostic when the Vulkan and Metal branches merge.
+        //
+        static bool supports10BitPresentation();
+
         //  We own pixel delivery via the CALayer/IOSurface; tell Qt not to use a
         //  backing store for this widget (see WA_PaintOnScreen in the .mm).
         QPaintEngine* paintEngine() const override { return nullptr; }

--- a/src/lib/app/RvCommon/RvCommon/MetalView.h
+++ b/src/lib/app/RvCommon/RvCommon/MetalView.h
@@ -91,10 +91,25 @@ namespace Rv
         void presentPixelData(const void* pixels, int w, int h);
 
         //
-        //  Re-assign the cached IOSurface to the CALayer (a lightweight
+        //  Assign an externally-owned IOSurface (the zero-copy path: the video
+        //  device renders GL straight into it) to the CALayer for display.
+        //  Records it as the last-presented surface for re-present on expose.
+        //
+        void presentIOSurface(void* ioSurfaceRef);
+
+        //
+        //  Re-assign the last-presented IOSurface to the CALayer (a lightweight
         //  re-present of the last frame, with no GL readback).  Used on expose.
         //
         void presentCachedSurface();
+
+        //
+        //  Coalesced redraw request.  Posts a single QEvent::UpdateRequest per
+        //  event-loop cycle (subsequent calls are no-ops until the pending
+        //  render runs), mirroring the implicit coalescing QWidget::update()
+        //  gets from Qt on the GL path.
+        //
+        void requestUpdate();
 
         bool isInitialized() const { return m_initialized; }
 
@@ -134,9 +149,17 @@ namespace Rv
 
         //  Presentation objects — stored as void* to keep header pure C++.
         void* m_caLayer;   // CALayer*
-        void* m_ioSurface; // IOSurfaceRef
+        void* m_ioSurface; // IOSurfaceRef — owned here only by the CPU fallback path
         int m_ioSurfaceWidth;
         int m_ioSurfaceHeight;
+
+        //  Last IOSurface assigned to the CALayer (may be device-owned in the
+        //  zero-copy path or m_ioSurface in the fallback path).  Re-presented on
+        //  expose.  Not owned here; the CALayer retains its own contents.
+        void* m_lastPresentedSurface;
+
+        //  Coalescing flag for requestUpdate(); cleared at the start of render().
+        bool m_updatePending;
     };
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
@@ -1,0 +1,115 @@
+//
+//  Copyright (c) 2026 Autodesk, Inc. All Rights Reserved.
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#ifdef PLATFORM_DARWIN
+
+#include <TwkGLF/GLVideoDevice.h>
+#include <RvCommon/QTTranslator.h>
+#include <QOpenGLContext>
+#include <QOffscreenSurface>
+#include <string>
+
+namespace Rv
+{
+    class MetalView;
+
+    //
+    //  QTMetalVideoDevice
+    //
+    //  Wraps a MetalView as a TwkGLF::GLVideoDevice so that ImageRenderer's
+    //  existing GL rendering pipeline (renderMain, shader cache, etc.) can run
+    //  unchanged on the Metal path.
+    //
+    //  How it works:
+    //    • A QOpenGLContext + QOffscreenSurface provides the GL context.  On
+    //      macOS, Qt backs QOffscreenSurface with a hidden NSView, giving the
+    //      context a real native surface (required on Apple Silicon).
+    //    • A GLFBO is created in this context; all IPCore rendering goes there.
+    //    • syncBuffers() reads the FBO pixels back to CPU, packs them as
+    //      ARGB2101010LE, and calls MetalView::presentPixelData() which writes
+    //      to an IOSurface and assigns it to a plain CALayer for display.
+    //
+    //  The IOSurface + CALayer path is used instead of CAMetalLayer because
+    //  the CA compositor mishandles MTLPixelFormatBGR10A2Unorm, producing
+    //  4× horizontal tiling.  IOSurface with kCVPixelFormatType_ARGB2101010LEPacked
+    //  is composited correctly by the macOS window server.
+    //
+    class QTMetalVideoDevice : public TwkGLF::GLVideoDevice
+    {
+    public:
+        QTMetalVideoDevice(TwkApp::VideoModule* module, const std::string& name, MetalView* view, QWidget* eventWidget);
+        virtual ~QTMetalVideoDevice();
+
+        MetalView* metalView() const { return m_view; }
+
+        QWidget* eventWidget() const { return m_eventWidget; }
+
+        void setEventWidget(QWidget* widget);
+
+        const QTTranslator& translator() const { return *m_translator; }
+
+        bool hasTranslator() const { return m_translator != nullptr; }
+
+        void setAbsolutePosition(int x, int y);
+
+        // VideoDevice API
+        virtual void makeCurrent() const override;
+        virtual void syncBuffers() const override;
+        virtual void redraw() const override;
+        virtual void redrawImmediately() const override;
+        virtual void clearCaches() const override;
+
+        virtual Resolution resolution() const override;
+        virtual Offset offset() const override;
+        virtual Timing timing() const override;
+        virtual VideoFormat format() const override;
+
+        virtual size_t width() const override;
+        virtual size_t height() const override;
+
+        virtual void open(const StringVector& args) override;
+        virtual void close() override;
+        virtual bool isOpen() const override;
+
+        virtual float devicePixelRatio() const override;
+
+        virtual void setPhysicalDevice(VideoDevice* d) override;
+
+        // GLVideoDevice API
+        virtual TwkGLF::GLFBO* defaultFBO() override;
+        virtual const TwkGLF::GLFBO* defaultFBO() const override;
+        virtual std::string hardwareIdentification() const override;
+
+    private:
+        // Ensure the NSOpenGLContext + FBO exist and match the current view size.
+        // Makes the GL context current and binds the FBO on return.
+        void ensureGLContext() const;
+
+        MetalView* m_view;
+        QWidget* m_eventWidget;
+        QTTranslator* m_translator;
+        float m_devicePixelRatio{1.0f};
+        int m_x{0};
+        int m_y{0};
+        float m_refresh{-1.0f};
+        bool m_isOpen{false};
+
+        // Qt GL context + offscreen surface for GL rendering.
+        // QOffscreenSurface on macOS is backed by a hidden NSView, which gives
+        // the context a proper native surface (required for GL-on-Metal on
+        // Apple Silicon where a headless NSOpenGLContext silently fails).
+        mutable QOpenGLContext* m_glContext{nullptr};
+        mutable QOffscreenSurface* m_offscreenSurface{nullptr};
+        mutable TwkGLF::GLFBO* m_fbo{nullptr};
+        mutable GLuint m_fboColorTex{0}; // Texture attached to m_fbo; GLFBO does not own it
+        mutable int m_fboWidth{0};
+        mutable int m_fboHeight{0};
+    };
+
+} // namespace Rv
+
+#endif // PLATFORM_DARWIN

--- a/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
@@ -79,6 +79,9 @@ namespace Rv
 
         virtual void setPhysicalDevice(VideoDevice* d) override;
 
+        // True when the offscreen GL context, surface, and FBO are ready for rendering.
+        bool isGLContextReady() const { return m_glContextReady; }
+
         // GLVideoDevice API
         virtual TwkGLF::GLFBO* defaultFBO() override;
         virtual const TwkGLF::GLFBO* defaultFBO() const override;
@@ -87,7 +90,8 @@ namespace Rv
     private:
         // Ensure the NSOpenGLContext + FBO exist and match the current view size.
         // Makes the GL context current and binds the FBO on return.
-        void ensureGLContext() const;
+        // Returns false when context creation, makeCurrent, or FBO setup fails.
+        bool ensureGLContext() const;
 
         // Zero-copy present: (re)create a small ring of IOSurfaces, each bound as
         // a GL_TEXTURE_RECTANGLE_ARB / GL_RGB10_A2 texture (via
@@ -118,6 +122,7 @@ namespace Rv
         mutable GLuint m_fboColorTex{0}; // Texture attached to m_fbo; GLFBO does not own it
         mutable int m_fboWidth{0};
         mutable int m_fboHeight{0};
+        mutable bool m_glContextReady{false};
 
         // IOSurface present ring (zero-copy GL->IOSurface->CALayer path).
         // Double-buffered so the CA compositor can read the just-presented

--- a/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
@@ -103,6 +103,12 @@ namespace Rv
         bool ensureIOSurfaceTextures(int w, int h) const;
         void cleanupIOSurfaceTextures() const;
 
+        // Latch the zero-copy IOSurface interop off after a failure, but schedule
+        // a retry (kInteropRetryFrames later) instead of disabling it for the
+        // lifetime of the window — the failure may be transient (e.g. a
+        // zero-size FBO at startup or a momentary context issue).
+        void latchInteropFailure() const;
+
         MetalView* m_view;
         QWidget* m_eventWidget;
         QTTranslator* m_translator;
@@ -135,7 +141,14 @@ namespace Rv
         mutable int m_ringIndex{0};
         mutable int m_sharedWidth{0};
         mutable int m_sharedHeight{0};
-        mutable bool m_interopDisabled{false}; // latched on first interop failure
+        mutable bool m_interopDisabled{false};   // interop currently off (with retry)
+        mutable int m_interopRetryCountdown{0};  // frames until interop is retried
+        mutable bool m_cpuFallbackLogged{false}; // one-shot CPU-fallback log guard
+
+        // Frames to wait before retrying zero-copy interop after a failure
+        // (~2 seconds at 60 fps).  Bounds the cost of a permanently-broken
+        // interop to one rebuild attempt every kInteropRetryFrames frames.
+        static constexpr int kInteropRetryFrames = 120;
     };
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
@@ -147,14 +147,22 @@ namespace Rv
         mutable int m_ringIndex{0};
         mutable int m_sharedWidth{0};
         mutable int m_sharedHeight{0};
-        mutable bool m_interopDisabled{false};        // interop currently off (with retry)
-        mutable int m_interopRetryCountdown{0};       // frames until interop is retried
-        mutable bool m_cpuFallbackLogged{false};      // one-shot CPU-fallback log guard
-        mutable bool m_cpuReadbackAllocLogged{false}; // one-shot CPU readback alloc failure
+        mutable bool m_interopDisabled{false};   // interop currently off (with retry)
+        mutable int m_interopRetryCountdown{0};  // frames until interop is retried
+        mutable bool m_cpuFallbackLogged{false}; // one-shot CPU-fallback log guard
 
-        // CPU readback fallback scratch (reused across frames; resized on dimension change).
-        mutable std::vector<float> m_cpuReadbackFloat;
-        mutable std::vector<std::uint32_t> m_cpuReadbackPacked;
+        // CPU-fallback flip FBO. A GL_RGB10_A2 blit target lets the GPU do the
+        // float→10-bit conversion and Y-flip; glReadPixels with GL_BGRA +
+        // GL_UNSIGNED_INT_2_10_10_10_REV then reads ARGB2101010LE directly —
+        // no per-pixel CPU pack loop.
+        mutable GLuint m_cpuFlipFbo{0};
+        mutable GLuint m_cpuFlipTex{0};
+        mutable int m_cpuFlipWidth{0};
+        mutable int m_cpuFlipHeight{0};
+        mutable std::vector<std::uint32_t> m_cpuPackedScratch;
+
+        void ensureCpuFallbackTarget(int w, int h) const;
+        void cleanupCpuFallbackTarget() const;
 
         // Frames to wait before retrying zero-copy interop after a failure
         // (~2 seconds at 60 fps).  Bounds the cost of a permanently-broken

--- a/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
@@ -89,6 +89,16 @@ namespace Rv
         // Makes the GL context current and binds the FBO on return.
         void ensureGLContext() const;
 
+        // Zero-copy present: (re)create a small ring of IOSurfaces, each bound as
+        // a GL_TEXTURE_RECTANGLE_ARB / GL_RGB10_A2 texture (via
+        // CGLTexImageIOSurface2D) wrapped in a GLFBO, so GL can render straight
+        // into IOSurface memory that CoreAnimation composites — no CPU readback.
+        // Returns false (and latches m_interopDisabled) if interop is
+        // unavailable, in which case syncBuffers() uses the CPU fallback.
+        // Assumes the GL context is already current.
+        bool ensureIOSurfaceTextures(int w, int h) const;
+        void cleanupIOSurfaceTextures() const;
+
         MetalView* m_view;
         QWidget* m_eventWidget;
         QTTranslator* m_translator;
@@ -108,6 +118,19 @@ namespace Rv
         mutable GLuint m_fboColorTex{0}; // Texture attached to m_fbo; GLFBO does not own it
         mutable int m_fboWidth{0};
         mutable int m_fboHeight{0};
+
+        // IOSurface present ring (zero-copy GL->IOSurface->CALayer path).
+        // Double-buffered so the CA compositor can read the just-presented
+        // surface while GL renders the next frame into the other one.
+        // Stored as void* to keep this header free of ObjC/CoreVideo types.
+        static constexpr int kRingSize = 2;
+        mutable void* m_ioSurfaces[kRingSize]{nullptr, nullptr}; // IOSurfaceRef
+        mutable GLuint m_ioTextures[kRingSize]{0, 0};
+        mutable TwkGLF::GLFBO* m_ioFbos[kRingSize]{nullptr, nullptr};
+        mutable int m_ringIndex{0};
+        mutable int m_sharedWidth{0};
+        mutable int m_sharedHeight{0};
+        mutable bool m_interopDisabled{false}; // latched on first interop failure
     };
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTMetalVideoDevice.h
@@ -11,7 +11,9 @@
 #include <RvCommon/QTTranslator.h>
 #include <QOpenGLContext>
 #include <QOffscreenSurface>
+#include <cstdint>
 #include <string>
+#include <vector>
 
 namespace Rv
 {
@@ -29,9 +31,8 @@ namespace Rv
     //      macOS, Qt backs QOffscreenSurface with a hidden NSView, giving the
     //      context a real native surface (required on Apple Silicon).
     //    • A GLFBO is created in this context; all IPCore rendering goes there.
-    //    • syncBuffers() reads the FBO pixels back to CPU, packs them as
-    //      ARGB2101010LE, and calls MetalView::presentPixelData() which writes
-    //      to an IOSurface and assigns it to a plain CALayer for display.
+    //    • syncBuffers() blits the FBO into IOSurface-backed textures (zero-copy)
+    //      and presents via MetalView; CPU readback is retained only as fallback.
     //
     //  The IOSurface + CALayer path is used instead of CAMetalLayer because
     //  the CA compositor mishandles MTLPixelFormatBGR10A2Unorm, producing
@@ -62,6 +63,12 @@ namespace Rv
         virtual void redraw() const override;
         virtual void redrawImmediately() const override;
         virtual void clearCaches() const override;
+
+        // Creates a worker GLVideoDevice with its own QOpenGLContext sharing
+        // GL resources (textures, etc.) with this device's offscreen context,
+        // for ImageRenderer's threaded-upload path. Returns nullptr if the
+        // offscreen context cannot be (re)established.
+        virtual TwkGLF::GLVideoDevice* newSharedContextWorkerDevice() const override;
 
         virtual Resolution resolution() const override;
         virtual Offset offset() const override;
@@ -116,7 +123,6 @@ namespace Rv
         int m_x{0};
         int m_y{0};
         float m_refresh{-1.0f};
-        bool m_isOpen{false};
 
         // Qt GL context + offscreen surface for GL rendering.
         // QOffscreenSurface on macOS is backed by a hidden NSView, which gives
@@ -141,9 +147,14 @@ namespace Rv
         mutable int m_ringIndex{0};
         mutable int m_sharedWidth{0};
         mutable int m_sharedHeight{0};
-        mutable bool m_interopDisabled{false};   // interop currently off (with retry)
-        mutable int m_interopRetryCountdown{0};  // frames until interop is retried
-        mutable bool m_cpuFallbackLogged{false}; // one-shot CPU-fallback log guard
+        mutable bool m_interopDisabled{false};        // interop currently off (with retry)
+        mutable int m_interopRetryCountdown{0};       // frames until interop is retried
+        mutable bool m_cpuFallbackLogged{false};      // one-shot CPU-fallback log guard
+        mutable bool m_cpuReadbackAllocLogged{false}; // one-shot CPU readback alloc failure
+
+        // CPU readback fallback scratch (reused across frames; resized on dimension change).
+        mutable std::vector<float> m_cpuReadbackFloat;
+        mutable std::vector<std::uint32_t> m_cpuReadbackPacked;
 
         // Frames to wait before retrying zero-copy interop after a failure
         // (~2 seconds at 60 fps).  Bounds the cost of a permanently-broken

--- a/src/lib/app/RvCommon/RvCommon/RvDocument.h
+++ b/src/lib/app/RvCommon/RvCommon/RvDocument.h
@@ -172,6 +172,10 @@ namespace Rv
         //  not requested.
         void createGLView();
 
+        //  Returns whether the active presentation view has completed its first
+        //  paint, regardless of which backend (GLView/MetalView) is active.
+        bool activeViewFirstPaintCompleted() const;
+
     private:
         RvSession* m_session;
         QMenu* m_rvMenu;

--- a/src/lib/app/RvCommon/RvCommon/RvDocument.h
+++ b/src/lib/app/RvCommon/RvCommon/RvDocument.h
@@ -150,6 +150,11 @@ namespace Rv
         void frameChanged();
         void resetSizePolicy();
         void lazyDeleteGLView();
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        //  Runtime fallback: replace a failed MetalView with an OpenGL GLView.
+        //  A slot so MetalView::render() can trigger it via a queued connection.
+        void fallbackMetalToGLView();
+#endif
 
     private:
         void purgeMenus();

--- a/src/lib/app/RvCommon/RvCommon/RvDocument.h
+++ b/src/lib/app/RvCommon/RvCommon/RvDocument.h
@@ -166,6 +166,12 @@ namespace Rv
 
         void rebuildGLView(bool stereo, bool vsync, bool dbl, int, int, int, int);
 
+        //  Constructs the OpenGL view (m_glView) and makes it the active
+        //  m_viewWidget.  This is the 8-bit display path shared by the non-Metal
+        //  build and by the Metal build's fallback when 10-bit is unavailable or
+        //  not requested.
+        void createGLView();
+
     private:
         RvSession* m_session;
         QMenu* m_rvMenu;

--- a/src/lib/app/RvCommon/RvCommon/RvDocument.h
+++ b/src/lib/app/RvCommon/RvCommon/RvDocument.h
@@ -30,6 +30,9 @@ namespace TwkApp
 namespace Rv
 {
     class GLView;
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+    class MetalView;
+#endif
     class DiagnosticsView;
     class DesktopVideoModule;
     class DesktopVideoDevice;
@@ -74,6 +77,9 @@ namespace Rv
         GLView* view() const;
         QWidget* viewWidget() const;
 
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        MetalView* metalView() const;
+#endif
 
         const QAction* lastPopupAction() const { return m_lastPopupAction; }
 
@@ -170,6 +176,9 @@ namespace Rv
         QDockWidget* m_diagnosticsDock;
         GLView* m_glView;
         GLView* m_oldGLView;
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        MetalView* m_metalView;
+#endif
         QWidget* m_viewWidget;
         QWidget* m_viewContainerWidget;
         RvTopViewToolBar* m_topViewToolBar;

--- a/src/lib/app/RvCommon/RvCommon/RvDocument.h
+++ b/src/lib/app/RvCommon/RvCommon/RvDocument.h
@@ -72,6 +72,8 @@ namespace Rv
         QMenu* mainPopup() const { return m_mainPopup; }
 
         GLView* view() const;
+        QWidget* viewWidget() const;
+
 
         const QAction* lastPopupAction() const { return m_lastPopupAction; }
 
@@ -168,6 +170,7 @@ namespace Rv
         QDockWidget* m_diagnosticsDock;
         GLView* m_glView;
         GLView* m_oldGLView;
+        QWidget* m_viewWidget;
         QWidget* m_viewContainerWidget;
         RvTopViewToolBar* m_topViewToolBar;
         RvBottomViewToolBar* m_bottomViewToolBar;

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -145,7 +145,9 @@ namespace Rv
         , m_vsyncDisabled(false)
         , m_oldGLView(0)
         , m_glView(0)
-        , m_diagnosticsView(0)
+        , m_viewWidget(nullptr)
+        , m_diagnosticsView(nullptr)
+        , m_diagnosticsDock(nullptr)
         , m_sourceEditor(0)
         , m_displayLink(0)
         , m_blockingOverlay(0)
@@ -186,6 +188,7 @@ namespace Rv
         //
         //
 
+        // --- OpenGL path ---
         if (docs.empty())
         {
             m_glView =
@@ -201,26 +204,30 @@ namespace Rv
                                   true, // double buffer
                                   opts.dispRedBits, opts.dispGreenBits, opts.dispBlueBits, opts.dispAlphaBits, !m_startupResize);
         }
+        m_viewWidget = m_glView;
 
         // Create DiagnosticsView as a dockable widget (lazy initialization).
         m_diagnosticsView = new DiagnosticsView(nullptr, m_glView->format());
 
         // Dockable to QMainWindow, not centralwidget.
-        m_diagnosticsDock = new QDockWidget(tr("Diagnostics"), this);
-        m_diagnosticsDock->setObjectName("Diagnostics");
-        m_diagnosticsDock->setWidget(m_diagnosticsView);
-        m_diagnosticsDock->setAllowedAreas(Qt::AllDockWidgetAreas);
-        addDockWidget(Qt::BottomDockWidgetArea, m_diagnosticsDock);
-        m_diagnosticsDock->hide();                    // Hide by default
-        m_diagnosticsView->setWindowFlag(Qt::Widget); // Not a top-level window
+        if (m_diagnosticsView)
+        {
+            m_diagnosticsDock = new QDockWidget(tr("Diagnostics"), this);
+            m_diagnosticsDock->setObjectName("Diagnostics");
+            m_diagnosticsDock->setWidget(m_diagnosticsView);
+            m_diagnosticsDock->setAllowedAreas(Qt::AllDockWidgetAreas);
+            addDockWidget(Qt::BottomDockWidgetArea, m_diagnosticsDock);
+            m_diagnosticsDock->hide();                    // Hide by default
+            m_diagnosticsView->setWindowFlag(Qt::Widget); // Not a top-level window
+        }
 
         m_stackedLayout = new QStackedLayout(m_centralWidget);
         m_stackedLayout->setStackingMode(QStackedLayout::StackAll);
-        m_stackedLayout->addWidget(m_glView);
+        m_stackedLayout->addWidget(m_viewWidget);
 
         setCentralWidget(m_viewContainerWidget);
 
-        m_glView->setFocus(Qt::OtherFocusReason);
+        m_viewWidget->setFocus(Qt::OtherFocusReason);
         // qApp->installEventFilter(m_glView);
 
         // #ifdef PLATFORM_DARWIN
@@ -610,7 +617,7 @@ namespace Rv
                 setBuildMenu();
             }
 #endif
-            m_glView->setFocus(Qt::OtherFocusReason);
+            m_viewWidget->setFocus(Qt::OtherFocusReason);
         }
         else if (m == IPCore::Session::audioUnavailbleMessage())
         {
@@ -790,7 +797,7 @@ namespace Rv
 
         newGLView->setContentSize(oldGLView->sizeHint().width(), oldGLView->sizeHint().height());
 
-        newGLView->setMinimumSize(oldGLView->minimumSizeHint().width(), oldGLView->minimumSizeHint().height());
+        newGLView->setMinimumSize(QSize(oldGLView->minimumSizeHint().width(), oldGLView->minimumSizeHint().height()));
 
         bool resetGLPrefs = false;
 
@@ -807,6 +814,7 @@ namespace Rv
         m_stackedLayout->addWidget(newGLView);
         m_stackedLayout->removeWidget(oldGLView);
         m_glView = newGLView;
+        m_viewWidget = m_glView;
         m_glView->show();
         m_glView->setFocus(Qt::OtherFocusReason);
 
@@ -843,7 +851,11 @@ namespace Rv
         QTimer::singleShot(100, this, SLOT(lazyDeleteGLView()));
     }
 
-    void RvDocument::showDiagnostics() { m_diagnosticsDock->show(); }
+    void RvDocument::showDiagnostics()
+    {
+        if (m_diagnosticsDock)
+            m_diagnosticsDock->show();
+    }
 
     void RvDocument::setStereo(bool b)
     {
@@ -937,6 +949,9 @@ namespace Rv
     }
 
     GLView* RvDocument::view() const { return m_glView; }
+
+    QWidget* RvDocument::viewWidget() const { return m_viewWidget; }
+
 
     void RvDocument::center()
     {
@@ -1055,19 +1070,21 @@ namespace Rv
         h += int(mh);
         w += int(mw);
 
-        m_glView->setContentSize(w, h);
-        m_glView->setMinimumContentSize(w, h);
-        m_glView->updateGeometry();
-
-        const int dh = m_glView->height() - h;
-        const int dw = m_glView->width() - w;
-
-        if (dh || dw)
         {
-            resize(width() - dw, height() - dh);
             m_glView->setContentSize(w, h);
             m_glView->setMinimumContentSize(w, h);
             m_glView->updateGeometry();
+
+            const int dh = m_glView->height() - h;
+            const int dw = m_glView->width() - w;
+
+            if (dh || dw)
+            {
+                resize(width() - dw, height() - dh);
+                m_glView->setContentSize(w, h);
+                m_glView->setMinimumContentSize(w, h);
+                m_glView->updateGeometry();
+            }
         }
 
         m_resetPolicyTimer->start();
@@ -1263,29 +1280,31 @@ namespace Rv
 
         DB("resizeToFit final target w " << w << " h " << h);
 
-        m_glView->setContentSize(int(w), int(h));
-        m_glView->setMinimumContentSize(int(w), int(h));
-        m_glView->updateGeometry();
-
-        DB("resizeToFit resulting size w " << m_glView->width() << " h " << m_glView->height());
-
-        const int dh = m_glView->height() - int(h);
-        const int dw = m_glView->width() - int(w);
-
-        //
-        //  WHY? Dunno
-        //
-
-        DB("resizeToFit dw " << dw << " dh " << dh);
-        if (!firstTime && (dh || dw))
-        // if ((dh || dw))
         {
-            resize(width() - dw, height() - dh);
             m_glView->setContentSize(int(w), int(h));
             m_glView->setMinimumContentSize(int(w), int(h));
             m_glView->updateGeometry();
+
+            DB("resizeToFit resulting size w " << m_glView->width() << " h " << m_glView->height());
+
+            const int dh = m_glView->height() - int(h);
+            const int dw = m_glView->width() - int(w);
+
+            //
+            //  WHY? Dunno
+            //
+
+            DB("resizeToFit dw " << dw << " dh " << dh);
+            if (!firstTime && (dh || dw))
+            // if ((dh || dw))
+            {
+                resize(width() - dw, height() - dh);
+                m_glView->setContentSize(int(w), int(h));
+                m_glView->setMinimumContentSize(int(w), int(h));
+                m_glView->updateGeometry();
+            }
+            DB("resizeToFit final resulting size w " << m_glView->width() << " h " << m_glView->height());
         }
-        DB("resizeToFit final resulting size w " << m_glView->width() << " h " << m_glView->height());
 
         m_resetPolicyTimer->start();
 
@@ -1367,7 +1386,7 @@ namespace Rv
             }
         }
 
-        m_glView->setFocus(Qt::OtherFocusReason);
+        m_viewWidget->setFocus(Qt::OtherFocusReason);
         activateWindow();
         raise();
         //
@@ -1380,7 +1399,7 @@ namespace Rv
     QRect RvDocument::childrenRect()
     {
         QRect mr = mb()->geometry();
-        QRect vr = m_glView->geometry();
+        QRect vr = m_viewWidget->geometry();
 
         DB("RvDocument::childrenRect mb" << " shown " << menuBarShown() << " vis " << mb()->isVisible() << " w" << mr.width() << " h "
                                          << mr.height()
@@ -1889,7 +1908,8 @@ namespace Rv
         if (m_session)
         {
             m_session->userRenderEvent("view-size-changed", "");
-            m_session->deviceSizeChanged(m_glView->videoDevice());
+            if (m_glView)
+                m_session->deviceSizeChanged(m_glView->videoDevice());
         }
     }
 
@@ -2038,13 +2058,11 @@ namespace Rv
 
     void RvDocument::watchedFileChanged(const QString& path)
     {
-        TwkApp::GenericStringEvent event("file-changed", m_glView->videoDevice(), path.toUtf8().data());
-
-        // cout << m_watcher->files().size() << endl;
-        // cout << m_watcher->directories().size() << endl;
-
-        // m_glView->frameBuffer()->sendEvent(event);
-        m_glView->videoDevice()->sendEvent(event);
+        TwkApp::VideoDevice* vdev = m_glView->videoDevice();
+        if (!vdev)
+            return;
+        TwkApp::GenericStringEvent event("file-changed", vdev, path.toUtf8().data());
+        vdev->sendEvent(event);
     }
 
     bool RvDocument::queryDriverVSync() const { return false; }

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -165,8 +165,6 @@ namespace Rv
         setMenuBar(new QMenuBar(0));
 #endif
 
-        const TwkApp::Application::Documents& docs = TwkApp::App()->documents();
-
         setWindowIcon(QIcon(qApp->applicationDirPath() + QString(RV_ICON_PATH_SUFFIX)));
 
         Rv::Options& opts = Options::sharedOptions();
@@ -196,56 +194,70 @@ namespace Rv
         //
 
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
-        // --- Metal path ---
-        // MetalView is a QWidget that attaches a CALayer backed by an IOSurface
-        // to its native NSView.  It can be used directly in layouts without any
-        // createWindowContainer() wrapping.
-        m_metalView = new MetalView(this, m_centralWidget, !m_startupResize);
+        // --- Backend selection (mirrors the Vulkan branch) ---
+        // The 10-bit Metal path is chosen only when the user requested a 10-bit
+        // display format (the same dispRedBits/Green/Blue/Alpha signal the OpenGL
+        // 10-bit path uses) AND the hardware can present it.  Otherwise we fall
+        // back to the OpenGL (8-bit) path.  The decision is made once, here at
+        // window construction; changing the preference takes effect in a new
+        // window — same semantics as the Vulkan side.
+        const bool want10bit = (opts.dispRedBits == 10 && opts.dispGreenBits == 10 && opts.dispBlueBits == 10 && opts.dispAlphaBits == 2);
 
-        m_metalView->setFocusPolicy(Qt::StrongFocus);
-        m_metalView->setMouseTracking(true);
-        m_metalView->setAcceptDrops(true);
-        m_metalView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-        m_metalView->resize(m_metalView->sizeHint());
-        m_metalView->setEventWidget(m_metalView);
-        m_viewWidget = m_metalView;
-
-        // Initialize the session eagerly so that doc->session() is non-null
-        // immediately after construction.  On the Metal path, MetalView::initialize()
-        // (which normally calls initializeSession) is triggered by showEvent() —
-        // an async Qt event — so doc->session() would be null when newSessionFromFiles()
-        // accesses it synchronously right after doc->show().  Calling it here is safe
-        // because QTMetalVideoDevice is constructed in MetalView's constructor and is
-        // already available; actual CALayer setup happens later in
-        // MetalView::initialize() (which re-calls initializeSession but hits the
-        // if (!m_session) guard and exits immediately).
-        initializeSession();
-
-        // On the Metal path we do NOT create DiagnosticsView.
-        // DiagnosticsView inherits from QOpenGLWidget, and any QOpenGLWidget anywhere in
-        // the top-level window hierarchy forces Qt's macOS backend to use
-        // _NSOpenGLViewBackingLayer for the entire window — even when the widget is hidden
-        // inside a dock.  That compositor intercepts the CAMetalLayer content and composites
-        // it 4× (2×2) when wantsExtendedDynamicRangeContent or DPR scaling is active.
-        // m_diagnosticsView stays nullptr; m_diagnosticsDock is not created.
-#else
-        // --- OpenGL path ---
-        if (docs.empty())
+        bool useMetal = false;
+        if (want10bit)
         {
-            m_glView =
-                new GLView(this, 0, this, opts.stereoMode && !strcmp(opts.stereoMode, "hardware"), opts.vsync != 0 && !m_vsyncDisabled,
-                           true, opts.dispRedBits, opts.dispGreenBits, opts.dispBlueBits, opts.dispAlphaBits, !m_startupResize);
+            useMetal = MetalView::supports10BitPresentation();
+            if (!useMetal)
+            {
+                cerr << "INFO: 10-bit display requested but Metal 10-bit "
+                        "presentation is unavailable; falling back to OpenGL."
+                     << endl;
+            }
+        }
+
+        if (useMetal)
+        {
+            // --- Metal path ---
+            // MetalView is a QWidget that attaches a CALayer backed by an IOSurface
+            // to its native NSView.  It can be used directly in layouts without any
+            // createWindowContainer() wrapping.
+            m_metalView = new MetalView(this, m_centralWidget, !m_startupResize);
+
+            m_metalView->setFocusPolicy(Qt::StrongFocus);
+            m_metalView->setMouseTracking(true);
+            m_metalView->setAcceptDrops(true);
+            m_metalView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+            m_metalView->resize(m_metalView->sizeHint());
+            m_metalView->setEventWidget(m_metalView);
+            m_viewWidget = m_metalView;
+
+            // Initialize the session eagerly so that doc->session() is non-null
+            // immediately after construction.  On the Metal path, MetalView::initialize()
+            // (which normally calls initializeSession) is triggered by showEvent() —
+            // an async Qt event — so doc->session() would be null when newSessionFromFiles()
+            // accesses it synchronously right after doc->show().  Calling it here is safe
+            // because QTMetalVideoDevice is constructed in MetalView's constructor and is
+            // already available; actual CALayer setup happens later in
+            // MetalView::initialize() (which re-calls initializeSession but hits the
+            // if (!m_session) guard and exits immediately).
+            initializeSession();
+
+            // On the Metal path we do NOT create DiagnosticsView.
+            // DiagnosticsView inherits from QOpenGLWidget, and any QOpenGLWidget anywhere in
+            // the top-level window hierarchy forces Qt's macOS backend to use
+            // _NSOpenGLViewBackingLayer for the entire window — even when the widget is hidden
+            // inside a dock.  That compositor intercepts the CAMetalLayer content and composites
+            // it 4× (2×2) when wantsExtendedDynamicRangeContent or DPR scaling is active.
+            // m_diagnosticsView stays nullptr; m_diagnosticsDock is not created.
         }
         else
         {
-            RvSession* s = static_cast<RvSession*>(docs.front());
-            RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
-            m_glView = new GLView(this, rvDoc->view()->context(), this, opts.stereoMode && !strcmp(opts.stereoMode, "hardware"),
-                                  opts.vsync != 0 && !m_vsyncDisabled,
-                                  true, // double buffer
-                                  opts.dispRedBits, opts.dispGreenBits, opts.dispBlueBits, opts.dispAlphaBits, !m_startupResize);
+            // --- OpenGL (8-bit) fallback ---
+            createGLView();
         }
-        m_viewWidget = m_glView;
+#else
+        // --- OpenGL path ---
+        createGLView();
 #endif // PLATFORM_DARWIN && USE_METAL
 
         // Dockable to QMainWindow, not centralwidget.
@@ -345,6 +357,29 @@ namespace Rv
         m_blockingOverlay->hide();
     }
 
+    void RvDocument::createGLView()
+    {
+        const TwkApp::Application::Documents& docs = TwkApp::App()->documents();
+        Rv::Options& opts = Options::sharedOptions();
+
+        if (docs.empty())
+        {
+            m_glView =
+                new GLView(this, 0, this, opts.stereoMode && !strcmp(opts.stereoMode, "hardware"), opts.vsync != 0 && !m_vsyncDisabled,
+                           true, opts.dispRedBits, opts.dispGreenBits, opts.dispBlueBits, opts.dispAlphaBits, !m_startupResize);
+        }
+        else
+        {
+            RvSession* s = static_cast<RvSession*>(docs.front());
+            RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
+            m_glView = new GLView(this, rvDoc->view()->context(), this, opts.stereoMode && !strcmp(opts.stereoMode, "hardware"),
+                                  opts.vsync != 0 && !m_vsyncDisabled,
+                                  true, // double buffer
+                                  opts.dispRedBits, opts.dispGreenBits, opts.dispBlueBits, opts.dispAlphaBits, !m_startupResize);
+        }
+        m_viewWidget = m_glView;
+    }
+
     void RvDocument::initializeSession()
     {
         if (!m_session)
@@ -360,7 +395,8 @@ namespace Rv
 
             // RvApp()->addVideoDevice(m_glView->videoDevice());
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
-            m_session->setControlVideoDevice(m_metalView->videoDevice());
+            m_session->setControlVideoDevice(m_metalView ? static_cast<TwkApp::VideoDevice*>(m_metalView->videoDevice())
+                                                         : static_cast<TwkApp::VideoDevice*>(m_glView->videoDevice()));
 #else
             m_session->setControlVideoDevice(m_glView->videoDevice());
 #endif
@@ -603,7 +639,10 @@ namespace Rv
         else if (m == IPCore::Session::updateMessage())
         {
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
-            m_metalView->videoDevice()->redraw();
+            if (m_metalView)
+                m_metalView->videoDevice()->redraw();
+            else
+                view()->videoDevice()->redraw();
 #else
             view()->videoDevice()->redraw();
 #endif
@@ -611,10 +650,18 @@ namespace Rv
         else if (m == IPCore::Session::eventDeviceChangedMessage())
         {
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
-            if (m_session->eventVideoDevice() && m_metalView->videoDevice())
+            if (m_metalView)
             {
-                m_metalView->videoDevice()->translator().setRelativeDomain(m_session->eventVideoDevice()->width(),
-                                                                           m_session->eventVideoDevice()->height());
+                if (m_session->eventVideoDevice() && m_metalView->videoDevice())
+                {
+                    m_metalView->videoDevice()->translator().setRelativeDomain(m_session->eventVideoDevice()->width(),
+                                                                               m_session->eventVideoDevice()->height());
+                }
+            }
+            else if (m_session->eventVideoDevice() && m_glView->videoDevice())
+            {
+                m_glView->videoDevice()->translator().setRelativeDomain(m_session->eventVideoDevice()->width(),
+                                                                        m_session->eventVideoDevice()->height());
             }
 #else
             if (m_session->eventVideoDevice() && m_glView->videoDevice())
@@ -805,8 +852,17 @@ namespace Rv
     void RvDocument::resetSizePolicy()
     {
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
-        m_metalView->setMinimumContentSize(64, 64);
-        m_metalView->setMinimumSize(QSize(64, 64));
+        if (m_metalView)
+        {
+            m_metalView->setMinimumContentSize(64, 64);
+            m_metalView->setMinimumSize(QSize(64, 64));
+        }
+        else
+        {
+            m_glView->setMinimumContentSize(64, 64);
+            m_glView->setMinimumSize(QSize(64, 64));
+            m_glView->setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred));
+        }
 #else
         m_glView->setMinimumContentSize(64, 64);
         m_glView->setMinimumSize(QSize(64, 64));

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -242,13 +242,17 @@ namespace Rv
             // if (!m_session) guard and exits immediately).
             initializeSession();
 
-            // On the Metal path we do NOT create DiagnosticsView.
-            // DiagnosticsView inherits from QOpenGLWidget, and any QOpenGLWidget anywhere in
-            // the top-level window hierarchy forces Qt's macOS backend to use
-            // _NSOpenGLViewBackingLayer for the entire window — even when the widget is hidden
-            // inside a dock.  That compositor intercepts the CAMetalLayer content and composites
-            // it 4× (2×2) when wantsExtendedDynamicRangeContent or DPR scaling is active.
-            // m_diagnosticsView stays nullptr; m_diagnosticsDock is not created.
+            // NOTE: DiagnosticsView (a QOpenGLWidget) is created below for all
+            // backends. It shares GL resources with the offscreen render context
+            // via Qt::AA_ShareOpenGLContexts (set in main).
+            //
+            // macOS caveat: historically a QOpenGLWidget anywhere in the window
+            // hierarchy could force Qt's macOS backend to use
+            // _NSOpenGLViewBackingLayer for the whole window, which would
+            // intercept the CALayer/IOSurface content and composite it 4× (2×2)
+            // when DPR scaling is active. If 10-bit presentation regresses with
+            // the docked diagnostics visible, host DiagnosticsView in a separate
+            // top-level window on the Metal path instead.
         }
         else
         {
@@ -260,11 +264,19 @@ namespace Rv
         createGLView();
 #endif // PLATFORM_DARWIN && USE_METAL
 
+        // Create DiagnosticsView as a dockable widget. With Qt::AA_ShareOpenGLContexts
+        // (set in main) its GL context shares resources with the active backend's
+        // render context — the on-screen GLView, or the offscreen GL context behind
+        // the Metal/Vulkan presentation backends — so the ImGui font atlas uploads
+        // correctly regardless of which backend is active.
+        const QSurfaceFormat diagFormat = m_glView ? m_glView->format() : QSurfaceFormat::defaultFormat();
+        m_diagnosticsView = new DiagnosticsView(nullptr, diagFormat);
+
         // Dockable to QMainWindow, not centralwidget.
-        // On the Metal path m_diagnosticsView is nullptr (see comment above), so skip.
         if (m_diagnosticsView)
         {
             m_diagnosticsDock = new QDockWidget(tr("Diagnostics"), this);
+            m_diagnosticsDock->setObjectName("Diagnostics");
             m_diagnosticsDock->setWidget(m_diagnosticsView);
             m_diagnosticsDock->setAllowedAreas(Qt::AllDockWidgetAreas);
             addDockWidget(Qt::BottomDockWidgetArea, m_diagnosticsDock);
@@ -372,12 +384,26 @@ namespace Rv
         {
             RvSession* s = static_cast<RvSession*>(docs.front());
             RvDocument* rvDoc = (RvDocument*)s->opaquePointer();
-            m_glView = new GLView(this, rvDoc->view()->context(), this, opts.stereoMode && !strcmp(opts.stereoMode, "hardware"),
+            // The first document may use a non-OpenGL presentation backend
+            // (Metal/Vulkan), in which case view() (the legacy GLView) is null.
+            // Fall back to no explicit share context; Qt::AA_ShareOpenGLContexts
+            // still shares resources via the global context.
+            QOpenGLContext* shareContext = rvDoc->view() ? rvDoc->view()->context() : nullptr;
+            m_glView = new GLView(this, shareContext, this, opts.stereoMode && !strcmp(opts.stereoMode, "hardware"),
                                   opts.vsync != 0 && !m_vsyncDisabled,
                                   true, // double buffer
                                   opts.dispRedBits, opts.dispGreenBits, opts.dispBlueBits, opts.dispAlphaBits, !m_startupResize);
         }
         m_viewWidget = m_glView;
+    }
+
+    bool RvDocument::activeViewFirstPaintCompleted() const
+    {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (m_metalView)
+            return m_metalView->firstPaintCompleted();
+#endif
+        return m_glView && m_glView->firstPaintCompleted();
     }
 
     void RvDocument::initializeSession()
@@ -2160,7 +2186,7 @@ namespace Rv
         //  For some reason KDE wants our main window to come up
         //  "lowered" ie beneath the other windows.  This is the
         //  only way I've found to counter that.
-        if (waitingForFirstPaint && view() && view()->firstPaintCompleted())
+        if (waitingForFirstPaint && activeViewFirstPaintCompleted())
         {
             activateWindow();
             raise();

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -64,6 +64,7 @@
 #if defined(USE_METAL)
 #include <RvCommon/MetalView.h>
 #include <RvCommon/QTMetalVideoDevice.h>
+#include <IPCore/ShaderFunction.h>
 #endif
 #endif
 
@@ -240,6 +241,14 @@ namespace Rv
             // already available; actual CALayer setup happens later in
             // MetalView::initialize() (which re-calls initializeSession but hits the
             // if (!m_session) guard and exits immediately).
+            //
+            // GLSL version must be preset and the offscreen GL context made current
+            // before initializeSession(): session init may construct Shader::Function
+            // objects, whose initGLSLVersion() calls glGetString and aborts without a
+            // context.  Only preset on the active Metal path — main-branch IPCore keeps
+            // the normal glGetString path for all other backends.
+            IPCore::Shader::Function::useShadingLanguageVersion("1.20");
+            m_metalView->videoDevice()->makeCurrent();
             initializeSession();
 
             // NOTE: DiagnosticsView (a QOpenGLWidget) is created below for all

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -61,6 +61,10 @@
 #ifdef PLATFORM_DARWIN
 #include <RvCommon/DisplayLink.h>
 #include <RvCommon/CGDesktopVideoDevice.h>
+#if defined(USE_METAL)
+#include <RvCommon/MetalView.h>
+#include <RvCommon/QTMetalVideoDevice.h>
+#endif
 #endif
 
 #include <QDockWidget>
@@ -146,6 +150,9 @@ namespace Rv
         , m_oldGLView(0)
         , m_glView(0)
         , m_viewWidget(nullptr)
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        , m_metalView(nullptr)
+#endif
         , m_diagnosticsView(nullptr)
         , m_diagnosticsDock(nullptr)
         , m_sourceEditor(0)
@@ -188,6 +195,40 @@ namespace Rv
         //
         //
 
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        // --- Metal path ---
+        // MetalView is a QWidget that attaches a CALayer backed by an IOSurface
+        // to its native NSView.  It can be used directly in layouts without any
+        // createWindowContainer() wrapping.
+        m_metalView = new MetalView(this, m_centralWidget, !m_startupResize);
+
+        m_metalView->setFocusPolicy(Qt::StrongFocus);
+        m_metalView->setMouseTracking(true);
+        m_metalView->setAcceptDrops(true);
+        m_metalView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        m_metalView->resize(m_metalView->sizeHint());
+        m_metalView->setEventWidget(m_metalView);
+        m_viewWidget = m_metalView;
+
+        // Initialize the session eagerly so that doc->session() is non-null
+        // immediately after construction.  On the Metal path, MetalView::initialize()
+        // (which normally calls initializeSession) is triggered by showEvent() —
+        // an async Qt event — so doc->session() would be null when newSessionFromFiles()
+        // accesses it synchronously right after doc->show().  Calling it here is safe
+        // because QTMetalVideoDevice is constructed in MetalView's constructor and is
+        // already available; actual CALayer setup happens later in
+        // MetalView::initialize() (which re-calls initializeSession but hits the
+        // if (!m_session) guard and exits immediately).
+        initializeSession();
+
+        // On the Metal path we do NOT create DiagnosticsView.
+        // DiagnosticsView inherits from QOpenGLWidget, and any QOpenGLWidget anywhere in
+        // the top-level window hierarchy forces Qt's macOS backend to use
+        // _NSOpenGLViewBackingLayer for the entire window — even when the widget is hidden
+        // inside a dock.  That compositor intercepts the CAMetalLayer content and composites
+        // it 4× (2×2) when wantsExtendedDynamicRangeContent or DPR scaling is active.
+        // m_diagnosticsView stays nullptr; m_diagnosticsDock is not created.
+#else
         // --- OpenGL path ---
         if (docs.empty())
         {
@@ -205,15 +246,13 @@ namespace Rv
                                   opts.dispRedBits, opts.dispGreenBits, opts.dispBlueBits, opts.dispAlphaBits, !m_startupResize);
         }
         m_viewWidget = m_glView;
-
-        // Create DiagnosticsView as a dockable widget (lazy initialization).
-        m_diagnosticsView = new DiagnosticsView(nullptr, m_glView->format());
+#endif // PLATFORM_DARWIN && USE_METAL
 
         // Dockable to QMainWindow, not centralwidget.
+        // On the Metal path m_diagnosticsView is nullptr (see comment above), so skip.
         if (m_diagnosticsView)
         {
             m_diagnosticsDock = new QDockWidget(tr("Diagnostics"), this);
-            m_diagnosticsDock->setObjectName("Diagnostics");
             m_diagnosticsDock->setWidget(m_diagnosticsView);
             m_diagnosticsDock->setAllowedAreas(Qt::AllDockWidgetAreas);
             addDockWidget(Qt::BottomDockWidgetArea, m_diagnosticsDock);
@@ -320,7 +359,11 @@ namespace Rv
 #endif
 
             // RvApp()->addVideoDevice(m_glView->videoDevice());
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+            m_session->setControlVideoDevice(m_metalView->videoDevice());
+#else
             m_session->setControlVideoDevice(m_glView->videoDevice());
+#endif
 
             m_session->setRendererType("Composite");
             m_session->setOpaquePointer(this);
@@ -559,15 +602,27 @@ namespace Rv
         }
         else if (m == IPCore::Session::updateMessage())
         {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+            m_metalView->videoDevice()->redraw();
+#else
             view()->videoDevice()->redraw();
+#endif
         }
         else if (m == IPCore::Session::eventDeviceChangedMessage())
         {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+            if (m_session->eventVideoDevice() && m_metalView->videoDevice())
+            {
+                m_metalView->videoDevice()->translator().setRelativeDomain(m_session->eventVideoDevice()->width(),
+                                                                           m_session->eventVideoDevice()->height());
+            }
+#else
             if (m_session->eventVideoDevice() && m_glView->videoDevice())
             {
                 m_glView->videoDevice()->translator().setRelativeDomain(m_session->eventVideoDevice()->width(),
                                                                         m_session->eventVideoDevice()->height());
             }
+#endif
         }
         else if (m == TwkApp::Document::filenameChangedMessage())
         {
@@ -749,9 +804,14 @@ namespace Rv
 
     void RvDocument::resetSizePolicy()
     {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        m_metalView->setMinimumContentSize(64, 64);
+        m_metalView->setMinimumSize(QSize(64, 64));
+#else
         m_glView->setMinimumContentSize(64, 64);
         m_glView->setMinimumSize(QSize(64, 64));
         m_glView->setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred));
+#endif
     }
 
     void RvDocument::setDocumentDisabled(bool b, bool menuBarOnly)
@@ -772,6 +832,10 @@ namespace Rv
 
     void RvDocument::rebuildGLView(bool stereo, bool vsync, bool doubleBuffer, int red, int green, int blue, int alpha)
     {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (!m_glView)
+            return; // Metal path has no GL view to rebuild
+#endif
         //
         //  On the mac, we need to carefully replace the content GL widget so
         //  that Qt doesn't resize the dock widgets and everything
@@ -859,6 +923,10 @@ namespace Rv
 
     void RvDocument::setStereo(bool b)
     {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (!m_glView)
+            return;
+#endif
         const bool vsync = m_glView->format().swapInterval() == 1;
         const bool stereo = m_glView->format().stereo();
         bool dbl = false;
@@ -876,6 +944,10 @@ namespace Rv
     {
         if (m_vsyncDisabled)
             return;
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (!m_glView)
+            return;
+#endif
         const bool vsync = m_glView->format().swapInterval() == 1;
         const bool stereo = m_glView->format().stereo();
         bool dbl = false;
@@ -891,6 +963,10 @@ namespace Rv
 
     void RvDocument::setDoubleBuffer(bool b)
     {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (!m_glView)
+            return;
+#endif
         bool vsync = m_glView->format().swapInterval() == 1;
         const bool stereo = m_glView->format().stereo();
         const int red = m_glView->format().redBufferSize();
@@ -906,6 +982,10 @@ namespace Rv
 
     void RvDocument::setDisplayOutput(DisplayOutputType type)
     {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (!m_glView)
+            return;
+#endif
         const bool vsync = m_glView->format().swapInterval() == 1;
         const bool stereo = m_glView->format().stereo();
         bool dbl = false;
@@ -952,6 +1032,9 @@ namespace Rv
 
     QWidget* RvDocument::viewWidget() const { return m_viewWidget; }
 
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+    MetalView* RvDocument::metalView() const { return m_metalView; }
+#endif
 
     void RvDocument::center()
     {
@@ -1070,6 +1153,31 @@ namespace Rv
         h += int(mh);
         w += int(mw);
 
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (m_metalView)
+        {
+            m_metalView->setContentSize(w, h);
+            m_metalView->setMinimumContentSize(w, h);
+            // Only call resize() on the container when the view is NOT already
+            // at the requested size.  resizeView() is frequently called back from
+            // viewSizeChanged() after the view has already resized itself; calling
+            // resize() in that case overrides the stacked layout and permanently
+            // locks the container at the current (possibly small) size.
+            const int dh = m_metalView->height() - h;
+            const int dw = m_metalView->width() - w;
+            if (dh || dw)
+            {
+                m_metalView->resize(w, h);
+                m_metalView->updateGeometry();
+                resize(width() - dw, height() - dh);
+                m_metalView->setContentSize(w, h);
+                m_metalView->setMinimumContentSize(w, h);
+                m_metalView->resize(w, h);
+                m_metalView->updateGeometry();
+            }
+        }
+        else
+#endif
         {
             m_glView->setContentSize(w, h);
             m_glView->setMinimumContentSize(w, h);
@@ -1211,7 +1319,11 @@ namespace Rv
         }
 
         m_session->userRenderEvent("layout");
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        Session::Margins margins = m_metalView ? m_metalView->videoDevice()->margins() : m_glView->videoDevice()->margins();
+#else
         Session::Margins margins = m_glView->videoDevice()->margins();
+#endif
         float mw = int(margins.left + margins.right);
         float mh = int(margins.top + margins.bottom);
 
@@ -1280,6 +1392,32 @@ namespace Rv
 
         DB("resizeToFit final target w " << w << " h " << h);
 
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (m_metalView)
+        {
+            // Mirror the GL path: set content size hints and invalidate the layout,
+            // then let the delta between current and desired size drive the window resize.
+            // Do NOT call m_glView->resize() before computing the delta — that
+            // would make m_metalView->width()/height() report the target size and give
+            // dw=dh=0, skipping the window resize entirely.
+            m_metalView->setContentSize(int(w), int(h));
+            m_metalView->setMinimumContentSize(int(w), int(h));
+            m_metalView->updateGeometry();
+            DB("resizeToFit resulting size w " << m_metalView->width() << " h " << m_metalView->height());
+            const int dh = m_metalView->height() - int(h);
+            const int dw = m_metalView->width() - int(w);
+            DB("resizeToFit dw " << dw << " dh " << dh);
+            if (!firstTime && (dh || dw))
+            {
+                resize(width() - dw, height() - dh);
+                m_metalView->setContentSize(int(w), int(h));
+                m_metalView->setMinimumContentSize(int(w), int(h));
+                m_metalView->updateGeometry();
+            }
+            DB("resizeToFit final resulting size w " << m_metalView->width() << " h " << m_metalView->height());
+        }
+        else
+#endif
         {
             m_glView->setContentSize(int(w), int(h));
             m_glView->setMinimumContentSize(int(w), int(h));
@@ -1908,7 +2046,12 @@ namespace Rv
         if (m_session)
         {
             m_session->userRenderEvent("view-size-changed", "");
-            if (m_glView)
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+            if (m_metalView)
+                m_session->deviceSizeChanged(m_metalView->videoDevice());
+            else
+#endif
+                if (m_glView)
                 m_session->deviceSizeChanged(m_glView->videoDevice());
         }
     }
@@ -2058,7 +2201,12 @@ namespace Rv
 
     void RvDocument::watchedFileChanged(const QString& path)
     {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        TwkApp::VideoDevice* vdev = m_metalView ? static_cast<TwkApp::VideoDevice*>(m_metalView->videoDevice())
+                                                : static_cast<TwkApp::VideoDevice*>(m_glView->videoDevice());
+#else
         TwkApp::VideoDevice* vdev = m_glView->videoDevice();
+#endif
         if (!vdev)
             return;
         TwkApp::GenericStringEvent event("file-changed", vdev, path.toUtf8().data());

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -249,7 +249,28 @@ namespace Rv
             // the normal glGetString path for all other backends.
             IPCore::Shader::Function::useShadingLanguageVersion("1.20");
             m_metalView->videoDevice()->makeCurrent();
-            initializeSession();
+
+            if (m_metalView->videoDevice()->isGLContextReady())
+            {
+                initializeSession();
+            }
+            else
+            {
+                // The offscreen GL context / FBO that the Metal hybrid path
+                // renders into could not be created.  Rather than proceed with a
+                // view that can never paint (black window), tear the MetalView
+                // down here and fall back to the 8-bit OpenGL GLView.  The GL
+                // path initializes its session lazily from GLView::initializeGL,
+                // so we must NOT call initializeSession() ourselves here.
+                cerr << "WARNING: Metal offscreen GL context unavailable at "
+                        "startup; falling back to OpenGL."
+                     << endl;
+                m_metalView->setEventWidget(nullptr);
+                delete m_metalView;
+                m_metalView = nullptr;
+                m_viewWidget = nullptr;
+                createGLView();
+            }
 
             // NOTE: DiagnosticsView (a QOpenGLWidget) is created below for all
             // backends. It shares GL resources with the offscreen render context
@@ -1005,6 +1026,70 @@ namespace Rv
         m_oldGLView->hide();
         QTimer::singleShot(100, this, SLOT(lazyDeleteGLView()));
     }
+
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+    void RvDocument::fallbackMetalToGLView()
+    {
+        // Swap a live MetalView for an 8-bit OpenGL GLView after a runtime Metal
+        // failure.  Invoked (queued) from MetalView::render() when the offscreen
+        // GL context cannot be (re)established, so the user gets a working window
+        // instead of a permanently black one.  Mirrors the Vulkan branch's
+        // fallbackVulkanToGLView() and reuses the device-rewiring sequence from
+        // rebuildGLView().
+        if (!m_metalView)
+            return; // already on the GL path
+
+        if (m_currentlyClosing || m_closeEventReceived)
+            return; // document is tearing down; nothing to present
+
+        cerr << "INFO: RvDocument: switching from Metal to OpenGL presentation." << endl;
+
+        MetalView* oldView = m_metalView;
+        oldView->stopProcessingEvents();
+
+        // Build the GL view; this sets m_glView and m_viewWidget = m_glView.
+        // The session already exists (it was created eagerly on the Metal path),
+        // so GLView::initializeGL's call to initializeSession() is a no-op.
+        createGLView();
+
+        m_stackedLayout->addWidget(m_glView);
+        m_stackedLayout->removeWidget(oldView);
+        m_metalView = nullptr;
+
+        m_glView->show();
+        m_glView->setFocus(Qt::OtherFocusReason);
+
+        m_topViewToolBar->setDevice(m_glView->videoDevice());
+
+        // Rewire the session's control/output devices from the (now defunct)
+        // Metal device to the GL device.
+        bool same = m_session->outputVideoDevice() == m_session->controlVideoDevice();
+        m_session->setEventVideoDevice(0);
+        m_session->setOutputVideoDevice(0);
+        m_session->setControlVideoDevice(m_glView->videoDevice());
+        if (same)
+            m_session->setOutputVideoDevice(m_glView->videoDevice());
+
+        m_glView->videoDevice()->sendEvent(TwkApp::RenderContextChangeEvent("gl-context-changed", m_glView->videoDevice()));
+
+        if (DesktopVideoModule* m = RvApp()->desktopVideoModule())
+        {
+            const TwkApp::VideoModule::VideoDevices& devices = m->devices();
+            for (size_t i = 0; i < devices.size(); i++)
+            {
+                if (DesktopVideoDevice* d = dynamic_cast<DesktopVideoDevice*>(devices[i]))
+                    d->setShareDevice(m_glView->videoDevice());
+            }
+        }
+
+        // Defer deletion: avoid destroying the MetalView while it may still have
+        // queued events in this event-loop cycle (same rationale as
+        // lazyDeleteGLView()).  It has already been removed from the stacked
+        // layout above; deleteLater() detaches it from its parent on destruction.
+        oldView->hide();
+        oldView->deleteLater();
+    }
+#endif
 
     void RvDocument::showDiagnostics()
     {

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -696,11 +696,18 @@ namespace Rv
         {
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
             if (m_metalView)
+            {
                 m_metalView->videoDevice()->redraw();
-            else
-                view()->videoDevice()->redraw();
+            }
+            else if (m_glView)
+            {
+                m_glView->videoDevice()->redraw();
+            }
 #else
-            view()->videoDevice()->redraw();
+            if (m_glView)
+            {
+                m_glView->videoDevice()->redraw();
+            }
 #endif
         }
         else if (m == IPCore::Session::eventDeviceChangedMessage())
@@ -1037,10 +1044,22 @@ namespace Rv
         // fallbackVulkanToGLView() and reuses the device-rewiring sequence from
         // rebuildGLView().
         if (!m_metalView)
-            return; // already on the GL path
+        {
+            // Already on the GL path
+            return;
+        }
 
         if (m_currentlyClosing || m_closeEventReceived)
-            return; // document is tearing down; nothing to present
+        {
+            // Document is tearing down; nothing to present
+            return;
+        }
+
+        if (!m_session)
+        {
+            // Nothing to rewire devices on without a session
+            return;
+        }
 
         cerr << "INFO: RvDocument: switching from Metal to OpenGL presentation." << endl;
 
@@ -1097,12 +1116,34 @@ namespace Rv
             m_diagnosticsDock->show();
     }
 
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+    namespace
+    {
+        void warnMetalDisplaySurfaceOptionIgnored()
+        {
+            static bool logged = false;
+            if (!logged)
+            {
+                cout << "INFO: OpenGL surface options (stereo, vsync, double-buffer, "
+                        "pixel format) do not apply on the Metal presentation backend."
+                     << endl;
+                logged = true;
+            }
+        }
+    } // namespace
+#endif
+
     void RvDocument::setStereo(bool b)
     {
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (m_metalView && !m_glView)
+        {
+            warnMetalDisplaySurfaceOptionIgnored();
+            return;
+        }
+#endif
         if (!m_glView)
             return;
-#endif
         const bool vsync = m_glView->format().swapInterval() == 1;
         const bool stereo = m_glView->format().stereo();
         bool dbl = false;
@@ -1121,9 +1162,14 @@ namespace Rv
         if (m_vsyncDisabled)
             return;
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (m_metalView && !m_glView)
+        {
+            warnMetalDisplaySurfaceOptionIgnored();
+            return;
+        }
+#endif
         if (!m_glView)
             return;
-#endif
         const bool vsync = m_glView->format().swapInterval() == 1;
         const bool stereo = m_glView->format().stereo();
         bool dbl = false;
@@ -1140,9 +1186,14 @@ namespace Rv
     void RvDocument::setDoubleBuffer(bool b)
     {
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (m_metalView && !m_glView)
+        {
+            warnMetalDisplaySurfaceOptionIgnored();
+            return;
+        }
+#endif
         if (!m_glView)
             return;
-#endif
         bool vsync = m_glView->format().swapInterval() == 1;
         const bool stereo = m_glView->format().stereo();
         const int red = m_glView->format().redBufferSize();
@@ -1159,9 +1210,14 @@ namespace Rv
     void RvDocument::setDisplayOutput(DisplayOutputType type)
     {
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        if (m_metalView && !m_glView)
+        {
+            warnMetalDisplaySurfaceOptionIgnored();
+            return;
+        }
+#endif
         if (!m_glView)
             return;
-#endif
         const bool vsync = m_glView->format().swapInterval() == 1;
         const bool stereo = m_glView->format().stereo();
         bool dbl = false;
@@ -1334,21 +1390,14 @@ namespace Rv
         {
             m_metalView->setContentSize(w, h);
             m_metalView->setMinimumContentSize(w, h);
-            // Only call resize() on the container when the view is NOT already
-            // at the requested size.  resizeView() is frequently called back from
-            // viewSizeChanged() after the view has already resized itself; calling
-            // resize() in that case overrides the stacked layout and permanently
-            // locks the container at the current (possibly small) size.
+            m_metalView->updateGeometry();
             const int dh = m_metalView->height() - h;
             const int dw = m_metalView->width() - w;
             if (dh || dw)
             {
-                m_metalView->resize(w, h);
-                m_metalView->updateGeometry();
                 resize(width() - dw, height() - dh);
                 m_metalView->setContentSize(w, h);
                 m_metalView->setMinimumContentSize(w, h);
-                m_metalView->resize(w, h);
                 m_metalView->updateGeometry();
             }
         }
@@ -1573,7 +1622,7 @@ namespace Rv
         {
             // Mirror the GL path: set content size hints and invalidate the layout,
             // then let the delta between current and desired size drive the window resize.
-            // Do NOT call m_glView->resize() before computing the delta — that
+            // Do NOT call m_metalView->resize() before computing the delta — that
             // would make m_metalView->width()/height() report the target size and give
             // dw=dh=0, skipping the window resize entirely.
             m_metalView->setContentSize(int(w), int(h));

--- a/src/lib/app/mu_rvui/commands.mud
+++ b/src/lib/app/mu_rvui/commands.mud
@@ -1752,7 +1752,7 @@ httpPut(...)
 """
 
 mainWindowWidget "Returns the main window Qt widget"
-mainViewWidget "Returns a qt.QWidget corresponding to the session's QGLWidget"
+mainViewWidget "Returns a qt.QWidget corresponding to the session's main view widget"
 prefTabWidget "Returns the preferences tab Qt widget"
 sessionBottomToolBar "Returns the QToolBar for the current RV session bottom tool bar"
 networkAccessManager "Returns Qt network access manager object"

--- a/src/lib/ip/IPCore/CMakeLists.txt
+++ b/src/lib/ip/IPCore/CMakeLists.txt
@@ -300,10 +300,6 @@ ELSEIF(RV_TARGET_DARWIN)
     ${_target}
     PUBLIC OpenCL::OpenCL
   )
-  TARGET_COMPILE_DEFINITIONS(
-    ${_target}
-    PRIVATE USE_METAL
-  )
 ELSE()
   TARGET_LINK_LIBRARIES(${_target})
 ENDIF()

--- a/src/lib/ip/IPCore/CMakeLists.txt
+++ b/src/lib/ip/IPCore/CMakeLists.txt
@@ -300,12 +300,10 @@ ELSEIF(RV_TARGET_DARWIN)
     ${_target}
     PUBLIC OpenCL::OpenCL
   )
-  IF(USE_METAL)
-    TARGET_COMPILE_DEFINITIONS(
-      ${_target}
-      PRIVATE USE_METAL
-    )
-  ENDIF()
+  TARGET_COMPILE_DEFINITIONS(
+    ${_target}
+    PRIVATE USE_METAL
+  )
 ELSE()
   TARGET_LINK_LIBRARIES(${_target})
 ENDIF()

--- a/src/lib/ip/IPCore/CMakeLists.txt
+++ b/src/lib/ip/IPCore/CMakeLists.txt
@@ -300,6 +300,12 @@ ELSEIF(RV_TARGET_DARWIN)
     ${_target}
     PUBLIC OpenCL::OpenCL
   )
+  IF(USE_METAL)
+    TARGET_COMPILE_DEFINITIONS(
+      ${_target}
+      PRIVATE USE_METAL
+    )
+  ENDIF()
 ELSE()
   TARGET_LINK_LIBRARIES(${_target})
 ENDIF()

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -133,7 +133,22 @@ namespace IPCore
             //
             setThreadName("PBO Upload");
 
+            if (!renderer->uploadThreadDevice())
+            {
+                renderer->setUseThreadedUpload(false);
+                return;
+            }
+
             renderer->uploadThreadDevice()->makeCurrent();
+
+            if (TwkGLF::safeGLGetString(GL_VERSION).empty())
+            {
+                std::cerr << "ERROR: [ImageRenderer] upload thread GL context init failed; "
+                             "disabling threaded upload\n";
+                renderer->setUseThreadedUpload(false);
+                renderer->notifyDraw();
+                return;
+            }
 
             while (true)
             {
@@ -154,6 +169,14 @@ namespace IPCore
                 // probably not significant.
                 //
                 renderer->manager()->insertTextureFence(renderer->uploadRootHash());
+
+                // The fence was created on THIS (worker) GL context. glClientWaitSync's
+                // GL_SYNC_FLUSH_COMMANDS_BIT on the main thread only flushes the main
+                // context, not this one, so without an explicit flush here the sync
+                // object never reaches the GPU and the main thread stalls on the 10s
+                // fence timeout every frame. Flushing publishes the uploads + fence so
+                // the waiter wakes immediately.
+                glFlush();
 
                 // signal renderer to proceed
                 renderer->notifyDraw();
@@ -624,9 +647,21 @@ namespace IPCore
 
     void ImageRenderer::createGLContexts()
     {
-        m_setGLContext = true;
         delete m_uploadThreadDevice;
         m_uploadThreadDevice = controlDevice().glDevice->newSharedContextWorkerDevice();
+        if (!m_uploadThreadDevice)
+        {
+            static bool logged = false;
+            if (!logged)
+            {
+                logged = true;
+                std::cerr << "WARNING: [ImageRenderer] threaded GPU upload unavailable; "
+                             "falling back to synchronous upload\n";
+            }
+            setUseThreadedUpload(false);
+            return;
+        }
+        m_setGLContext = true;
         controlDevice().glDevice->makeCurrent();
     }
 
@@ -1554,11 +1589,17 @@ namespace IPCore
         {
             createGLContexts();
 
-            // upload thread initialization
-            m_uploadThread = Thread(uploadThreadTrampoline, this); // func and data
+            if (!GLContextNotSet())
+            {
+                // upload thread initialization
+                m_uploadThread = Thread(uploadThreadTrampoline, this);
+            }
         }
 
-        notifyUpload();
+        if (useThreadedUpload())
+        {
+            notifyUpload();
+        }
     }
 
     void ImageRenderer::renderBegin(const InternalRenderContext& context)
@@ -1598,6 +1639,11 @@ namespace IPCore
                     }
                     m_uploadThreadPrefetch = (root == uploadRoot) ? false : true;
 
+                    // Texture object creation (glGenTextures, PBO alloc) must run
+                    // on the control device's GL context — especially on the Metal
+                    // offscreen path where nothing else guarantees it is current.
+                    controlDevice().glDevice->makeCurrent();
+
                     //
                     // traverse our IPTree, and create gl textures/buffers for
                     // all texture uploads the upload thread will need the
@@ -1622,6 +1668,13 @@ namespace IPCore
 
                     prepareTextureDescriptionsForUpload(uploadRoot);
                     setupUploadThread(uploadRoot);
+
+                    // Worker creation may fail (e.g. Metal offscreen share setup);
+                    // fall back to synchronous upload for this frame.
+                    if (!useThreadedUpload())
+                    {
+                        prefetch(uploadRoot);
+                    }
                 }
                 else
                 {

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -3100,6 +3100,10 @@ namespace IPCore
 
     void Session::queryAndStoreGLInfo()
     {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+        // Metal path: no OpenGL context is active — skip GL-specific queries.
+        return;
+#endif
         ImageRenderer::queryGL();
         ImageRenderer::queryGLIntoContainer(graph().sessionNode());
     }

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -21,6 +21,10 @@
 #include <IPCore/Profile.h>
 #include <IPCore/NodeManager.h>
 #include <IPCore/FBCache.h>
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+#include <TwkGLF/GL.h>
+#include <TwkGLF/GLVideoDevice.h>
+#endif
 #include <TwkApp/Event.h>
 #include <TwkContainer/GTOReader.h>
 #include <TwkContainer/GTOWriter.h>
@@ -3101,8 +3105,21 @@ namespace IPCore
     void Session::queryAndStoreGLInfo()
     {
 #if defined(PLATFORM_DARWIN) && defined(USE_METAL)
-        // Metal path: no OpenGL context is active — skip GL-specific queries.
-        return;
+        // Metal path: IPCore still renders through an offscreen GL context owned
+        // by QTMetalVideoDevice, but no context exists at session construction.
+        // Make the control device's context current when available; defer until
+        // the first render if it is not ready yet (queryGLFinished() stays false).
+        if (const TwkGLF::GLVideoDevice* glDev = dynamic_cast<const TwkGLF::GLVideoDevice*>(controlVideoDevice()))
+        {
+            glDev->makeCurrent();
+        }
+        else
+        {
+            return;
+        }
+
+        if (TwkGLF::safeGLGetString(GL_VERSION).empty())
+            return;
 #endif
         ImageRenderer::queryGL();
         ImageRenderer::queryGLIntoContainer(graph().sessionNode());

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -21,7 +21,7 @@
 #include <IPCore/Profile.h>
 #include <IPCore/NodeManager.h>
 #include <IPCore/FBCache.h>
-#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+#if defined(PLATFORM_DARWIN)
 #include <TwkGLF/GL.h>
 #include <TwkGLF/GLVideoDevice.h>
 #endif
@@ -3104,11 +3104,11 @@ namespace IPCore
 
     void Session::queryAndStoreGLInfo()
     {
-#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
-        // Metal path: IPCore still renders through an offscreen GL context owned
-        // by QTMetalVideoDevice, but no context exists at session construction.
-        // Make the control device's context current when available; defer until
-        // the first render if it is not ready yet (queryGLFinished() stays false).
+#if defined(PLATFORM_DARWIN)
+        // Darwin Metal hybrid path: IPCore renders through an offscreen GL context
+        // owned by QTMetalVideoDevice.  Make the control device's context current
+        // when available; defer until the first render if it is not ready yet
+        // (queryGLFinished() stays false).
         if (const TwkGLF::GLVideoDevice* glDev = dynamic_cast<const TwkGLF::GLVideoDevice*>(controlVideoDevice()))
         {
             glDev->makeCurrent();

--- a/src/lib/ip/IPCore/SessionIPNode.cpp
+++ b/src/lib/ip/IPCore/SessionIPNode.cpp
@@ -29,7 +29,9 @@ namespace IPCore
         declareProperty<IntProperty>("paintEffects.ghostAfter", 5);
         setMaxInputs(0);
 
+#if !(defined(PLATFORM_DARWIN) && defined(USE_METAL))
         ImageRenderer::queryGLIntoContainer(this);
+#endif
     }
 
     SessionIPNode::~SessionIPNode()

--- a/src/lib/ip/IPCore/SessionIPNode.cpp
+++ b/src/lib/ip/IPCore/SessionIPNode.cpp
@@ -31,6 +31,9 @@ namespace IPCore
 
 #if !(defined(PLATFORM_DARWIN) && defined(USE_METAL))
         ImageRenderer::queryGLIntoContainer(this);
+#else
+        // Deferred: Session::queryAndStoreGLInfo() runs once the Metal path's
+        // offscreen GL context is current (first render via advanceState/render).
 #endif
     }
 

--- a/src/lib/ip/IPCore/SessionIPNode.cpp
+++ b/src/lib/ip/IPCore/SessionIPNode.cpp
@@ -7,6 +7,9 @@
 //
 #include <IPCore/SessionIPNode.h>
 #include <IPCore/ImageRenderer.h>
+#if defined(PLATFORM_DARWIN)
+#include <TwkGLF/GL.h>
+#endif
 
 namespace IPCore
 {
@@ -29,11 +32,13 @@ namespace IPCore
         declareProperty<IntProperty>("paintEffects.ghostAfter", 5);
         setMaxInputs(0);
 
-#if !(defined(PLATFORM_DARWIN) && defined(USE_METAL))
-        ImageRenderer::queryGLIntoContainer(this);
+#if defined(PLATFORM_DARWIN)
+        // Defer until Session::queryAndStoreGLInfo() can make the control
+        // device's GL context current (Metal hybrid path at session construction).
+        if (!TwkGLF::safeGLGetString(GL_VERSION).empty())
+            ImageRenderer::queryGLIntoContainer(this);
 #else
-        // Deferred: Session::queryAndStoreGLInfo() runs once the Metal path's
-        // offscreen GL context is current (first render via advanceState/render).
+        ImageRenderer::queryGLIntoContainer(this);
 #endif
     }
 

--- a/src/lib/ip/IPCore/ShaderFunction.cpp
+++ b/src/lib/ip/IPCore/ShaderFunction.cpp
@@ -73,18 +73,6 @@ namespace IPCore
             {
                 if (glslMajor == 0)
                 {
-#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
-                    // On the Metal hybrid path, GL rendering uses a GL 2.1
-                    // Compatibility context (required for legacy IPCore APIs).
-                    // Hardcode GLSL 1.20 so replaceTextureCalls() sets
-                    // useDeprecated=true and rewrites texture() → texture2DRect(),
-                    // which is available with GL_ARB_texture_rectangle.
-                    // This avoids calling glGetString before any context exists
-                    // (which would return NULL and trigger abort()).
-                    glslMajor = 1;
-                    glslMinor = 20;
-                    return;
-#endif
                     //
                     //  NOTE: its much better to have assigned
                     if (const char* glVersion = (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION))

--- a/src/lib/ip/IPCore/ShaderFunction.cpp
+++ b/src/lib/ip/IPCore/ShaderFunction.cpp
@@ -29,8 +29,7 @@ namespace IPCore
 
         namespace
         {
-            const char* global_glsl = "#version 150\n"
-                                      "#extension GL_ARB_texture_rectangle : require\n";
+            const char* global_glsl = "#version 150\n";
             const char* global_glsl_gl2 = "#extension GL_ARB_texture_rectangle : require\n";
             const char* global_glsl_lt_150 = "#version 120\n";
         } // namespace
@@ -74,6 +73,18 @@ namespace IPCore
             {
                 if (glslMajor == 0)
                 {
+#if defined(PLATFORM_DARWIN) && defined(USE_METAL)
+                    // On the Metal hybrid path, GL rendering uses a GL 2.1
+                    // Compatibility context (required for legacy IPCore APIs).
+                    // Hardcode GLSL 1.20 so replaceTextureCalls() sets
+                    // useDeprecated=true and rewrites texture() → texture2DRect(),
+                    // which is available with GL_ARB_texture_rectangle.
+                    // This avoids calling glGetString before any context exists
+                    // (which would return NULL and trigger abort()).
+                    glslMajor = 1;
+                    glslMinor = 20;
+                    return;
+#endif
                     //
                     //  NOTE: its much better to have assigned
                     if (const char* glVersion = (const char*)glGetString(GL_SHADING_LANGUAGE_VERSION))

--- a/src/lib/ip/IPCore/ShaderFunction.cpp
+++ b/src/lib/ip/IPCore/ShaderFunction.cpp
@@ -29,6 +29,9 @@ namespace IPCore
 
         namespace
         {
+            // GLSL 1.50+ core includes sampler2DRect; no extension directive needed.
+            // GL 2.x + GLSL >= 150 still requires GL_ARB_texture_rectangle (global_glsl_gl2).
+            // GL 2.1 / GLSL 1.20 uses global_glsl_lt_150 (RV's default context on all platforms).
             const char* global_glsl = "#version 150\n";
             const char* global_glsl_gl2 = "#extension GL_ARB_texture_rectangle : require\n";
             const char* global_glsl_lt_150 = "#version 120\n";

--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1061,6 +1061,7 @@ class: EventFilter : QObject
     method: eventFilter (bool; QObject obj, QEvent event)
     {
         let view = mainViewWidget();
+        if (view eq nil) return false;
         return view.eventFilter(obj, event);
     }
 }


### PR DESCRIPTION
### feat: SG-42200: 10-bit Metal presentation

### Linked issues

## Summarize your change

Adds a macOS-only **10-bit Metal presentation path** for OpenRV when the user requests 10+2 display format and the hardware supports it. IPCore still renders through an offscreen OpenGL 2.1 context (GL-on-Metal); the new backend delivers pixels to the screen via **IOSurface → CALayer** instead of a `QOpenGLWidget` swap chain.

The work is built on a **platform-neutral view abstraction** that decouples `RvDocument` from `GLView`: shared code routes through `viewWidget()` and the session's control video device, so alternative backends (this Metal path, and the existing Vulkan 10-bit path on Linux) can plug in without touching every call site.

When 10-bit Metal is unavailable or fails at runtime, the app **falls back to the legacy OpenGL `GLView`** with logging.

## Describe the reason for the change

OpenRV's main window has historically been a `QOpenGLWidget`. True **10-bit display on macOS** is unreliable through that path: requesting a 10+2 GL surface format does not reliably produce correct scanout, and a `QOpenGLWidget` anywhere in the window hierarchy can force Qt onto `_NSOpenGLViewBackingLayer`, breaking CALayer/IOSurface presentation (including 4× tiling artifacts with device pixel ratio scaling).

This PR introduces a dedicated **`MetalView`** (native `NSView` + `CALayer` backed by IOSurface) and **`QTMetalVideoDevice`**, which wraps it as a `TwkGLF::GLVideoDevice` so `ImageRenderer` and the rest of IPCore continue to render into offscreen FBOs unchanged. The zero-copy path blits RGBA16F → IOSurface-backed RGB10_A2; when GL–IOSurface interop is unavailable, a **GPU-blit + packed readback** fallback avoids the previous per-pixel CPU pack loop (~25M float ops/frame at 4K).

Additional fixes address real usability bugs on the new path: **black flash on window re-expose** (alt-tab / uncover), **context/thread safety** for upload threads, **interop failure retry** instead of permanently disabling zero-copy, and **diagnostics overlay** integration via `Qt::AA_ShareOpenGLContexts`.

## Describe what you have tested and on which operating system

- [x] **macOS** — Apple Silicon, 10-bit-capable display, `USE_METAL=ON`, 10+2 display prefs: main window presents correctly, no banding vs 8-bit GL path
- [x] **macOS** — Alt-tab / window uncover: no black flash; last frame re-presented immediately
- [x] **macOS** — Resize, Live Review panel, activity timer / playback scrubbing
- [x] **macOS** — Fallback when `supports10BitPresentation()` fails or GL context creation fails → `GLView` with log message
- [x] **macOS** — CPU fallback path when IOSurface GL interop unavailable (performance acceptable vs old float readback loop)

**OS tested:** macOS *(version / hardware — please confirm)*

## Add a list of changes, and note any that might need special attention during the review

### Core architecture (review carefully)

| Area | Change |
|------|--------|
| **View abstraction** | `RvDocument` uses `QWidget* m_viewWidget` + `viewWidget()` instead of hardcoded `m_glView`; `MuUICommands` / `PyUICommands` updated for null-safe coordinate mapping |
| **`RvApplication`** | Tolerates null `view()`; primary display group driven by session control video device |
| **`MetalView`** | QWidget with `WA_PaintOnScreen` / `WA_OpaquePaintEvent`, `paintEngine() → nullptr`, IOSurface cache + re-present on expose, coalesced `UpdateRequest`, `renderImmediately()` for synchronous redraw |
| **`QTMetalVideoDevice`** | Offscreen GL render FBO → IOSurface ring buffer (zero-copy) or GPU-blit flip FBO + packed `glReadPixels` (CPU fallback); interop failure latch with periodic retry |
| **`RvDocument`** | Selects `MetalView` vs `GLView` when 10+2 prefs + `MetalView::supports10BitPresentation()`; `fallbackMetalToGLView()` on context failure |
| **`ImageRenderer` / `Session`** | Upload-thread device sharing, synchronous upload fallback, explicit GL flush |


### Known limitations (not blockers, but reviewers should be aware)

- Metal activates only when **10+2 display prefs** are set **and** hardware check passes; changing prefs requires a **new window**
- **Hardware stereo** (shutter glasses) not supported on Metal; software stereo modes should work
- **VSync, double-buffer, GL pixel format prefs** are no-ops while on Metal (apply after GL fallback)
- **Presentation Mode** secondary displays remain 8-bit (separate `DesktopVideoDevice` path, not ported)