### PR TITLE
fix: strip DWARF from staged Release Linux binaries

### DIFF
--- a/cmake/macros/rv_stage.cmake
+++ b/cmake/macros/rv_stage.cmake
@@ -78,6 +78,28 @@ FUNCTION(rv_stage)
   )
   IF(arg_TYPE IN_LIST _rv_stage_binary_types)
     RV_GENERATE_SYMBOLS(TARGET ${arg_TARGET})
+
+    # Release builds compile with -g so dump_syms can extract Breakpad .sym files (see docs/crash-reporting.md section 7). On Linux the shipped artifact is the
+    # stage tree itself, so leaving the DWARF in the staged ELF would ship full debug info to customers. Strip it here -- AFTER RV_GENERATE_SYMBOLS has run
+    # dump_syms on the real ELF, and BEFORE the .bin rename below -- so the shipped binaries carry no DWARF while the symbols live only in the symbols_archive
+    # zip. --strip-debug keeps .symtab and, crucially, the GNU build-id that the .sym directory tree is keyed on, so offline symbolication still matches. This
+    # is gated on Release + Linux only (not on the Breakpad version, per contract C6): macOS Mach-O binaries do not embed DWARF (it stays in the dSYM, which
+    # rv_generate_symbols.cmake produces then deletes), so they are not bloated and need no strip.
+    #
+    # strip_debug_safe.sh (not a bare `strip`) guards against a GNU strip bug that corrupts binaries whose layout triggers the "'.dynstr' not in segment"
+    # warning: it strips to a temp copy and only replaces the original when strip is warning- and error-free, otherwise it leaves the binary unstripped. RV's
+    # own compiled targets strip cleanly; the guard protects any that do not.
+    IF(RV_TARGET_LINUX
+       AND CMAKE_BUILD_TYPE STREQUAL "Release"
+    )
+      ADD_CUSTOM_COMMAND(
+        TARGET ${arg_TARGET}
+        POST_BUILD
+        COMMENT "Stripping DWARF debug info from ${arg_TARGET} (symbols archived separately)"
+        COMMAND bash ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../scripts/strip_debug_safe.sh "$<TARGET_FILE:${arg_TARGET}>"
+        VERBATIM
+      )
+    ENDIF()
   ENDIF()
 
   IF(RV_TARGET_LINUX)

--- a/cmake/scripts/strip_debug_safe.sh
+++ b/cmake/scripts/strip_debug_safe.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright (C) 2026  Autodesk, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Safely strip DWARF debug info from an ELF binary.
+#
+# GNU strip has a known bug: for binaries whose layout makes it emit
+#   "allocated section `.dynstr' not in segment"
+# (observed on Google Crashpad's crashpad_handler and some Qt tools such as
+# lupdate), it rewrites the program headers incorrectly and produces an
+# UNLOADABLE binary (the loader fails with exit 127 / "Connection reset by
+# peer" for crashpad_handler). strip can still exit 0 while emitting that
+# warning, so a plain in-place `strip` silently corrupts the shipped binary.
+#
+# This wrapper strips to a temporary copy and only replaces the original when
+# strip completed with NO warnings/errors on stderr and a zero exit code.
+# Otherwise the original binary is left untouched (it keeps its debug info, but
+# it stays loadable). Such binaries typically carry little or no DWARF anyway,
+# so the size cost of skipping them is negligible.
+#
+# Usage: ./strip_debug_safe.sh <elf-binary>
+#
+
+TARGET="$1"
+
+if [ -z "${TARGET}" ]; then
+    echo "strip_debug_safe: usage: $0 <elf-binary>" >&2
+    exit 2
+fi
+
+if [ ! -f "${TARGET}" ]; then
+    # Nothing to strip (e.g. target produced no file); do not fail the build.
+    echo "strip_debug_safe: no such file, skipping: ${TARGET}" >&2
+    exit 0
+fi
+
+# Strip to a temp copy in the same directory (same filesystem => atomic mv).
+TMP="$(mktemp "${TARGET}.stripXXXXXX")" || exit 1
+
+# Capture stderr while discarding stdout. The command-substitution exit status
+# is strip's exit code, which the following test consumes.
+if STRIP_ERR="$(strip --strip-debug -o "${TMP}" "${TARGET}" 2>&1 >/dev/null)" && [ -z "${STRIP_ERR}" ]; then
+    # Clean strip: preserve permissions and replace the original atomically.
+    chmod --reference="${TARGET}" "${TMP}" 2>/dev/null || true
+    mv -f "${TMP}" "${TARGET}"
+else
+    rm -f "${TMP}"
+    echo "strip_debug_safe: keeping ${TARGET} unstripped (strip reported: ${STRIP_ERR:-nonzero exit})" >&2
+fi
+
+exit 0

--- a/docs/crash-reporting.md
+++ b/docs/crash-reporting.md
@@ -184,6 +184,15 @@ key: Mu context is function-level (see C2 for why line-level cannot be captured 
    them from Release installs — the macOS/Linux `symbols/` tree and the Windows `.pdb` files. (Debug
    installs keep them for local debugging; the strip is gated on `CMAKE_INSTALL_CONFIG_NAME`.)
    Customers never symbolicate, so shipping symbols only bloats the package.
+
+   In addition, the *staged binaries themselves* must not embed DWARF. Release compiles with `-g`
+   (so `dump_syms` can extract the `.sym` above), but on Linux the shipped artifact is the `stage`
+   tree itself — not a `cmake --install` output — so the install-time strip never runs on it.
+   Therefore `rv_stage.cmake` runs `strip --strip-debug` on each staged Linux binary in Release,
+   *after* `dump_syms` has read the DWARF and *before* the `.bin` rename. This keeps `.symtab` and
+   the GNU build-id (the key for the `symbols/` tree), so the DWARF lives only in the
+   `symbols_archive` zip while the shipped binaries carry none. macOS Mach-O binaries do not embed
+   DWARF (it stays in the dSYM), so no equivalent strip is needed there.
 3. The `symbols_archive` build target (`rv_archive_symbols.cmake`) instead packages a versioned,
    per-platform `RV-<version>-<os>-<arch>-symbols.zip` under `stage/packages/`:
    - macOS/Linux: the Breakpad `symbols/` tree plus the symbolication tools (`minidump_stackwalk`,


### PR DESCRIPTION
### fix: strip DWARF from staged Release Linux binaries

### Linked issues

NA

### Summarize your change.

Release builds compile with -g so dump_syms can extract Breakpad .sym files, but on Linux the shipped artifact is the stage tree itself, so the install-time strip never runs and binaries embedded full DWARF. Strip --strip-debug each staged Linux binary in Release, after dump_syms reads the DWARF and before the .bin rename. This preserves .symtab and the GNU build-id (the symbols/ tree key), so DWARF lives only in the symbols_archive zip while shipped binaries carry none.

GNU strip can silently corrupt binaries whose layout triggers the "'.dynstr' not in segment" warning (e.g. crashpad_handler, some Qt tools): it rewrites the program headers and produces an unloadable binary while still exiting 0. Guard the staged strip with strip_debug_safe.sh, which strips to a temp copy and only replaces the original when strip is warning- and error-free, otherwise leaves the binary unstripped. Such binaries carry little or no DWARF, so the size cost of skipping them is negligible.

### Describe the reason for the change.

After a build on Linux, the resulting RV build was almost twice as large in MB because it contained DWARF debug info

### Describe what you have tested and on which operating system.

Successfully tested on Rocky Linux 9

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.