### PR TITLE
feat: Add shapes and text support to OTIO annotation reader

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -82,6 +82,166 @@ def _transform_otio_to_world_coordinate(point):
     return (world_coordinate_x, world_coordinate_y, world_coordinate_width)
 
 
+def _get_source_image_height() -> float:
+    """Return the pixel height of the first media source. Falls back to 1080."""
+    try:
+        media_switch = commands.nodeConnections("MediaTrack")[0][0]
+        media_source_group = commands.nodeConnections(media_switch)[0][0]
+        first_source_node = extra_commands.nodesInGroupOfType(media_source_group, "RVFileSource")[0]
+        media_info = commands.sourceMediaInfo(first_source_node)
+        h = float(media_info.get("height", 0))
+        if h > 1:
+            return h
+    except Exception:
+        pass
+    return 1080.0
+
+
+def _transform_pos(x, y):
+    """Transform a 2D OTIO position to RV WCS. Returns (wcs_x, wcs_y) or None."""
+    result = _transform_otio_to_world_coordinate(otio.schemadef.Point.Point(x=x, y=y, width=0.0))
+    if result is None:
+        return None
+    return result[0], result[1]
+
+
+def _transform_scalar(w):
+    """Scale a scalar OTIO distance to RV WCS via the x-axis scale, or return the raw value."""
+    result = _transform_otio_to_world_coordinate(otio.schemadef.Point.Point(x=0.0, y=0.0, width=float(w)))
+    return result[2] if result is not None else float(w)
+
+
+def _add_shape_to_frame_order(paint_node, stroke_id, frame, prefix):
+    """Insert a shape into the frame draw-order list."""
+    frame_component = f"{paint_node}.frame:{frame}"
+    if not commands.propertyExists(f"{frame_component}.order"):
+        commands.newProperty(f"{frame_component}.order", commands.StringType, 1)
+    commands.insertStringProperty(f"{frame_component}.order", [f"{prefix}:{stroke_id}:{frame}:annotation"])
+
+
+def _create_bbox_shape(layer, paint_node, stroke_id, frame, shape_type):
+    """Create an RVPaint rect: or ellipse: node from a shape layer."""
+    prefix = "rect" if shape_type.startswith("Rectangle.") else "ellipse"
+    shape_component = f"{paint_node}.{prefix}:{stroke_id}:{frame}:annotation"
+
+    min_pos = _transform_pos(layer.min.x, layer.min.y)
+    max_pos = _transform_pos(layer.max.x, layer.max.y)
+    if min_pos is None or max_pos is None:
+        logging.warning(f"annotation_hook: could not transform bbox coords for {shape_component} — skipping")
+        return
+
+    border_width = float(layer.border_width) if layer.border_width is not None else 0.0
+    wcs_border_width = _transform_scalar(border_width)
+
+    corner_radius = getattr(layer, "corner_radius", None)
+    wcs_corner_radius = float(corner_radius) if corner_radius is not None else 0.0
+
+    effectHook.add_rv_effect_props(
+        shape_component,
+        {
+            "min": list(min_pos),
+            "max": list(max_pos),
+            "innerColor": [float(c) for c in layer.inner_color],
+            "borderColor": [float(c) for c in layer.border_color],
+            "borderWidth": [wcs_border_width],
+            "cornerRadius": [wcs_corner_radius],
+            "startFrame": frame,
+            "duration": 1,
+            "eye": 2,
+            "softDeleted": layer.visible is False,
+            "uuid": [layer.id],
+        },
+    )
+
+    if layer.visible is not False:
+        _add_shape_to_frame_order(paint_node, stroke_id, frame, prefix)
+
+
+def _create_point_pair_shape(layer, paint_node, stroke_id, frame, shape_type):
+    """Create an RVPaint arrow: or line: node from a shape layer."""
+    prefix = "arrow" if shape_type.startswith("Arrow.") else "line"
+    shape_component = f"{paint_node}.{prefix}:{stroke_id}:{frame}:annotation"
+
+    start_pos = _transform_pos(layer.start_position.x, layer.start_position.y)
+    end_pos = _transform_pos(layer.end_position.x, layer.end_position.y)
+    if start_pos is None or end_pos is None:
+        logging.warning(f"annotation_hook: could not transform point-pair coords for {shape_component} — skipping")
+        return
+
+    raw_bw = float(layer.width if shape_type.startswith("Line.") else layer.border_width)
+    wcs_border_width = _transform_scalar(raw_bw)
+
+    props = {
+        "startPos": list(start_pos),
+        "endPos": list(end_pos),
+        "borderColor": [float(c) for c in layer.border_color],
+        "borderWidth": [wcs_border_width],
+        "startFrame": frame,
+        "duration": 1,
+        "eye": 2,
+        "softDeleted": layer.visible is False,
+        "uuid": [layer.id],
+    }
+
+    if shape_type.startswith("Arrow."):
+        wcs_thickness = _transform_scalar(float(layer.width))
+        props["innerColor"] = [float(c) for c in layer.inner_color]
+        props["thickness"] = [wcs_thickness]
+
+    effectHook.add_rv_effect_props(shape_component, props)
+
+    if layer.visible is not False:
+        _add_shape_to_frame_order(paint_node, stroke_id, frame, prefix)
+
+
+def _create_text_shape(layer, paint_node, stroke_id, frame, source_node=None):
+    """Create an RVPaint text: node from a shape layer."""
+    shape_component = f"{paint_node}.text:{stroke_id}:{frame}:annotation"
+
+    anchor = layer.anchor
+    anchor_pos = _transform_pos(anchor.x, anchor.y)
+    if anchor_pos is None:
+        logging.warning(f"annotation_hook: could not transform text anchor for {shape_component} — skipping")
+        return
+
+    # font_size in OTIO is in OTIO-space units (same coordinate space as
+    # border_width). Convert to RVPaint logical pixels: OTIO → WCS via
+    # _transform_scalar, then WCS → pixels by multiplying by image height.
+    # Use the media track's source for height — the annotation source group
+    # is a blank node whose sourceMediaInfo returns height=1, not the real
+    # image dimensions.
+    image_h = _get_source_image_height()
+    font_size_wcs = _transform_scalar(float(layer.font_size))
+    font_size_rv = font_size_wcs * image_h
+
+    # RVPaint .position is the BOTTOM of the text quad (y-up). The OTIO anchor
+    # is the typographic baseline. Descent ≈ 0.2 × em, so the bottom of the
+    # quad is ~0.2 × em below the baseline → shift position DOWN by 0.2 × em.
+    anchor_pos = (anchor_pos[0], anchor_pos[1] - font_size_wcs * 0.2)
+
+    effectHook.add_rv_effect_props(
+        shape_component,
+        {
+            "text": [layer.text],
+            "fontFamily": [layer.font_family],
+            "fontWeight": [layer.font_weight],
+            "fontStyle": [layer.font_style],
+            "textDecoration": [layer.text_decoration],
+            "textAlign": [layer.text_align],
+            "position": list(anchor_pos),
+            "fontSize": [font_size_rv],
+            "color": [float(c) for c in layer.inner_color],
+            "startFrame": frame,
+            "duration": 1,
+            "softDeleted": layer.visible is False,
+            "uuid": [layer.id],
+        },
+    )
+
+    if layer.visible is not False:
+        _add_shape_to_frame_order(paint_node, stroke_id, frame, "text")
+
+
 def hook_function(in_timeline: otio.schemadef.Annotation.Annotation, argument_map: dict | None = None) -> None:
     """A hook for the annotation schema"""
     try:
