### PR TITLE
fix: SG-44089 add soft_deleted to shape schemas

### DIFF
--- a/src/plugins/rv-packages/otio_reader/annotation_hook.py
+++ b/src/plugins/rv-packages/otio_reader/annotation_hook.py
@@ -121,6 +121,8 @@ def _create_bbox_shape(layer, paint_node, stroke_id, frame, shape_type):
     corner_radius = getattr(layer, "corner_radius", None)
     wcs_corner_radius = float(corner_radius) if corner_radius is not None else 0.0
 
+    is_deleted = layer.visible is False or bool(layer.soft_deleted)
+
     effectHook.add_rv_effect_props(
         shape_component,
         {
@@ -133,12 +135,12 @@ def _create_bbox_shape(layer, paint_node, stroke_id, frame, shape_type):
             "startFrame": frame,
             "duration": 1,
             "eye": 2,
-            "softDeleted": layer.visible is False,
+            "softDeleted": is_deleted,
             "uuid": [layer.id],
         },
     )
 
-    if layer.visible is not False:
+    if not is_deleted:
         _add_shape_to_frame_order(paint_node, stroke_id, frame, prefix)
 
 
@@ -156,6 +158,8 @@ def _create_point_pair_shape(layer, paint_node, stroke_id, frame, shape_type):
     raw_bw = float(layer.width if shape_type.startswith("Line.") else layer.border_width)
     wcs_border_width = _transform_scalar(raw_bw)
 
+    is_deleted = layer.visible is False or bool(layer.soft_deleted)
+
     props = {
         "startPos": list(start_pos),
         "endPos": list(end_pos),
@@ -164,7 +168,7 @@ def _create_point_pair_shape(layer, paint_node, stroke_id, frame, shape_type):
         "startFrame": frame,
         "duration": 1,
         "eye": 2,
-        "softDeleted": layer.visible is False,
+        "softDeleted": is_deleted,
         "uuid": [layer.id],
     }
 
@@ -175,7 +179,7 @@ def _create_point_pair_shape(layer, paint_node, stroke_id, frame, shape_type):
 
     effectHook.add_rv_effect_props(shape_component, props)
 
-    if layer.visible is not False:
+    if not is_deleted:
         _add_shape_to_frame_order(paint_node, stroke_id, frame, prefix)
 
 
@@ -195,6 +199,8 @@ def _create_text_shape(layer, paint_node, stroke_id, frame, source_node=None):
     # time (see PaintCommand.cpp) — so no pixel conversion happens here.
     font_size_wcs = _transform_scalar(float(layer.font_size))
 
+    is_deleted = layer.visible is False or bool(layer.soft_deleted)
+
     # Wire/OTIO values are upper-case ("BOLD", "ITALIC", "UNDERLINE"); RVPaint's
     # properties and PaintCommand.cpp's comparisons are lower-case ("bold", ...).
     effectHook.add_rv_effect_props(
@@ -211,12 +217,12 @@ def _create_text_shape(layer, paint_node, stroke_id, frame, source_node=None):
             "color": [float(c) for c in layer.inner_color],
             "startFrame": frame,
             "duration": 1,
-            "softDeleted": layer.visible is False,
+            "softDeleted": is_deleted,
             "uuid": [layer.id],
         },
     )
 
-    if layer.visible is not False:
+    if not is_deleted:
         _add_shape_to_frame_order(paint_node, stroke_id, frame, "text")
 
 

--- a/src/plugins/rv-packages/otio_reader/arrow_schema.py
+++ b/src/plugins/rv-packages/otio_reader/arrow_schema.py
@@ -45,6 +45,7 @@ class Arrow(otio.core.SerializableObject):
         border_width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
+        soft_deleted: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()
@@ -56,6 +57,7 @@ class Arrow(otio.core.SerializableObject):
         self.border_width = border_width
         self.id = id
         self.visible = visible
+        self.soft_deleted = soft_deleted
         self.layer_range = layer_range
 
     start_position = otio.core.serializable_field("start_position", doc="Tail of the arrow (Position.1)")
