### PR TITLE
fix: SG-43908: stale frame-invariant paint cache (#1329)

### DIFF
--- a/src/lib/ip/IPCore/IPCore/ImageRenderer.h
+++ b/src/lib/ip/IPCore/IPCore/ImageRenderer.h
@@ -799,7 +799,7 @@ namespace IPCore
         //
 
         void renderImage(InternalRenderContext&);
-        void renderPaint(const IPImage*, const GLFBO*);
+        void renderPaint(const IPImage*, const GLFBO*, int frame);
 
         void renderExternal(InternalRenderContext&);
         void renderRootBuffer(InternalRenderContext&);

--- a/src/lib/ip/IPCore/ImageRenderer.cpp
+++ b/src/lib/ip/IPCore/ImageRenderer.cpp
@@ -1895,7 +1895,7 @@ namespace IPCore
 
         renderImage(context);
         if (!context.norender)
-            renderPaint(context.image, context.targetFBO);
+            renderPaint(context.image, context.targetFBO, context.frame);
     }
 
     void ImageRenderer::renderAllChildren(InternalRenderContext& context)
@@ -4815,7 +4815,7 @@ namespace IPCore
         return hasErase;
     }
 
-    void ImageRenderer::renderPaint(const IPImage* root, const GLFBO* fbo)
+    void ImageRenderer::renderPaint(const IPImage* root, const GLFBO* fbo, int frame)
     {
         //
         // if this image has overlay commands, such as matts, these commands
@@ -4891,9 +4891,20 @@ namespace IPCore
             // a recompute of the renderID which is a unique identifier
             // associated with the render.
 
+            // If we have erase commands that allow us to see underlying sources, we must consider the
+            // frame number in the cache key. If we do not and we composite a frame-invariant source
+            // (gap, colour source, etc) on top of source media, we will generate the same cache key across
+            // all frames. Thus if we are holding frames, we will re-use first held frame from the cache
+            // across all frames in the held sequence, rendering only the erased strokes on top of a static
+            // cached image.
+            const bool hasEraseCommands = imageHasEraseCommands(root);
+
             ostringstream newRenderID;
             newRenderID << root->renderIDWithPartialPaint(true /*force_recompute*/) << " " << m_filter << " " << m_bgpattern << " "
-                        << fbo->width() << "x" << fbo->height() << " paintCmdNo" << curCmdNum - 1;
+                        << fbo->width() << "x" << fbo->height();
+            if (hasEraseCommands)
+                newRenderID << " frame" << frame;
+            newRenderID << " paintCmdNo" << curCmdNum - 1;
 
             cachedFBO =
                 m_imageFBOManager.findExistingPaintFBO(fbo, newRenderID.str(), foundCachedFBO, lastCmdNum, m_fullRenderSerialNumber);


### PR DESCRIPTION
### Fix frame-invariant paint cache with erase brushes

### Summarize your change.

This fixes an issue in the paint cache where we would use stale paint caches with erased frames.

In a regular annotation with a held sequence, only the geometry matters, it's perfectly fine to reapply the same geometry over all frames in the range. However, once we have erased strokes which reveal what is underneath the image, the annotation becomes unique to that specific frame since part of the underlying image has effectively been burned into it.

This was effectively only ever visible when using a frame-invariant source in the composition however, since the FBO id is used in the cache key, and that is only ever reused across a frame-invariant source.

Thus the simplest fix is to simply include the frame number in the cache key when we have erased stokes, so that we can re-evaluate the underlying image for each frame regardless of what is in the composition.

### Describe the reason for the change.

This fix an issue in the context of live review which has a dedicated annotation track over a gap composited over top of another track containing the media.

### Describe what you have tested and on which operating system.

Mac OS 26.5.1

<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.