### PR TITLE
chore: make soft-deleted an optional boolean

### DIFF
--- a/src/plugins/rv-packages/otio_reader/arrow_schema.py
+++ b/src/plugins/rv-packages/otio_reader/arrow_schema.py
@@ -45,7 +45,7 @@ class Arrow(otio.core.SerializableObject):
         border_width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
-        soft_deleted: bool | None = None,
+        soft_deleted: bool = False,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()

--- a/src/plugins/rv-packages/otio_reader/ellipse_schema.py
+++ b/src/plugins/rv-packages/otio_reader/ellipse_schema.py
@@ -43,7 +43,7 @@ class Ellipse(otio.core.SerializableObject):
         border_width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
-        soft_deleted: bool | None = None,
+        soft_deleted: bool = False,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()

--- a/src/plugins/rv-packages/otio_reader/line_schema.py
+++ b/src/plugins/rv-packages/otio_reader/line_schema.py
@@ -41,7 +41,7 @@ class Line(otio.core.SerializableObject):
         width: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
-        soft_deleted: bool | None = None,
+        soft_deleted: bool = False,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()

--- a/src/plugins/rv-packages/otio_reader/rectangle_schema.py
+++ b/src/plugins/rv-packages/otio_reader/rectangle_schema.py
@@ -46,7 +46,7 @@ class Rectangle(otio.core.SerializableObject):
         corner_radius: float | None = None,
         id: str | None = None,
         visible: bool | None = None,
-        soft_deleted: bool | None = None,
+        soft_deleted: bool = False,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()

--- a/src/plugins/rv-packages/otio_reader/text_schema.py
+++ b/src/plugins/rv-packages/otio_reader/text_schema.py
@@ -63,7 +63,7 @@ class Text(otio.core.SerializableObject):
         inner_color: list | None = None,
         id: str | None = None,
         visible: bool | None = None,
-        soft_deleted: bool | None = None,
+        soft_deleted: bool = False,
         layer_range: otio.opentime.TimeRange | None = None,
     ) -> None:
         super().__init__()


### PR DESCRIPTION
### Make soft_delete a strict boolean

### Summarize your change.

This is a followup to my last change. There's no reason to make soft_deleted null. This makes it an optional boolean instead.

### Describe the reason for the change.

Just a cleaner approach.

### Describe what you have tested and on which operating system.

Mac OS 26.5.1
