### PR TITLE
fix: SG-43970 loading pre-qt font sizes, line wrapping, backwards comp

### DIFF
--- a/src/bin/imgtools/rvio/main.cpp
+++ b/src/bin/imgtools/rvio/main.cpp
@@ -88,6 +88,8 @@
 #include <gl/glew.h>
 #include <QtGui/QtGui>
 #include <QtWidgets/QApplication>
+#else
+#include <QtGui/QGuiApplication>
 #endif
 
 #include <QtCore/QtCore>
@@ -998,13 +1000,27 @@ int utf8Main(int argc, char* argv[])
     pthread_win32_process_attach_np();
 #endif
 
+#ifndef PLATFORM_WINDOWS
+    //
+    // Paint/text annotation rendering (PaintCommand.cpp) uses Qt's font
+    // stack (QFont, QFontDatabase, QPainter), which requires a
+    // QGuiApplication rather than a QCoreApplication. rvio has no UI, so
+    // force the offscreen QPA platform plugin unless the caller already
+    // requested a specific one, avoiding any dependency on a real display.
+    //
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
+    {
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    }
+#endif
+
 #ifdef PLATFORM_DARWIN
-    QCoreApplication qapp(argc, argv);
+    QGuiApplication qapp(argc, argv);
     TwkApp::DarwinBundle bundle("RV", MAJOR_VERSION, MINOR_VERSION, REVISION_NUMBER);
 #endif
 
 #ifdef PLATFORM_LINUX
-    QCoreApplication qapp(argc, argv);
+    QGuiApplication qapp(argc, argv);
     TwkApp::QTBundle bundle("rv", MAJOR_VERSION, MINOR_VERSION, REVISION_NUMBER);
 #endif
 

--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -452,12 +452,18 @@ namespace IPCore
         p.duration = readProp<IntProperty>(c, "duration", 0);
 
         p.fontFamily = readProp<StringProperty>(c, "fontFamily", string(""));
-        // Legacy (pre-QFont) sessions have no fontSize property, fontSize is a WCS
-        // fraction of image height, the old size prop was a point value normalized
-        // for a 1080p image
+        // Legacy (pre-QFont) sessions have no fontSize property. fontSize is a WCS
+        // fraction of image height (see PaintCommand::Text::execute), whereas the
+        // old FTGL renderer drew glyphs sized by ptsize (computed above) directly
+        // in font-design units, then placed them via modelviewMatrix*S*T where
+        // S = makeScale(p.scale). Composing S*T shows a font-space vertex of
+        // magnitude g lands at a WCS-space offset of g * p.scale -- the same WCS
+        // space fontSize/border_width live in -- so ptsize * p.scale is exactly
+        // the legacy visual height already expressed as a WCS fraction. (p.scale
+        // itself already folds in the raw "scale" property's /800 legacy divisor,
+        // set just above.)
         const FloatProperty* fontSizeProp = c->property<FloatProperty>("fontSize");
-        p.fontSize = (fontSizeProp && fontSizeProp->size()) ? fontSizeProp->front()
-                                                            : (p.ptsize / 1080.0f) * readProp<FloatProperty>(c, "scale", 1.0f);
+        p.fontSize = (fontSizeProp && fontSizeProp->size()) ? fontSizeProp->front() : p.ptsize * p.scale;
         p.fontWeight = readProp<StringProperty>(c, "fontWeight", string("normal"));
         p.fontStyle = readProp<StringProperty>(c, "fontStyle", string("normal"));
         p.textDecoration = readProp<StringProperty>(c, "textDecoration", string("none"));

--- a/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
+++ b/src/lib/ip/IPBaseNodes/PaintIPNode.cpp
@@ -452,7 +452,12 @@ namespace IPCore
         p.duration = readProp<IntProperty>(c, "duration", 0);
 
         p.fontFamily = readProp<StringProperty>(c, "fontFamily", string(""));
