### PR TITLE
fix: SG-43948 more stale paint cache fixes

### DIFF
--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -70,6 +70,18 @@ namespace
         return std::min(1.0f, ghostOpacity);
     }
 
+    // This should be set if the paint command depends on the frame content
+    // and as such cannot be cached independently of it -- such as holding or
+    // ghosting, where the underlying frame needs to change even though the
+    // annotation geometry remains the same.
+    void setFrameDependent(PaintIPNode::LocalCommand* command, bool value)
+    {
+        if (auto* baseCommand = dynamic_cast<Paint::Command*>(command))
+        {
+            baseCommand->frameDependent = value;
+        }
+    }
+
     // Loop over all commands and separate them in 3 containers:
     // 1. Commands that are visible on the current frame (based only on their
     // visibility range settings)
@@ -144,6 +156,7 @@ namespace
                 {
                     isHoldedCommandsInFirstLevel = true;
                     command->ghostOn = true;
+                    setFrameDependent(command, true);
 
                     if (auto* polyLine = dynamic_cast<PaintIPNode::LocalPolyLine*>(command))
                     {
@@ -176,6 +189,7 @@ namespace
                 if (paintEffects.ghost != 0 && paintEffects.ghostBefore >= ghostLevel)
                 {
                     command->ghostOn = true;
+                    setFrameDependent(command, true);
                     command->ghostColor = PaintIPNode::Color(1.0, 0.0, 0.0, 1.0); // Ghosted "Before" commands
                                                                                   // are drawn in green
                     command->ghostColor[3] = getGhostOpacity(frame, command->startFrame, command->duration);
@@ -198,6 +212,7 @@ namespace
                 if (paintEffects.ghost != 0 && paintEffects.ghostAfter >= levelIndex)
                 {
                     command->ghostOn = true;
+                    setFrameDependent(command, true);
                     command->ghostColor = PaintIPNode::Color(0.0, 1.0, 0.0,
                                                              1.0); // Ghosted "After" commands are drawn in red
                     command->ghostColor[3] = getGhostOpacity(frame, command->startFrame, command->duration);
@@ -224,6 +239,12 @@ namespace
         PaintIPNode::LocalCommands currentFrameCommands; // visible commands, excluding hold and ghost
         PerFramePaintCommands beforeCommands;
         PerFramePaintCommands afterCommands;
+
+        // Reset frameDependent up front since LocalCommand objects persist across frames
+        for (auto* command : commands)
+        {
+            setFrameDependent(command, false);
+        }
 
         std::tie(currentFrameCommands, beforeCommands, afterCommands) = separateCommandsByFrameGroup(commands, frame, eye);
 

--- a/src/lib/ip/IPCore/IPCore/ImageRenderer.h
+++ b/src/lib/ip/IPCore/IPCore/ImageRenderer.h
@@ -930,6 +930,7 @@ namespace IPCore
         FastPath findFastPath(const FrameBuffer*) const;
         std::string imageToFBOIdentifier(const IPImage* image) const;
         bool imageHasEraseCommands(const IPImage* image) const;
+        bool imageHasFrameDependentCommands(const IPImage* image) const;
 
         void createGLContexts();
 

--- a/src/lib/ip/IPCore/IPCore/PaintCommand.h
+++ b/src/lib/ip/IPCore/IPCore/PaintCommand.h
@@ -144,6 +144,8 @@ namespace IPCore
             unsigned int version;
             Color color;
 
+            bool frameDependent{false};
+
             virtual void execute(CommandContext& context) const = 0;
             virtual void hash(std::ostream& ostream) const = 0;
             [[nodiscard]] virtual size_t getType() const = 0;

--- a/src/lib/ip/IPCore/ImageFBO.cpp
+++ b/src/lib/ip/IPCore/ImageFBO.cpp
@@ -162,7 +162,10 @@ namespace IPCore
             size_t loc = imageFBO->identifier.find("paintCmdNo");
             if (loc != string::npos)
             {
-                if (strncmp(imageFBO->identifier.c_str(), identifier.c_str(), loc) == 0)
+                // Note that we must also compare cache key length in order for them to be equal,
+                // since some cache keys may have "frameN" if they are frame dependent and we don't
+                // want to match on keys that are identical aside from the frameN suffix.
+                if (loc == identifier.find("paintCmdNo") && strncmp(imageFBO->identifier.c_str(), identifier.c_str(), loc) == 0)
                 {
                     // this means we found a fbo containing the IPImage and a
                     // number of commands (could be zero) we need to find out

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -4819,6 +4819,16 @@ namespace IPCore
         return hasErase;
     }
 
+    bool ImageRenderer::imageHasFrameDependentCommands(const IPImage* root) const
+    {
+        for (size_t i = 0; i < root->commands.size(); ++i)
+        {
+            if (root->commands[i]->frameDependent)
+                return true;
+        }
+        return false;
+    }
+
     void ImageRenderer::renderPaint(const IPImage* root, const GLFBO* fbo, int frame)
     {
         //
@@ -4895,18 +4905,20 @@ namespace IPCore
             // a recompute of the renderID which is a unique identifier
             // associated with the render.
 
-            // If we have erase commands that allow us to see underlying sources, we must consider the
-            // frame number in the cache key. If we do not and we composite a frame-invariant source
-            // (gap, colour source, etc) on top of source media, we will generate the same cache key across
-            // all frames. Thus if we are holding frames, we will re-use first held frame from the cache
-            // across all frames in the held sequence, rendering only the erased strokes on top of a static
-            // cached image.
-            const bool hasEraseCommands = imageHasEraseCommands(root);
+            // If we have erase commands that allow us to see underlying sources, or commands whose
+            // effective rendering varies by frame (e.g. Hold & Ghost, which keep reusing the same
+            // command objects across many frames), we must consider the frame number in the cache
+            // key. If we do not and we composite a frame-invariant source (gap, colour source, etc)
+            // on top of source media, we will generate the same cache key across all frames. Thus if
+            // we are holding or ghosting frames, we will re-use the first cached frame across all
+            // frames in the sequence, rendering on top of a static cached backdrop instead of the
+            // current frame's actual composited image.
+            const bool needsFrameInCacheKey = imageHasFrameDependentCommands(root) || imageHasEraseCommands(root);
 
             ostringstream newRenderID;
             newRenderID << root->renderIDWithPartialPaint(true /*force_recompute*/) << " " << m_filter << " " << m_bgpattern << " "
                         << fbo->width() << "x" << fbo->height();
-            if (hasEraseCommands)
+            if (needsFrameInCacheKey)
                 newRenderID << " frame" << frame;
             newRenderID << " paintCmdNo" << curCmdNum - 1;
 

--- a/src/lib/ip/IPCore/PaintCommand.cpp
+++ b/src/lib/ip/IPCore/PaintCommand.cpp
@@ -1515,9 +1515,9 @@ namespace IPCore
                 }
                 // Update the cache AFTER command execution
                 // We cache up to the second-to-last command in the batch (not the very last, which might still be dragging)
-                // count is the number of commands rendered so far (1-indexed after increment)
-                // Cache after rendering the second-to-last command: count == curCmdNum - 1
-                bool shouldCache = context.updateCache && context.cachedfbo && (curCmdNum > 1) && (count == curCmdNum - 1);
+                // count is 0-indexed at this point (incremented by the for-loop after this body runs), so it equals the
+                // index of the command just executed. The second-to-last index is curCmdNum - 2.
+                bool shouldCache = context.updateCache && context.cachedfbo && (curCmdNum > 1) && (count == curCmdNum - 2);
 
                 if (shouldCache)
                 {


### PR DESCRIPTION
### More stale paint command cache fixes

### Summarize your change.

I previously fixed a stale cache bug with eraser strokes in https://github.com/AcademySoftwareFoundation/OpenRV/pull/1329. However, a similar problem exists more generally as well. 

Even if we do not have erase strokes and we are using hold and/or ghost we still need to make the cache frame-dependent in order to work when composited over a frame-invariant source, since if we are using the same frame invariant FBO and the same geometry, we still may need to be able to see whatever is being composited underneath that frame-invariant source (if it has alpha, is a gap, etc).

Thus, in order to fix this in all cases, I added a flag we can set to a PaintCommand when hold and/or ghost are set.  When the flag is true, we do the same thing we did for the previous fix -- append the frame number to the cache key.

Note that I did not revert the previous fix in favour of this one, since erase strokes could still technically have a duration > 1 and we would then have the same bug without hold or ghost, so I kept them complimentary.

There was also an off-by-one bug in PaintCommand that I thought was the initial cause of this, but it was not. It's still a fix worth doing, so I kept it. The real source of my problem was that when comparing cache keys we were only comparing up to length of the source string( so xyz would match xyzFrameN for example).  

### Describe the reason for the change.

The Review app in FPT constructs a topology where all the annotations are on a dedicated gap track above the media, which exposes this particular bug. This fix will make RV composite that topology correctly.

### Describe what you have tested and on which operating system.

Mac OS 26.5.1