### PR TITLE
fix: SG-43961 text size in otio_reader

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -82,21 +82,6 @@ def _transform_otio_to_world_coordinate(point):
     return (world_coordinate_x, world_coordinate_y, world_coordinate_width)
 
 
-def _get_source_image_height() -> float:
-    """Return the pixel height of the first media source. Falls back to 1080."""
-    try:
-        media_switch = commands.nodeConnections("MediaTrack")[0][0]
-        media_source_group = commands.nodeConnections(media_switch)[0][0]
-        first_source_node = extra_commands.nodesInGroupOfType(media_source_group, "RVFileSource")[0]
-        media_info = commands.sourceMediaInfo(first_source_node)
-        h = float(media_info.get("height", 0))
-        if h > 1:
-            return h
-    except Exception:
-        pass
-    return 1080.0
-
-
 def _transform_pos(x, y):
     """Transform a 2D OTIO position to RV WCS. Returns (wcs_x, wcs_y) or None."""
     result = _transform_otio_to_world_coordinate(otio.schemadef.Point.Point(x=x, y=y, width=0.0))
@@ -205,14 +190,10 @@ def _create_text_shape(layer, paint_node, stroke_id, frame, source_node=None):
         return
 
     # font_size in OTIO is in OTIO-space units (same coordinate space as
-    # border_width). Convert to RVPaint logical pixels: OTIO → WCS via
-    # _transform_scalar, then WCS → pixels by multiplying by image height.
-    # Use the media track's source for height — the annotation source group
-    # is a blank node whose sourceMediaInfo returns height=1, not the real
-    # image dimensions.
-    image_h = _get_source_image_height()
+    # border_width). RVPaint's fontSize is a WCS fraction (image-height-
+    # normalised) — the renderer multiplies by framebuffer height at draw
+    # time (see PaintCommand.cpp) — so no pixel conversion happens here.
     font_size_wcs = _transform_scalar(float(layer.font_size))
-    font_size_rv = font_size_wcs * image_h
 
     # RVPaint .position is the BOTTOM of the text quad (y-up). The OTIO anchor
     # is the typographic baseline. Descent ≈ 0.2 × em, so the bottom of the
@@ -229,7 +210,7 @@ def _create_text_shape(layer, paint_node, stroke_id, frame, source_node=None):
             "textDecoration": [layer.text_decoration],
             "textAlign": [layer.text_align],
             "position": list(anchor_pos),
-            "fontSize": [font_size_rv],
+            "fontSize": [font_size_wcs],
             "color": [float(c) for c in layer.inner_color],
             "startFrame": frame,
             "duration": 1,

--- a/src/plugins/rv-packages/otio_reader/text_schema.py
+++ b/src/plugins/rv-packages/otio_reader/text_schema.py
@@ -17,8 +17,9 @@ use a top-left origin (e.g. RVPaint) must offset upward by one em (font_size).
 font_size is in OTIO normalised coordinate units (same space as border_width
 and all other scalar dimensions). For standard 16:9 content the OTIO y-range
 is 9 units, so small ≈ 0.15, medium ≈ 0.25, large ≈ 0.5.
-To get RVPaint's logical fontSize: divide by bounds_size to reach WCS, then
-multiply by image_height_pixels.
+RVPaint's fontSize is a WCS fraction, exactly like border_width: divide by
+bounds_size to reach WCS and store that directly — no pixel conversion.
+The renderer multiplies by framebuffer height at draw time (PaintCommand.cpp).
 
 All coordinates are in normalised image space (see position_schema.py).
 


### PR DESCRIPTION
### Fix test sizing in OTIO reader

### Summarize your change.

After https://github.com/AcademySoftwareFoundation/OpenRV/pull/1334 I need to make the same changes as were made there to the text scaling.  Text sizing is now simply a normalized value, so just input it directly from the OTIO Annotations as such.

### Describe the reason for the change.

Fix image scaling in OTIO import.

### Describe what you have tested and on which operating system.

Mac OS 26.5.1
