### PR TITLE
fix: remove automatic Mu debugging on crash handler init

### DIFF
--- a/docs/crash-reporting.md
+++ b/docs/crash-reporting.md
@@ -239,12 +239,12 @@ violates. This list is a remediation tracker, not part of the permanent design.
       entry points (values are set correctly at init via `StartHandler`).
 - [x] **C1 — three diverging init paths** for `rv` / `RV` / `rvio` (violated C4). Fixed: all three
       now call one shared helper, `TwkApp::initializeCrashHandler(appName, version, executableDir)`
-      (`src/lib/app/MuTwkApp/CrashHandlerInit.{h,cpp}`), which resolves the handler, initializes, and
-      enables Mu debugging. The per-`main.cpp` `#ifdef` path blocks are gone.
-- [x] **C2 — `rvio` used the bare `crashpad_handler`** (violated C5) and never called
-      `setDebugging(true)`. Fixed by C1's shared helper: every binary now uses the platform wrapper
-      (`crashpad_handler_{macos,linux}.sh` / `.exe`) and enables Mu debugging. The leftover
-      `rvio` `addAnnotation("platform", …)` dead write (B3) was removed in the same change.
+      (`src/lib/app/MuTwkApp/CrashHandlerInit.{h,cpp}`), which resolves the handler and initializes
+      it. The per-`main.cpp` `#ifdef` path blocks are gone. (Automatic Mu debugging was later
+      removed — the `mu_function` annotation carries the script context without it.)
+- [x] **C2 — `rvio` used the bare `crashpad_handler`** (violated C5). Fixed by C1's shared helper:
+      every binary now uses the platform wrapper (`crashpad_handler_{macos,linux}.sh` / `.exe`). The
+      leftover `rvio` `addAnnotation("platform", …)` dead write (B3) was removed in the same change.
 - [x] **D1 — Crashpad wrapper install guarded on `RV_DEPS_BREAKPAD_VERSION`** in
       `src/bin/nsapps/RV/CMakeLists.txt` (violated C6). Fixed: split by tool ownership — the Crashpad
       wrapper is now guarded on `RV_DEPS_CRASHPAD_VERSION`, `symbolicate_crash.sh` on the Breakpad var.

--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-nine.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-nine.md
@@ -319,8 +319,6 @@ similarly, if you want to force a mode not to be loaded:
 
 Normally, RV will compile Mu files to conserve space in memory. Unfortunately, that means loosing a lot of information like source locations when exceptions are thrown. You can tell RV to allow debugging information by adding -debug mu to the end of the RV command line. This will consume more memory but report source file information when displaying a stack trace.
 
-**Note:** When crash dumps are enabled (via `RV_CRASH_DUMPS_ENABLED` environment variable), RV automatically enables Mu debugging to ensure crash dumps contain useful Mu script source location information.
-
 #### 9.5.4 The Mu API Documentation Browser
 
 The Mu modules are documented dynamically by the documentation browser. This is available under RV's help menu “Mu API Documentation Browser”.

--- a/src/lib/app/MuTwkApp/CrashHandlerInit.cpp
+++ b/src/lib/app/MuTwkApp/CrashHandlerInit.cpp
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <MuTwkApp/CrashHandlerInit.h>
-#include <MuTwkApp/MuInterface.h>
 #include <TwkUtil/CrashHandler.h>
-#include <iostream>
 #include <sstream>
 
 namespace TwkApp
@@ -32,16 +30,7 @@ namespace TwkApp
 #endif
         const std::string handlerPath = executableDir + "/" + handlerName;
 
-        const bool initialized = TwkUtil::CrashHandler::instance().initialize(appName, appVersion, handlerPath);
-
-        if (initialized)
-        {
-            // Enable Mu debugging so crash dumps include script source context.
-            setDebugging(true);
-            std::cout << "INFO: Automatically enabled -debug mu for crash dumps" << std::endl;
-        }
-
-        return initialized;
+        return TwkUtil::CrashHandler::instance().initialize(appName, appVersion, handlerPath);
     }
 
 } // namespace TwkApp

--- a/src/lib/app/MuTwkApp/MuTwkApp/CrashHandlerInit.h
+++ b/src/lib/app/MuTwkApp/MuTwkApp/CrashHandlerInit.h
@@ -15,13 +15,12 @@ namespace TwkApp
     //
     //  Single shared crash-reporting init path for every RV executable (rv, the
     //  macOS RV bundle app, rvio, ...). Resolves the platform-specific crashpad
-    //  handler *wrapper* sitting next to the executable, initializes the crash
-    //  handler, and - on success - enables Mu debugging so dumps carry script
-    //  source context.
+    //  handler *wrapper* sitting next to the executable and initializes the
+    //  crash handler.
     //
     //  Per-executable copies of this sequence are how the entry points drifted
-    //  apart (bare handler vs wrapper, missing setDebugging); all binaries MUST
-    //  call this instead. See docs/crash-reporting.md (contracts C4/C5).
+    //  apart (bare handler vs wrapper); all binaries MUST call this instead.
+    //  See docs/crash-reporting.md (contracts C4/C5).
     //
     //  The handler path is resolved as executableDir + "/" + the fixed wrapper
     //  name for the platform:

--- a/src/lib/base/TwkUtil/CrashHandler.cpp
+++ b/src/lib/base/TwkUtil/CrashHandler.cpp
@@ -26,10 +26,6 @@ namespace TwkUtil
 
     // Environment variables for crash handler configuration
     //
-    // NOTE: When RV_CRASH_DUMPS_ENABLED is set, RV automatically enables Mu debugging
-    // (equivalent to -debug mu flag) to include Mu script source file information in
-    // crash dumps. This helps identify which Mu script caused a crash.
-    //
     ENVVAR_BOOL(evCrashDumpsEnabled, "RV_CRASH_DUMPS_ENABLED", true);
     ENVVAR_STRING(evCrashDumpsDir, "RV_CRASH_DUMPS_DIR", "");
     ENVVAR_INT(evCrashDumpsMaxCount, "RV_CRASH_DUMPS_MAX_COUNT", 10);


### PR DESCRIPTION
### fix: remove automatic Mu debugging on crash handler init

### Linked issues
NA

### Summarize your change.

Enabling Mu debugging (-debug mu) on crash handler initialization is unnecessary: the mu_function annotation already surfaces the script context in the symbolicated crash report's Crashpad Annotations. Remove the setDebugging(true) call and update documentation accordingly.


Note: Without the Mu debugging, the symbolicated crash report still shows the correct mu function name at the time of the crash. 

Example where I had simulated a crash in the annotate_mode.AnnotateMinorMode.newShape function:
The function name is still visible after removing the Mu debugging:

```
========================================
Crashpad Annotations
========================================

gpu_renderer: Apple M1 Pro
gpu_vendor: Apple
mu_function: annotate_mode.AnnotateMinorMode.newShape

```

### Describe the reason for the change.

With Mu debugging enabled by defauly, errors were reported in the console when accessing the OCIO menu options.

### Describe what you have tested and on which operating system.

Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.