@@ -91,6 +93,9 @@ class Arrow(otio.core.SerializableObject):
     )
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")
+    soft_deleted = otio.core.serializable_field(
+        "soft_deleted", required_type=bool, doc="Undo/redo soft-delete flag, consistent with Paint.2"
+    )
 
     _layer_range = otio.core.serializable_field(
         "layer_range",

--- a/src/plugins/rv-packages/otio_reader/ellipse_schema.py
+++ b/src/plugins/rv-packages/otio_reader/ellipse_schema.py
@@ -43,6 +43,7 @@ class Ellipse(otio.core.SerializableObject):
         border_width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
+        soft_deleted: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()
@@ -53,6 +54,7 @@ class Ellipse(otio.core.SerializableObject):
         self.border_width = border_width
         self.id = id
         self.visible = visible
+        self.soft_deleted = soft_deleted
         self.layer_range = layer_range
 
     min = otio.core.serializable_field("min", doc="Top-left corner of bounding box (Position.1)")
@@ -83,6 +85,9 @@ class Ellipse(otio.core.SerializableObject):
     )
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")
+    soft_deleted = otio.core.serializable_field(
+        "soft_deleted", required_type=bool, doc="Undo/redo soft-delete flag, consistent with Paint.2"
+    )
 
     _layer_range = otio.core.serializable_field(
         "layer_range",

--- a/src/plugins/rv-packages/otio_reader/line_schema.py
+++ b/src/plugins/rv-packages/otio_reader/line_schema.py
@@ -41,6 +41,7 @@ class Line(otio.core.SerializableObject):
         width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
+        soft_deleted: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()
@@ -50,6 +51,7 @@ class Line(otio.core.SerializableObject):
         self.width = width
         self.id = id
         self.visible = visible
+        self.soft_deleted = soft_deleted
         self.layer_range = layer_range
 
     start_position = otio.core.serializable_field("start_position", doc="Start point (Position.1)")
@@ -68,6 +70,9 @@ class Line(otio.core.SerializableObject):
     width = otio.core.serializable_field("width", required_type=float, doc="Line width in normalised units")
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")
+    soft_deleted = otio.core.serializable_field(
+        "soft_deleted", required_type=bool, doc="Undo/redo soft-delete flag, consistent with Paint.2"
+    )
 
     _layer_range = otio.core.serializable_field(
         "layer_range",

--- a/src/plugins/rv-packages/otio_reader/rectangle_schema.py
+++ b/src/plugins/rv-packages/otio_reader/rectangle_schema.py
@@ -46,6 +46,7 @@ class Rectangle(otio.core.SerializableObject):
         corner_radius: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
+        soft_deleted: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()
@@ -57,6 +58,7 @@ class Rectangle(otio.core.SerializableObject):
         self.corner_radius = corner_radius
         self.id = id
         self.visible = visible
+        self.soft_deleted = soft_deleted
         self.layer_range = layer_range
 
     # Position.1 objects — required_type omitted to avoid load-order dependency
@@ -91,6 +93,9 @@ class Rectangle(otio.core.SerializableObject):
     )
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")
+    soft_deleted = otio.core.serializable_field(
+        "soft_deleted", required_type=bool, doc="Undo/redo soft-delete flag, consistent with Paint.2"
+    )
 
     _layer_range = otio.core.serializable_field(
         "layer_range",

--- a/src/plugins/rv-packages/otio_reader/text_schema.py
+++ b/src/plugins/rv-packages/otio_reader/text_schema.py
@@ -63,6 +63,7 @@ class Text(otio.core.SerializableObject):
         inner_color: list | None = None,
         id: str | None = None,
         visible: bool | None = None,
+        soft_deleted: bool | None = None,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()
@@ -77,6 +78,7 @@ class Text(otio.core.SerializableObject):
         self.inner_color = inner_color
         self.id = id
         self.visible = visible
+        self.soft_deleted = soft_deleted
         self.layer_range = layer_range
 
     anchor = otio.core.serializable_field("anchor", doc="Baseline start point (Position.1)")
@@ -114,6 +116,9 @@ class Text(otio.core.SerializableObject):
 
     id = otio.core.serializable_field("id", required_type=str, doc="UUID for undo/redo tracking")
     visible = otio.core.serializable_field("visible", required_type=bool, doc="Show/hide")
+    soft_deleted = otio.core.serializable_field(
+        "soft_deleted", required_type=bool, doc="Undo/redo soft-delete flag, consistent with Paint.2"
+    )
 
     _layer_range = otio.core.serializable_field(
         "layer_range",


### PR DESCRIPTION
### Add soft deleted flag to annotation schemas

### Summarize your change.

This branch adds a `soft_deleted` flag to the shape schemas and uses it in the annotation_hook to set visibility.  This will allow us to receive payloads and hide annotations that have been undone.

### Describe the reason for the change.

This fixes setting the initial payload from the Review app in FPT when it contains shape annotations that have been undone.

### Describe what you have tested and on which operating system.

Mac OS 26.5.1.
