### PR TITLE
fix: SG-43881: Fix scrollbar on reordering with previews enabled

### DIFF
--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -1486,6 +1486,13 @@ class: SessionManagerMode : MinorMode
 
         _inputOrderLock = true;
 
+        string topNode = nil;
+        let topIndex = _inputsView.indexAt(QPoint(0, 0));
+        if (topIndex.isValid())
+        {
+            topNode = nodeFromIndex(topIndex, _inputsModel);
+        }
+
         _inputsModel.clear();
         let connections = nodeInputs(node);
 
@@ -1512,6 +1519,15 @@ class: SessionManagerMode : MinorMode
         }
 
         _inputOrderLock = false;
+
+        if (topNode neq nil)
+        {
+            let topItem = itemOfNode(_inputsModel, topNode);
+            if (topItem neq nil)
+            {
+                _inputsView.scrollTo(_inputsModel.indexFromItem(topItem), QAbstractItemView.PositionAtTop);
+            }
+        }
     }
 
     method: selectViewableNode (void;)


### PR DESCRIPTION
### fix: [SG-43881](https://autodesk.atlassian.net/browse/SG-43881): Fix scrollbar on reordering with previews enabled

### Summarize your change.

Record the top most input in the visible viewport before clearing it and scrolling back to that position once the list has been updated.

### Describe the reason for the change.

When "Show Source Preview" is enabled in the Session Manager, reordering inputs up and down caused the inputs list to scroll back to the top. A reorder rebuilds the list in `updateInputs`. This means that all the rows are removed from the model and added back in the new order. With previews enabled, each source row also has a preview QWidget. Clearing the model destroys those widgets and the rebuild creates new ones, which resets the scroll position to the top. Without previews, there are no QWidgets to recreate, which explains why the issue is only visible when "Show Source Preview" is enabled.

### Describe what you have tested and on which operating system.

Reordering up and down a single input and multiple inputs with and without "Show Source Preview" was tested on macOS.