### PR TITLE
fix: SG-43880: Optimize session manager inputs reordering with previews

### DIFF
--- a/src/plugins/rv-packages/session_manager/session_manager.mu.in
+++ b/src/plugins/rv-packages/session_manager/session_manager.mu.in
@@ -621,10 +621,13 @@ class: ThumbnailWidget : QLabel
 
     method: setFallback (void; QPixmap pixmap) { setPixmap(pixmap); }
 
-    method: load (void; string path)
+    method: load (void; QImage thumbnailImage)
     {
-        let pixmap = QPixmap.fromImage(QImage(path, ""), Qt.AutoColor);
-        if (!pixmap.isNull()) setPixmap(pixmap);
+        let pixmap = QPixmap.fromImage(thumbnailImage, Qt.AutoColor);
+        if (!pixmap.isNull())
+        {
+            setPixmap(pixmap);
+        }
     }
 }
 
@@ -660,9 +663,8 @@ class: FilmstripWidget : QLabel
 
     method: isLoaded (bool;) { _loaded; }
 
-    method: load (void; string path)
+    method: load (void; QImage filmstripImage)
     {
-        let filmstripImage = QImage(path, "");
         if (!filmstripImage.isNull())
         {
             _strip  = filmstripImage;
@@ -698,9 +700,9 @@ class: SourcePreviewWidget : QWidget
         _filmstrip.hide();
     }
 
-    method: setFallback (void; QPixmap pixmap) { _thumbnail.setFallback(pixmap); }
-    method: loadStrip   (void; string path) { _filmstrip.load(path); }
-    method: loadThumbnail (void; string path) { _thumbnail.load(path); }
+    method: setFallback   (void; QPixmap pixmap) { _thumbnail.setFallback(pixmap); }
+    method: loadStrip     (void; QImage filmstripImage) { _filmstrip.load(filmstripImage); }
+    method: loadThumbnail (void; QImage thumbnailImage) { _thumbnail.load(thumbnailImage); }
 
     method: event (bool; QEvent event)
     {
@@ -1104,6 +1106,7 @@ class: SessionManagerMode : MinorMode
     QIcon              _channelIcon;
     QIcon              _videoIcon;
     QIcon              _fallbackSourceIcon;
+    (string, QImage)[]  _previewsCache;
     bool               _inputOrderLock;
     bool               _disableUpdates;
     bool               _previewsEnabled;
@@ -1813,6 +1816,37 @@ class: SessionManagerMode : MinorMode
         item;
     }
 
+    method: cachedPreview (QImage; string pathToCache)
+    {
+        for_each (preview; _previewsCache)
+        {
+            let (previewPath, previewImage) = (preview._0, preview._1);
+
+            if (previewPath == pathToCache)
+            {
+                return previewImage;
+            }
+        }
+
+        let imageToCache = QImage(pathToCache, nil);
+        _previewsCache.push_back((pathToCache, imageToCache));
+
+        return imageToCache;
+    }
+
+    method: dropPreviewFromCache (void; string pathToDrop)
+    {
+        for (int i = 0; i < _previewsCache.size(); i++)
+        {
+            let previewPath = _previewsCache[i]._0;
+            if (previewPath == pathToDrop)
+            {
+                _previewsCache.erase(i, 1);
+                return;
+            }
+        }
+    }
+
     method: makeSourceRowWidget (QWidget; string node)
     {
         string sourceNode = nil;
@@ -1843,11 +1877,15 @@ class: SessionManagerMode : MinorMode
             let thumbnailPath = sendInternalEvent("session-manager-get-thumbnail-path", sourceNode);
             if (thumbnailPath != "" && io.path.exists(thumbnailPath))
             {
-                preview.loadThumbnail(thumbnailPath);
+                let thumbnailImage = cachedPreview(thumbnailPath);
+                preview.loadThumbnail(thumbnailImage);
 
                 let filmstripPath = sendInternalEvent("session-manager-get-filmstrip-path", sourceNode);
                 if (filmstripPath != "" && io.path.exists(filmstripPath))
-                    preview.loadStrip(filmstripPath);
+                {
+                    let filmstripImage = cachedPreview(filmstripPath);
+                    preview.loadStrip(filmstripImage);
+                }
             }
 
             let mediaPropertyPath = sourceNode + ".media.movie";
@@ -2196,6 +2234,12 @@ class: SessionManagerMode : MinorMode
             if (_srcNodeKeys[i] == sourceNode) { node = _grpNodeValues[i]; break; }
         }
         if (node eq nil) return;
+        
+        let thumbnailPath = sendInternalEvent("session-manager-get-thumbnail-path", sourceNode);
+        dropPreviewFromCache(thumbnailPath);
+
+        let filmstripPath = sendInternalEvent("session-manager-get-filmstrip-path", sourceNode);
+        dropPreviewFromCache(filmstripPath);
 
         let item = itemOfNode(_viewModel, node);
         if (item neq nil)
@@ -3276,6 +3320,8 @@ class: SessionManagerMode : MinorMode
         _layerIcon = auxIcon("layer.png", true);
         _unknownTypeIcon = auxIcon("new_48x48.png", true);
         _fallbackSourceIcon = QIcon(auxFilePath("fallback_thumbnail.png"));
+
+        _previewsCache = (string, QImage)[]();
 
         _addButton.setDefaultAction(addAction);
         _deleteButton.setDefaultAction(deleteAction);


### PR DESCRIPTION
### fix: [SG-43880](https://autodesk.atlassian.net/browse/SG-43880): Optimize session manager inputs reordering with previews 

### Summarize your change.

Add a cache for the previews to avoid loading from disk each thumbnail and filmstrip in `makeSourceRowWidget`. When the image stored at a specific path is updated, the cache will drop the preview for it, and the new image will be added to the cache on the next call to `makeSourceRowWidget`.

### Describe the reason for the change.

Reordering and erasing sources from the inputs list with `Show Source Preview` enabled would take exponentially more time  the more sources there were. If the option was disabled, it would take less than 1 second no matter the number of sources loaded. The user experience while reordering or erasing sources shouldn't be affected by previews being enabled in the session manager.

### Describe what you have tested and on which operating system.

Reordering and erasing sources from the inputs list with `Show Source Preview` enabled was tested on macOS.