-        p.fontSize = readProp<FloatProperty>(c, "fontSize", 24.0f);
+        // Legacy (pre-QFont) sessions have no fontSize property, fontSize is a WCS
+        // fraction of image height, the old size prop was a point value normalized
+        // for a 1080p image
+        const FloatProperty* fontSizeProp = c->property<FloatProperty>("fontSize");
+        p.fontSize = (fontSizeProp && fontSizeProp->size()) ? fontSizeProp->front()
+                                                            : (p.ptsize / 1080.0f) * readProp<FloatProperty>(c, "scale", 1.0f);
         p.fontWeight = readProp<StringProperty>(c, "fontWeight", string("normal"));
         p.fontStyle = readProp<StringProperty>(c, "fontStyle", string("normal"));
         p.textDecoration = readProp<StringProperty>(c, "textDecoration", string("none"));

--- a/src/lib/ip/IPCore/PaintCommand.cpp
+++ b/src/lib/ip/IPCore/PaintCommand.cpp
@@ -982,14 +982,14 @@ namespace IPCore
                 const float tw = (fbH > 0) ? imgW / fbH : 0.001f;
                 const float th = (fbH > 0) ? imgH / fbH : 0.001f;
 
-                // pos anchors the bottom of the FIRST line, not the bottom of the
-                // whole (possibly multi-line) block. qyTop only depends on the
-                // single-line image height, so it stays fixed as more lines are
+                // pos anchors the BASELINE of the first line (top of the image is
+                // one ascent above pos), not the bottom of the whole (possibly
+                // multi-line) block. Anchoring on ascent() rather than the full
+                // line-spacing box also means qyTop stays fixed as more lines are
                 // appended -- already-typed lines hold their position and new
                 // lines extend the block downward, instead of the whole block
                 // (and every existing line) sliding upward off pos as it grows.
-                const int imgHOneLine = static_cast<int>(std::ceil(fm.lineSpacing())) + 4;
-                const float qyTop = pos.y + ((fbH > 0) ? imgHOneLine / fbH : 0.001f);
+                const float qyTop = pos.y + ((fbH > 0) ? static_cast<float>(fm.ascent()) / fbH : 0.001f);
                 const float qy = qyTop - th;
 
                 // Vertices: (x,y, u,v) quads — position + texcoord

--- a/src/lib/ip/IPCore/PaintCommand.cpp
+++ b/src/lib/ip/IPCore/PaintCommand.cpp
@@ -979,16 +979,25 @@ namespace IPCore
                 // zoom, matching the behaviour of pen strokes and shapes.
                 //
                 const float qx = pos.x;
-                const float qy = pos.y;
                 const float tw = (fbH > 0) ? imgW / fbH : 0.001f;
                 const float th = (fbH > 0) ? imgH / fbH : 0.001f;
 
+                // pos anchors the bottom of the FIRST line, not the bottom of the
+                // whole (possibly multi-line) block. qyTop only depends on the
+                // single-line image height, so it stays fixed as more lines are
+                // appended -- already-typed lines hold their position and new
+                // lines extend the block downward, instead of the whole block
+                // (and every existing line) sliding upward off pos as it grows.
+                const int imgHOneLine = static_cast<int>(std::ceil(fm.lineSpacing())) + 4;
+                const float qyTop = pos.y + ((fbH > 0) ? imgHOneLine / fbH : 0.001f);
+                const float qy = qyTop - th;
+
                 // Vertices: (x,y, u,v) quads — position + texcoord
                 float data[] = {
-                    qx,      qy,      0.0f, 1.0f, // BL
-                    qx + tw, qy,      1.0f, 1.0f, // BR
-                    qx + tw, qy + th, 1.0f, 0.0f, // TR
-                    qx,      qy + th, 0.0f, 0.0f, // TL
+                    qx,      qy,    0.0f, 1.0f, // BL
+                    qx + tw, qy,    1.0f, 1.0f, // BR
+                    qx + tw, qyTop, 1.0f, 0.0f, // TR
+                    qx,      qyTop, 0.0f, 0.0f, // TL
                 };
 
                 // Texture is Format_ARGB32_Premultiplied so use premul blend:

