### PR TITLE
docs: SG-43650: Update Rocky Linux build instructions

### DIFF
--- a/.github/actions/build-linux/action.yml
+++ b/.github/actions/build-linux/action.yml
@@ -55,24 +55,6 @@ runs:
       run: df -h /
       shell: bash
 
-    # Rocky 9.8 dropped mesa-libOSMesa{,-devel} from the CRB repo (Mesa upstream
-    # deprecated OSMesa in favor of llvmpipe via EGL). Pin all subsequent dnf
-    # calls in this container to the 9.7 minor release until OpenRV migrates off
-    # OSMesa. 9.7 is now a superseded minor, so the production CDN no longer
-    # serves it (the default 'extras' repo 404s); point the pinned repos at the
-    # durable vault archive (dl.rockylinux.org/vault) instead. Remove this whole
-    # step once OpenRV no longer needs OSMesa.
-    - name: Pin Rocky 9 to 9.7 minor release (vault)
-      if: ${{ inputs.rocky-version == '9' }}
-      run: |
-        echo "9.7" > /etc/dnf/vars/releasever
-        sed -i \
-          -e 's|^mirrorlist=|#mirrorlist=|g' \
-          -e 's|^#\?baseurl=https\?://dl.rockylinux.org/\$contentdir/|baseurl=https://dl.rockylinux.org/vault/rocky/|g' \
-          /etc/yum.repos.d/[Rr]ocky*.repo
-        dnf clean all
-      shell: bash
-
     - name: Install system dependencies
       run: |
         retry_count=0
@@ -84,9 +66,14 @@ runs:
           if dnf install -y epel-release && \
              dnf config-manager --set-enabled ${{ inputs.extra_repo }} devel && \
              dnf groupinstall "Development Tools" -y && \
-             dnf install -y alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex gcc gcc-c++ git libXcomposite libXi-devel libaio-devel libffi-devel nasm ncurses-devel nss libtool libxkbcommon libXcomposite libXdamage libXrandr libXtst libXcursor mesa-libOSMesa mesa-libOSMesa-devel meson openssl-devel patch pulseaudio-libs pulseaudio-libs-glib2 ocl-icd ocl-icd-devel opencl-headers qt5-qtbase-devel readline-devel sqlite-devel systemd-devel tcl-devel tcsh tk-devel yasm zip zlib-devel wget patchelf pcsc-lite libxkbfile perl-IPC-Cmd perl-Time-Piece && \
+             dnf install -y alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex gcc gcc-c++ git libXcomposite libXi-devel libaio-devel libffi-devel nasm ncurses-devel nss libtool libxkbcommon libXcomposite libXdamage libXrandr libXtst libXcursor meson openssl-devel patch pulseaudio-libs pulseaudio-libs-glib2 ocl-icd ocl-icd-devel opencl-headers qt5-qtbase-devel readline-devel sqlite-devel systemd-devel tcl-devel tcsh tk-devel yasm zip zlib-devel wget patchelf pcsc-lite libxkbfile perl-IPC-Cmd perl-Time-Piece && \
              dnf install -y libX11-devel libXext-devel libXrender-devel libXrandr-devel libXcursor-devel libXi-devel libXxf86vm-devel libxkbcommon-devel && \
              dnf install -y xz-devel mesa-libGLU mesa-libGLU-devel && \
+             if [ "${{ inputs.rocky-version }}" = "9" ]; then \
+               dnf install -y mesa-compat-libOSMesa mesa-compat-libOSMesa-devel; \
+             else \
+               dnf install -y mesa-libOSMesa mesa-libOSMesa-devel; \
+             fi && \
              dnf clean all; then
             echo "Dependencies installed successfully"
             break

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -97,34 +97,27 @@ jobs:
         run: |
           df -h /
 
-      # Rocky 9.8 dropped mesa-libOSMesa{,-devel} from the CRB repo. Pin all
-      # subsequent dnf calls in this container to the 9.7 minor release until
-      # OpenRV migrates off OSMesa. Remove this step once that's done.
-      - name: Pin Rocky 9 to 9.7 minor release (vault)
-        if: ${{ matrix.rocky-version == '9' }}
-        run: |
-          echo "9.7" > /etc/dnf/vars/releasever
-          sed -i \
-            -e 's|^mirrorlist=|#mirrorlist=|g' \
-            -e 's|^#\?baseurl=https\?://dl.rockylinux.org/\$contentdir/|baseurl=https://dl.rockylinux.org/vault/rocky/|g' \
-            /etc/yum.repos.d/[Rr]ocky*.repo
-          dnf clean all
-
       - name: Install system dependencies
         run: |
           dnf install -y epel-release
           dnf config-manager --set-enabled ${{ matrix.extra_repo }} devel
           dnf install -y which findutils
           dnf groupinstall "Development Tools" -y
