### PR TITLE
fix: SG-43808: Fix killing rvio processes for the session manager when shutting down

### DIFF
--- a/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
+++ b/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
@@ -458,6 +458,8 @@ class LocalThumbnailGen(rvtypes.MinorMode):
 
     def _generate_thumbnail(self, cache_key: str, rvio_bin: str, media_path: str, mid_frame: int) -> None:
         """Runs rvio to generate a single-frame thumbnail in a worker thread."""
+        if self._shutting_down:
+            return
         output_path = self._cache_dir / f"{cache_key}_thumbnail.jpg"
         try:
             self._run_suspendable(
@@ -484,6 +486,8 @@ class LocalThumbnailGen(rvtypes.MinorMode):
         height: int,
     ) -> None:
         """Runs rvio to generate a filmstrip image in a worker thread."""
+        if self._shutting_down:
+            return
         output_path = self._cache_dir / f"{cache_key}_filmstrip.jpg"
         session_path = self._cache_dir / f"filmstrip_{cache_key}.rv"
         try:


### PR DESCRIPTION
### fix: [SG-43808](https://autodesk.atlassian.net/browse/SG-43808): Fix killing rvio processes for the session manager when shutting down

### Summarize your change.

Return early in `generate_thumbnail` and `generate_filmstrips` to avoid spawning a new RVIO process when we are shutting down.

### Describe the reason for the change.

On Windows, quitting Open RV after disabling "Show Source Previews" from the Session Manager could leave Open RV unable to exit. An RVIO process could be left suspended, causing the worker thread waiting on it to never return and forcing users to manually end the Open RV process from the Task Manager.

This issue was caused by a race in `_run_suspendable`. RVIO processes are created with `Popen` before being added to `_active_procs`. On shutdown, the code would look at this list and kill the processes it contains. However, a process spawned in the small window before it is registered would be absent from it and would never be killed. Because previews are disabled, `_should_defer()` stays true, so `_run_suspendable` keeps extending the process' deadline indefinitely rather than terminating it. This caused an orphaned and suspended RVIO process, blocking Open RV from shutting down.

Note that this issue was present before replacing the manual signal handling with `psutil`. We are probably only seeing it now because `psutil` suspends the process more reliably so the orphaned process now stays frozen, whereas the previous implementation might have let the process finish and exit on its own.

### Describe what you have tested and on which operating system.

Tested that enabling "Show Source Previews", then disabling it just before quitting Open RV is removing all the RVIO processes (and the Open RV process itself) from the Task Manager on Windows.