### PR TITLE
fix: SG-44076: Fix session file thumbnail generation

### DIFF
--- a/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
+++ b/src/plugins/rv-packages/session_manager/local_thumbnail_gen.py
@@ -109,8 +109,13 @@ class LocalThumbnailGen(rvtypes.MinorMode):
             ),
             (
                 "before-clear-session",
-                self._on_clear_session,
+                self._on_before_clear_session,
                 "Cancel in-flight generation and evict cache when the session is cleared",
+            ),
+            (
+                "after-clear-session",
+                self._on_after_clear_session,
+                "Re-enable thumbnail generation once the session has been cleared",
             ),
             (
                 "before-source-delete",
@@ -617,7 +622,7 @@ class LocalThumbnailGen(rvtypes.MinorMode):
                     _resume_proc(proc)
         self._drain_one()
 
-    def _on_clear_session(self, event: Any) -> None:
+    def _on_before_clear_session(self, event: Any) -> None:
         """Cancel in-flight generation and evict all caches when the session is cleared."""
         event.reject()
         self._shutting_down = True
@@ -637,6 +642,10 @@ class LocalThumbnailGen(rvtypes.MinorMode):
                 proc.wait()
             except OSError:
                 logger.warning(f"Failed to kill process {proc}")
+
+    def _on_after_clear_session(self, event: Any) -> None:
+        event.reject()
+        self._shutting_down = False
 
     def _on_session_deletion(self, event: Any) -> None:
         event.reject()


### PR DESCRIPTION
### fix: [SG-44076](https://autodesk.atlassian.net/browse/SG-44076): Fix session file thumbnail generation

### Summarize your change.

When an RV session file is loaded, the whole session is cleared, triggering a `before-clear-session` event. However, in `local_thumbnail_gen.py`, the listener on that event is setting `self._shutting_down` to True to prevent thumbnails and filmstrips generation when clearing a session. However, nothing was listening to `after-clear-session` in order to set back `self._shutting_down` to False, preventing the generation of previews after that point for RV session files. It was working for movie clips because this would trigger a `before-progressive-loading` event, and the handler of this event would set back `self._shutting_down` to False.

### Describe the reason for the change.

Thumbnails and filmstrips of sources in the Session Manager panel were not being generated with `Show Source Preview` enabled when loading an RV session file.

### Describe what you have tested and on which operating system.

Loading an RV session file with `Show Source Preview` enabled in the Session Manager was tested on macOS.