-          dnf install -y alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex gcc gcc-c++ git libXcomposite libXi-devel libaio-devel libffi-devel nasm ncurses-devel nss libtool libxkbcommon libXcomposite libXdamage libXrandr libXtst libXcursor mesa-libOSMesa mesa-libOSMesa-devel meson openssl-devel patch pulseaudio-libs pulseaudio-libs-glib2 ocl-icd ocl-icd-devel opencl-headers qt5-qtbase-devel readline-devel sqlite-devel systemd-devel tcl-devel tcsh tk-devel yasm zip zlib-devel wget patchelf pcsc-lite libxkbfile perl-IPC-Cmd perl-Digest-SHA
+          dnf install -y alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel bison bzip2-devel cmake-gui curl-devel flex gcc gcc-c++ git libXcomposite libXi-devel libaio-devel libffi-devel nasm ncurses-devel nss libtool libxkbcommon libXcomposite libXdamage libXrandr libXtst libXcursor meson openssl-devel patch pulseaudio-libs pulseaudio-libs-glib2 ocl-icd ocl-icd-devel opencl-headers qt5-qtbase-devel readline-devel sqlite-devel systemd-devel tcl-devel tcsh tk-devel yasm zip zlib-devel wget patchelf pcsc-lite libxkbfile perl-IPC-Cmd perl-Digest-SHA
           dnf install -y libX11-devel libXext-devel libXrender-devel libXrandr-devel libXcursor-devel libXi-devel libXxf86vm-devel libxkbcommon-devel
           dnf install -y xz-devel mesa-libGLU mesa-libGLU-devel
+          if [ "${{ matrix.rocky-version }}" = "9" ]; then \
+            dnf install -y mesa-compat-libOSMesa mesa-compat-libOSMesa-devel; \
+          else \
+            dnf install -y mesa-libOSMesa mesa-libOSMesa-devel; \
+          fi && \
           dnf clean all
 
       - name: Install other system dependencies
         if: ${{ matrix.rocky-version == '9' }}
         run: |
           dnf install -y perl-CPAN
+
           cpan FindBin
 
       - name: Install GCC 11 toolchain for Rocky Linux 8

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
     python: "3.8"
     

--- a/dockerfiles/Dockerfile.Linux-Rocky9-CY2023
+++ b/dockerfiles/Dockerfile.Linux-Rocky9-CY2023
@@ -63,8 +63,8 @@ RUN dnf groupinstall "Development Tools" -y \
     libxkbfile \
     mesa-libGLU \
     mesa-libGLU-devel \
-    mesa-libOSMesa \
-    mesa-libOSMesa-devel \
+    mesa-compat-libOSMesa \
+    mesa-compat-libOSMesa-devel \
     meson \
     nasm \
     ncurses-devel \

--- a/dockerfiles/Dockerfile.Linux-Rocky9-CY2024
+++ b/dockerfiles/Dockerfile.Linux-Rocky9-CY2024
@@ -63,8 +63,8 @@ RUN dnf groupinstall "Development Tools" -y \
     libxkbfile \
     mesa-libGLU \
     mesa-libGLU-devel \
-    mesa-libOSMesa \
-    mesa-libOSMesa-devel \
+    mesa-compat-libOSMesa \
+    mesa-compat-libOSMesa-devel \
     meson \
     nasm \
     ncurses-devel \
@@ -92,6 +92,8 @@ RUN dnf groupinstall "Development Tools" -y \
     yasm \
     zip \
     zlib-devel \
+    rust \
+    cargo \
     && dnf clean all
 
 # Disable the devel repo afterwards since dnf will warn about it

--- a/docs/build_system/config_linux_rocky89.md
+++ b/docs/build_system/config_linux_rocky89.md
@@ -116,6 +116,15 @@ sudo dnf install -y libX11-devel libXext-devel libXrender-devel libXrandr-devel 
 sudo dnf install -y xz-devel mesa-libGLU mesa-libGLU-devel
 ```
 
+````{tabs}
+```{code-tab} bash Rocky 8
+sudo dnf install -y mesa-libOSMesa mesa-libOSMesa-devel
+```
+```{code-tab} bash Rocky 9
+sudo dnf install -y mesa-compat-libOSMesa mesa-compat-libOSMesa-devel
+```
+````
+
 ```bash
 sudo dnf clean all
 ```


### PR DESCRIPTION
### docs: [SG-43650](https://autodesk.atlassian.net/browse/SG-43650): Update Rocky Linux build instructions

### Linked issues
Fixes #1287

### Summarize your change.

`config_linux_rocky89.md`, `Dockerfile.Linux-Rocky9-CY2023`, `Dockerfile.Linux-Rocky9-CY2024`, `conan.yml` and `action.yml` were all updated to reflect the deprecation of `mesa-libOSMesa` and `mesa-libOSMesa-devel` as of Rocky Linux 9.8. Note that `.readthedocs.yaml` was also updated to build the documentation with `ubuntu-lts-latest`instead of `ubuntu-20.04` since the latter was removed on 2026-06-01.

### Describe the reason for the change.

With the release of Rocky Linux 9.8, the CRB dropped the support for `mesa-libOSMesa` and `mesa-libOSMesa-devel`. However, the compatibility packages are still available under `mesa-compat-libOSMesa` and `mesa-compat-libOSMesa-devel`. 

### Describe what you have tested and on which operating system.

- [X] Rendering the documentation with the package name update for Rocky Linux 8 and 9
- [X] Building Docker containers with all three Dockerfiles. For Rocky Linux 9, both 9.7 and 9.8 were tested with the new package names.
- [X]  Running the CI pipelines with action.yml and conan.yml

### If possible, provide screenshots.

The updated documentation can be viewed here: https://readthedocs-openrv.readthedocs.io/en/update-rocky-build-instructions/build_system/config_linux_rocky89.html#install-other-dependencies

Rocky 8:
<img width="553" height="681" alt="Rocky8" src="https://github.com/user-attachments/assets/3fb93b15-de3c-45bb-a389-399cb12601c8" />

Rocky 9:
<img width="553" height="681" alt="Rocky9" src="https://github.com/user-attachments/assets/e5238066-41e7-4d74-abdc-b65955dade84" />

