### PR TITLE
docs: Set VFX platform badge to 2025 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ---
 
 ![Supported Versions](https://img.shields.io/badge/python-3.11-blue)
-[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2024-lightgrey.svg)](http://www.vfxplatform.com/)
+[![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2025-lightgrey.svg)](http://www.vfxplatform.com/)
 [![docs](https://readthedocs.org/projects/aswf-openrv/badge/?version=latest)](https://aswf-openrv.readthedocs.io/en/latest)
 
 ## Overview


### PR DESCRIPTION
### docs: Set VFX platform badge to 2025 in README.md

### Linked issues

NA

### Summarize your change.

Update VFX platform badge from 2024 to 2025 in README.md

### Describe the reason for the change.

The current README.md's VFX platform badge (2024) was not representating the default VFX platform of the main branch (2025)

### Describe what you have tested and on which operating system.

Successfully tested on macOS

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.

Before:
<img width="228" height="140" alt="before" src="https://github.com/user-attachments/assets/34ea5404-fc1d-4a4c-98e7-0e55363e42f9" />

After:
<img width="224" height="139" alt="after" src="https://github.com/user-attachments/assets/82aaf565-4658-451b-a2ee-031de0c44866" />