--- a/src/lib/ip/IPCore/PaintCommand.cpp
+++ b/src/lib/ip/IPCore/PaintCommand.cpp
@@ -876,7 +876,8 @@ namespace IPCore
                 // the WCS fraction for the quad. The projection matrix scales
                 // the quad with zoom — text behaves identically to strokes:
                 // a fixed WCS size that grows on screen as you zoom in.
-                const float renderFontSize = std::max(1.0f, effectiveFontSize * fbH);
+                // Clamp against corrupt  session data to avoid loading a value too large
+                const float renderFontSize = std::min(2000.0f, std::max(1.0f, effectiveFontSize * fbH));
 
                 // ── Build QFont ───────────────────────────────────────────────
                 QFont qfont;

--- a/src/plugins/rv-packages/annotate/annotate_mode.mu
+++ b/src/plugins/rv-packages/annotate/annotate_mode.mu
@@ -713,9 +713,20 @@ class: AnnotateMinorMode : MinorMode
         newProperty(modeName, IntType, 1);
         setIntProperty(modeName, int[] {mode}, true);
 
+        // The legacy "size" property is consumed by pre-QFont RV builds as
+        // ptsize = size * 10000 font-design-units, placed via a modelview scale
+        // of (scale / 800) -- so the resulting on-screen WCS height old RV
+        // produces is size * 10000 * (scale / 800) = size * scale * 12.5 (see
+        // PaintIPNode::compileTextComponent's fontSize fallback for the matching
+        // forward conversion). We want that to equal this text's actual fontSize
+        // (size * scale, set below), so back-convert with legacySize = size /
+        // 12.5. This is purely for forward compatibility with older RV versions;
+        // current RV only reads the fontSize property below.
+        let legacySize = size / 12.5;
+
         setFloatProperty(posName, float[] {pos.x, pos.y}, true);
         setFloatProperty(colorName, float[] {color[0], color[1], color[2], color[3]}, true);
-        setFloatProperty(sizeName, float[] {size}, true);
+        setFloatProperty(sizeName, float[] {legacySize}, true);
         setFloatProperty(scaleName, float[] {scale}, true);
         setFloatProperty(rotName, float[] {rot}, true);
         setFloatProperty(spacingName, float[] {0.8}, true);

--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -195,11 +195,6 @@ def _create_text_shape(layer, paint_node, stroke_id, frame, source_node=None):
     # time (see PaintCommand.cpp) — so no pixel conversion happens here.
     font_size_wcs = _transform_scalar(float(layer.font_size))
 
-    # RVPaint .position is the BOTTOM of the text quad (y-up). The OTIO anchor
-    # is the typographic baseline. Descent ≈ 0.2 × em, so the bottom of the
-    # quad is ~0.2 × em below the baseline → shift position DOWN by 0.2 × em.
-    anchor_pos = (anchor_pos[0], anchor_pos[1] - font_size_wcs * 0.2)
-
     effectHook.add_rv_effect_props(
         shape_component,
         {


### PR DESCRIPTION
### Fix loading pre-QT font sizes

### Summarize your change.

pre-QT fonts were size was in points (based on a 1080p source size). If we load a session file containing the old value, convert it to the new normalized value (fraction of image height), so we can load older sessions.

If you tried to load the old default value of 24, it will try to load something 24x the size of the image, and hang for a long time, so I added a reasonable max clamp in the renderer as a safety measure to avoid that.

I also made sure that multi-line text (user hits shift-enter) scales down.

### Describe the reason for the change.

Backwards compatibility with FTGL font renderer

### Describe what you have tested and on which operating system.

Mac OS 26.5.1