@@ -106,54 +266,71 @@ def hook_function(in_timeline: otio.schemadef.Annotation.Annotation, argument_ma
         paint_node = extra_commands.nodesInGroupOfType(source_node, "RVPaint")[0]
         paint_component = f"{paint_node}.paint"
         stroke_id = commands.getIntProperty(f"{paint_component}.nextId")[0] + 1
-        pen_component = f"{paint_node}.pen:{stroke_id}:{frame}:annotation"
         frame_component = f"{paint_node}.frame:{frame}"
 
         # Set properties on the paint component of the RVPaint node
         effectHook.set_rv_effect_props(paint_component, {"nextId": stroke_id})
 
-        start_time = int(time_range.start_time.value)
-        end_time = int(start_time + time_range.duration.value)
+        shape_label = getattr(layer, "_serializable_label", "")
 
-        duration = end_time - start_time
+        if isinstance(layer, otio.schemadef.Paint.Paint):
+            pen_component = f"{paint_node}.pen:{stroke_id}:{frame}:annotation"
 
-        # Add and set properties on the pen component of the RVPaint node
-        effectHook.add_rv_effect_props(
-            pen_component,
-            {
-                "color": list(map(float, layer.rgba)),
-                "brush": [layer.brush],
-                "debug": 1,
-                "join": 3,
-                "cap": 1,
-                "splat": 0,
-                "mode": 0 if layer.type == "COLOR" else 1,
-                "startFrame": start_time,
-                "duration": duration,
-                "softDeleted": layer.soft_deleted,
-                "uuid": [layer.id],
-            },
-        )
+            start_time = int(time_range.start_time.value)
+            end_time = int(start_time + time_range.duration.value)
+            duration = end_time - start_time
 
-        points_property = f"{pen_component}.points"
-        width_property = f"{pen_component}.width"
-
-        if not commands.propertyExists(points_property):
-            commands.newProperty(points_property, commands.FloatType, 2)
-        if not commands.propertyExists(width_property):
-            commands.newProperty(width_property, commands.FloatType, 1)
-
-        for point in layer.points:
-            world_coordinate_x, world_coordinate_y, world_coordinate_width = _transform_otio_to_world_coordinate(point)
-
-            commands.insertFloatProperty(
-                points_property,
-                [world_coordinate_x, world_coordinate_y],
+            # Add and set properties on the pen component of the RVPaint node
+            effectHook.add_rv_effect_props(
+                pen_component,
+                {
+                    "color": list(map(float, layer.rgba)),
+                    "brush": [layer.brush],
+                    "debug": 1,
+                    "join": 3,
+                    "cap": 1,
+                    "splat": 0,
+                    "mode": 0 if layer.type == "COLOR" else 1,
+                    "startFrame": start_time,
+                    "duration": duration,
+                    "softDeleted": layer.soft_deleted,
+                    "uuid": [layer.id],
+                },
             )
-            commands.insertFloatProperty(width_property, [world_coordinate_width])
 
-        if not layer.soft_deleted:
-            if not commands.propertyExists(f"{frame_component}.order"):
-                commands.newProperty(f"{frame_component}.order", commands.StringType, 1)
+            points_property = f"{pen_component}.points"
+            width_property = f"{pen_component}.width"
 
-            commands.insertStringProperty(f"{frame_component}.order", [f"pen:{stroke_id}:{frame}:annotation"])
+            if not commands.propertyExists(points_property):
+                commands.newProperty(points_property, commands.FloatType, 2)
+            if not commands.propertyExists(width_property):
+                commands.newProperty(width_property, commands.FloatType, 1)
+
+            for point in layer.points:
+                world_coordinate_x, world_coordinate_y, world_coordinate_width = _transform_otio_to_world_coordinate(
+                    point
+                )
+
+                commands.insertFloatProperty(
+                    points_property,
+                    [world_coordinate_x, world_coordinate_y],
+                )
+                commands.insertFloatProperty(width_property, [world_coordinate_width])
+
+            if not layer.soft_deleted:
+                if not commands.propertyExists(f"{frame_component}.order"):
+                    commands.newProperty(f"{frame_component}.order", commands.StringType, 1)
+
+                commands.insertStringProperty(f"{frame_component}.order", [f"pen:{stroke_id}:{frame}:annotation"])
+
+        elif shape_label.startswith(("Rectangle.", "Ellipse.")):
+            _create_bbox_shape(layer, paint_node, stroke_id, frame, shape_label)
+
+        elif shape_label.startswith(("Arrow.", "Line.")):
+            _create_point_pair_shape(layer, paint_node, stroke_id, frame, shape_label)
+
+        elif shape_label.startswith("Text."):
+            _create_text_shape(layer, paint_node, stroke_id, frame, source_node)
+
+        else:
+            logging.warning(f"annotation_hook: unrecognised layer type {shape_label!r} — skipping")

--- a/src/plugins/rv-packages/otio_reader/arrow_schema.py
+++ b/src/plugins/rv-packages/otio_reader/arrow_schema.py
@@ -15,10 +15,10 @@ Example:
     arrow = otio.schemadef.Arrow.Arrow(
         start_position=otio.schemadef.Position.Position(x=-4.0, y=0.0),
         end_position=otio.schemadef.Position.Position(x=4.0, y=0.0),
-        innerColor=[1.0, 1.0, 0.0, 1.0],
-        borderColor=[0.8, 0.8, 0.0, 1.0],
+        inner_color=[1.0, 1.0, 0.0, 1.0],
+        border_color=[0.8, 0.8, 0.0, 1.0],
         width=0.15,
-        borderWidth=0.02,
+        border_width=0.02,
         id="c3d4e5f6-a7b8-9012-cdef-123456789012",
         visible=True,
         layer_range=otio.opentime.TimeRange(...),
@@ -39,10 +39,10 @@ class Arrow(otio.core.SerializableObject):
         self,
         start_position=None,
         end_position=None,
-        innerColor: list | None = None,
-        borderColor: list | None = None,
+        inner_color: list | None = None,
+        border_color: list | None = None,
         width: float | None = None,
-        borderWidth: float | None = None,
+        border_width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
@@ -50,10 +50,10 @@ class Arrow(otio.core.SerializableObject):
         super().__init__()
         self.start_position = start_position
         self.end_position = end_position
-        self.innerColor = innerColor
-        self.borderColor = borderColor
+        self.inner_color = inner_color
+        self.border_color = border_color
         self.width = width
-        self.borderWidth = borderWidth
+        self.border_width = border_width
         self.id = id
         self.visible = visible
         self.layer_range = layer_range
@@ -63,31 +63,31 @@ class Arrow(otio.core.SerializableObject):
         "end_position", doc="Tip of the arrow — arrowhead points here (Position.1)"
     )
 
-    _innerColor = otio.core.serializable_field("innerColor", required_type=list, doc="Shaft fill colour [r, g, b, a]")
+    _inner_color = otio.core.serializable_field("inner_color", required_type=list, doc="Shaft fill colour [r, g, b, a]")
 
     @property
-    def innerColor(self) -> list:
-        return self._innerColor
+    def inner_color(self) -> list:
+        return self._inner_color
 
-    @innerColor.setter
-    def innerColor(self, val: list) -> None:
-        self._innerColor = val
+    @inner_color.setter
+    def inner_color(self, val: list) -> None:
+        self._inner_color = val
 
-    _borderColor = otio.core.serializable_field("borderColor", required_type=list, doc="Outline colour [r, g, b, a]")
+    _border_color = otio.core.serializable_field("border_color", required_type=list, doc="Outline colour [r, g, b, a]")
 
     @property
-    def borderColor(self) -> list:
-        return self._borderColor
+    def border_color(self) -> list:
+        return self._border_color
 
-    @borderColor.setter
-    def borderColor(self, val: list) -> None:
-        self._borderColor = val
+    @border_color.setter
+    def border_color(self, val: list) -> None:
+        self._border_color = val
 
     width = otio.core.serializable_field(
         "width", required_type=float, doc="Shaft width in normalised units; arrowhead scales proportionally"
     )
-    borderWidth = otio.core.serializable_field(
-        "borderWidth", required_type=float, doc="Outline width in normalised units"
+    border_width = otio.core.serializable_field(
+        "border_width", required_type=float, doc="Outline width in normalised units"
     )
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")

--- a/src/plugins/rv-packages/otio_reader/ellipse_schema.py
+++ b/src/plugins/rv-packages/otio_reader/ellipse_schema.py
@@ -15,9 +15,9 @@ Example:
     ellipse = otio.schemadef.Ellipse.Ellipse(
         min=otio.schemadef.Position.Position(x=-2.0, y=-1.0),
         max=otio.schemadef.Position.Position(x=2.0, y=1.0),
-        innerColor=[0.0, 0.5, 1.0, 0.2],
-        borderColor=[0.0, 0.5, 1.0, 1.0],
-        borderWidth=0.05,
+        inner_color=[0.0, 0.5, 1.0, 0.2],
+        border_color=[0.0, 0.5, 1.0, 1.0],
+        border_width=0.05,
         id="b2c3d4e5-f6a7-8901-bcde-f12345678901",
         visible=True,
         layer_range=otio.opentime.TimeRange(...),
@@ -38,9 +38,9 @@ class Ellipse(otio.core.SerializableObject):
         self,
         min=None,
         max=None,
-        innerColor: list | None = None,
-        borderColor: list | None = None,
-        borderWidth: float | None = None,
+        inner_color: list | None = None,
+        border_color: list | None = None,
+        border_width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
@@ -48,9 +48,9 @@ class Ellipse(otio.core.SerializableObject):
         super().__init__()
         self.min = min
         self.max = max
-        self.innerColor = innerColor
-        self.borderColor = borderColor
-        self.borderWidth = borderWidth
+        self.inner_color = inner_color
+        self.border_color = border_color
+        self.border_width = border_width
         self.id = id
         self.visible = visible
         self.layer_range = layer_range
@@ -58,28 +58,28 @@ class Ellipse(otio.core.SerializableObject):
     min = otio.core.serializable_field("min", doc="Top-left corner of bounding box (Position.1)")
     max = otio.core.serializable_field("max", doc="Bottom-right corner of bounding box (Position.1)")
 
-    _innerColor = otio.core.serializable_field("innerColor", required_type=list, doc="Fill colour [r, g, b, a]")
+    _inner_color = otio.core.serializable_field("inner_color", required_type=list, doc="Fill colour [r, g, b, a]")
 
     @property
-    def innerColor(self) -> list:
-        return self._innerColor
+    def inner_color(self) -> list:
+        return self._inner_color
 
-    @innerColor.setter
-    def innerColor(self, val: list) -> None:
-        self._innerColor = val
+    @inner_color.setter
+    def inner_color(self, val: list) -> None:
+        self._inner_color = val
 
-    _borderColor = otio.core.serializable_field("borderColor", required_type=list, doc="Outline colour [r, g, b, a]")
+    _border_color = otio.core.serializable_field("border_color", required_type=list, doc="Outline colour [r, g, b, a]")
 
     @property
-    def borderColor(self) -> list:
-        return self._borderColor
+    def border_color(self) -> list:
+        return self._border_color
 
-    @borderColor.setter
-    def borderColor(self, val: list) -> None:
-        self._borderColor = val
+    @border_color.setter
+    def border_color(self, val: list) -> None:
+        self._border_color = val
 
-    borderWidth = otio.core.serializable_field(
-        "borderWidth", required_type=float, doc="Outline width in normalised units"
+    border_width = otio.core.serializable_field(
+        "border_width", required_type=float, doc="Outline width in normalised units"
     )
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")
@@ -104,5 +104,5 @@ class Ellipse(otio.core.SerializableObject):
     def __repr__(self) -> str:
         return (
             f"otio.schemadef.Ellipse.Ellipse("
-            f"id={self.id!r}, min={self.min!r}, max={self.max!r}, borderWidth={self.borderWidth!r})"
+            f"id={self.id!r}, min={self.min!r}, max={self.max!r}, border_width={self.border_width!r})"
         )

--- a/src/plugins/rv-packages/otio_reader/line_schema.py
+++ b/src/plugins/rv-packages/otio_reader/line_schema.py
@@ -8,14 +8,14 @@
 """
 OTIO schemadef for a straight line annotation shape.
 
-Lines have no fill — borderColor is the line colour. Ends are rounded (capsule).
+Lines have no fill — border_color is the line colour. Ends are rounded (capsule).
 All coordinates are in normalised image space (see position_schema.py).
 
 Example:
     line = otio.schemadef.Line.Line(
         start_position=otio.schemadef.Position.Position(x=-4.0, y=2.0),
         end_position=otio.schemadef.Position.Position(x=4.0, y=-2.0),
-        borderColor=[0.0, 1.0, 0.5, 1.0],
+        border_color=[0.0, 1.0, 0.5, 1.0],
         width=0.04,
         id="d4e5f6a7-b8c9-0123-defa-234567890123",
         visible=True,
@@ -37,7 +37,7 @@ class Line(otio.core.SerializableObject):
         self,
         start_position=None,
         end_position=None,
-        borderColor: list | None = None,
+        border_color: list | None = None,
         width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
@@ -46,7 +46,7 @@ class Line(otio.core.SerializableObject):
         super().__init__()
         self.start_position = start_position
         self.end_position = end_position
-        self.borderColor = borderColor
+        self.border_color = border_color
         self.width = width
         self.id = id
         self.visible = visible
@@ -55,15 +55,15 @@ class Line(otio.core.SerializableObject):
     start_position = otio.core.serializable_field("start_position", doc="Start point (Position.1)")
     end_position = otio.core.serializable_field("end_position", doc="End point (Position.1)")
 
-    _borderColor = otio.core.serializable_field("borderColor", required_type=list, doc="Line colour [r, g, b, a]")
+    _border_color = otio.core.serializable_field("border_color", required_type=list, doc="Line colour [r, g, b, a]")
 
     @property
-    def borderColor(self) -> list:
-        return self._borderColor
+    def border_color(self) -> list:
+        return self._border_color
 
-    @borderColor.setter
-    def borderColor(self, val: list) -> None:
-        self._borderColor = val
+    @border_color.setter
+    def border_color(self, val: list) -> None:
+        self._border_color = val
 
     width = otio.core.serializable_field("width", required_type=float, doc="Line width in normalised units")
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")

--- a/src/plugins/rv-packages/otio_reader/rectangle_schema.py
+++ b/src/plugins/rv-packages/otio_reader/rectangle_schema.py
@@ -16,10 +16,10 @@ Example:
     rect = otio.schemadef.Rectangle.Rectangle(
         min=otio.schemadef.Position.Position(x=-2.0, y=-1.0),
         max=otio.schemadef.Position.Position(x=2.0, y=1.0),
-        innerColor=[1.0, 0.0, 0.0, 0.3],
-        borderColor=[1.0, 0.0, 0.0, 1.0],
-        borderWidth=0.05,
-        cornerRadius=0.0,
+        inner_color=[1.0, 0.0, 0.0, 0.3],
+        border_color=[1.0, 0.0, 0.0, 1.0],
+        border_width=0.05,
+        corner_radius=0.0,
         id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
         visible=True,
         layer_range=otio.opentime.TimeRange(...),
@@ -40,10 +40,10 @@ class Rectangle(otio.core.SerializableObject):
         self,
         min=None,
         max=None,
-        innerColor: list | None = None,
-        borderColor: list | None = None,
-        borderWidth: float | None = None,
-        cornerRadius: float | None = None,
+        inner_color: list | None = None,
+        border_color: list | None = None,
+        border_width: float | None = None,
+        corner_radius: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
@@ -51,10 +51,10 @@ class Rectangle(otio.core.SerializableObject):
         super().__init__()
         self.min = min
         self.max = max
-        self.innerColor = innerColor
-        self.borderColor = borderColor
-        self.borderWidth = borderWidth
-        self.cornerRadius = cornerRadius
+        self.inner_color = inner_color
+        self.border_color = border_color
+        self.border_width = border_width
+        self.corner_radius = corner_radius
         self.id = id
         self.visible = visible
         self.layer_range = layer_range
@@ -63,31 +63,31 @@ class Rectangle(otio.core.SerializableObject):
     min = otio.core.serializable_field("min", doc="Top-left corner (Position.1)")
     max = otio.core.serializable_field("max", doc="Bottom-right corner (Position.1)")
 
-    _innerColor = otio.core.serializable_field("innerColor", required_type=list, doc="Fill colour [r, g, b, a]")
+    _inner_color = otio.core.serializable_field("inner_color", required_type=list, doc="Fill colour [r, g, b, a]")
 
     @property
-    def innerColor(self) -> list:
-        return self._innerColor
+    def inner_color(self) -> list:
+        return self._inner_color
 
-    @innerColor.setter
-    def innerColor(self, val: list) -> None:
-        self._innerColor = val
+    @inner_color.setter
+    def inner_color(self, val: list) -> None:
+        self._inner_color = val
 
-    _borderColor = otio.core.serializable_field("borderColor", required_type=list, doc="Outline colour [r, g, b, a]")
+    _border_color = otio.core.serializable_field("border_color", required_type=list, doc="Outline colour [r, g, b, a]")
 
     @property
-    def borderColor(self) -> list:
-        return self._borderColor
+    def border_color(self) -> list:
+        return self._border_color
 
-    @borderColor.setter
-    def borderColor(self, val: list) -> None:
-        self._borderColor = val
+    @border_color.setter
+    def border_color(self, val: list) -> None:
+        self._border_color = val
 
-    borderWidth = otio.core.serializable_field(
-        "borderWidth", required_type=float, doc="Outline width in normalised units"
+    border_width = otio.core.serializable_field(
+        "border_width", required_type=float, doc="Outline width in normalised units"
     )
-    cornerRadius = otio.core.serializable_field(
-        "cornerRadius", required_type=float, doc="Corner radius in normalised units; 0.0 = sharp"
+    corner_radius = otio.core.serializable_field(
+        "corner_radius", required_type=float, doc="Corner radius in normalised units; 0.0 = sharp"
     )
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")
@@ -113,5 +113,5 @@ class Rectangle(otio.core.SerializableObject):
         return (
             f"otio.schemadef.Rectangle.Rectangle("
             f"id={self.id!r}, min={self.min!r}, max={self.max!r}, "
-            f"borderWidth={self.borderWidth!r}, cornerRadius={self.cornerRadius!r})"
+            f"border_width={self.border_width!r}, corner_radius={self.corner_radius!r})"
         )

--- a/src/plugins/rv-packages/otio_reader/text_schema.py
+++ b/src/plugins/rv-packages/otio_reader/text_schema.py
@@ -10,11 +10,15 @@ OTIO schemadef for a text annotation shape.
 
 Font properties are discrete fields so each platform constructs its own
 representation (CSS for web clients, QFont for RV) without string parsing.
-anchor is the baseline start point, consistent with min/max/start_position
-on other shape types.
+anchor is the typographic baseline origin (bottom-left of the first character,
+excluding descenders). This matches the CSS/web convention. Renderers that
+use a top-left origin (e.g. RVPaint) must offset upward by one em (font_size).
 
-fontSize is in normalised units (relative to image height).
-For 16:9 content: small ≈ 0.15, medium ≈ 0.22, large ≈ 0.33.
+font_size is in OTIO normalised coordinate units (same space as border_width
+and all other scalar dimensions). For standard 16:9 content the OTIO y-range
+is 9 units, so small ≈ 0.15, medium ≈ 0.25, large ≈ 0.5.
+To get RVPaint's logical fontSize: divide by bounds_size to reach WCS, then
+multiply by image_height_pixels.
 
 All coordinates are in normalised image space (see position_schema.py).
 
@@ -22,13 +26,13 @@ Example:
     text = otio.schemadef.Text.Text(
         anchor=otio.schemadef.Position.Position(x=-3.0, y=2.0),
         text="Frame needs colour correction",
-        fontFamily="Inter",
-        fontSize=0.22,
-        fontWeight="normal",
-        fontStyle="normal",
-        textDecoration="none",
-        textAlign="left",
-        innerColor=[1.0, 1.0, 1.0, 1.0],
+        font_family="Inter",
+        font_size=0.22,
+        font_weight="NORMAL",
+        font_style="NORMAL",
+        text_decoration="NONE",
+        text_align="LEFT",
+        inner_color=[1.0, 1.0, 1.0, 1.0],
         id="e5f6a7b8-c9d0-1234-efab-345678901234",
         visible=True,
         layer_range=otio.opentime.TimeRange(...),
@@ -49,13 +53,13 @@ class Text(otio.core.SerializableObject):
         self,
         anchor=None,
         text: str | None = None,
-        fontFamily: str | None = None,
-        fontSize: float | None = None,
-        fontWeight: str | None = None,
-        fontStyle: str | None = None,
-        textDecoration: str | None = None,
-        textAlign: str | None = None,
-        innerColor: list | None = None,
+        font_family: str | None = None,
+        font_size: float | None = None,
+        font_weight: str | None = None,
+        font_style: str | None = None,
+        text_decoration: str | None = None,
+        text_align: str | None = None,
+        inner_color: list | None = None,
         id: str | None = None,
         visible: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
@@ -63,49 +67,49 @@ class Text(otio.core.SerializableObject):
         super().__init__()
         self.anchor = anchor
         self.text = text
-        self.fontFamily = fontFamily
-        self.fontSize = fontSize
-        self.fontWeight = fontWeight
-        self.fontStyle = fontStyle
-        self.textDecoration = textDecoration
-        self.textAlign = textAlign
-        self.innerColor = innerColor
+        self.font_family = font_family
+        self.font_size = font_size
+        self.font_weight = font_weight
+        self.font_style = font_style
+        self.text_decoration = text_decoration
+        self.text_align = text_align
+        self.inner_color = inner_color
         self.id = id
         self.visible = visible
         self.layer_range = layer_range
 
     anchor = otio.core.serializable_field("anchor", doc="Baseline start point (Position.1)")
     text = otio.core.serializable_field("text", required_type=str, doc="Text content")
-    fontFamily = otio.core.serializable_field("fontFamily", required_type=str, doc="Font family, e.g. 'Inter'")
-    fontSize = otio.core.serializable_field(
-        "fontSize", required_type=float, doc="Font size in normalised units (relative to image height)"
+    font_family = otio.core.serializable_field("font_family", required_type=str, doc="Font family, e.g. 'Inter'")
+    font_size = otio.core.serializable_field(
+        "font_size", required_type=float, doc="Font size in normalised units (relative to image height)"
     )
 
-    # "normal" | "bold"
-    fontWeight = otio.core.serializable_field("fontWeight", required_type=str, doc="Font weight: 'normal' or 'bold'")
+    # "NORMAL" | "BOLD"
+    font_weight = otio.core.serializable_field("font_weight", required_type=str, doc="Font weight: 'NORMAL' or 'BOLD'")
 
-    # "normal" | "italic"
-    fontStyle = otio.core.serializable_field("fontStyle", required_type=str, doc="Font style: 'normal' or 'italic'")
+    # "NORMAL" | "ITALIC"
+    font_style = otio.core.serializable_field("font_style", required_type=str, doc="Font style: 'NORMAL' or 'ITALIC'")
 
-    # "none" | "underline"
-    textDecoration = otio.core.serializable_field(
-        "textDecoration", required_type=str, doc="Text decoration: 'none' or 'underline'"
+    # "NONE" | "UNDERLINE"
+    text_decoration = otio.core.serializable_field(
+        "text_decoration", required_type=str, doc="Text decoration: 'NONE' or 'UNDERLINE'"
     )
 
-    # "left" | "center" | "right"
-    textAlign = otio.core.serializable_field(
-        "textAlign", required_type=str, doc="Text alignment relative to anchor: 'left', 'center', or 'right'"
+    # "LEFT" | "CENTER" | "RIGHT"
+    text_align = otio.core.serializable_field(
+        "text_align", required_type=str, doc="Text alignment relative to anchor: 'LEFT', 'CENTER', or 'RIGHT'"
     )
 
-    _innerColor = otio.core.serializable_field("innerColor", required_type=list, doc="Text fill colour [r, g, b, a]")
+    _inner_color = otio.core.serializable_field("inner_color", required_type=list, doc="Text fill colour [r, g, b, a]")
 
     @property
-    def innerColor(self) -> list:
-        return self._innerColor
+    def inner_color(self) -> list:
+        return self._inner_color
 
-    @innerColor.setter
-    def innerColor(self, val: list) -> None:
-        self._innerColor = val
+    @inner_color.setter
+    def inner_color(self, val: list) -> None:
+        self._inner_color = val
 
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")
@@ -130,6 +134,6 @@ class Text(otio.core.SerializableObject):
     def __repr__(self) -> str:
         return (
             f"otio.schemadef.Text.Text("
-            f"id={self.id!r}, text={self.text!r}, fontFamily={self.fontFamily!r}, "
-            f"fontSize={self.fontSize!r}, anchor={self.anchor!r})"
+            f"id={self.id!r}, text={self.text!r}, font_family={self.font_family!r}, "
+            f"font_size={self.font_size!r}, anchor={self.anchor!r})"
         )


### PR DESCRIPTION
### Add schema changes for supporting Shapes and Text annotation in Live Review

### Summarize your change.

The are the changes necessary for support shapes and text of the live review protocol. They include:
- Changes from camelCase to snake_case
- Transformations from LiveReview protocol co-orindates space into RV normalized coordinates for shape and text messages

### Describe the reason for the change.

This enables RV to communicate with the Review web client over the LiveReview protocol

### Describe what you have tested and on which operating system.

Mac OS 26.5.1
