### PR TITLE
SG-44518: 1362: feature: Pixel Inspector optionally returns raw pixel values

### DIFF
--- a/src/lib/app/RvApp/CommandsModule.cpp
+++ b/src/lib/app/RvApp/CommandsModule.cpp
@@ -1152,7 +1152,17 @@ namespace Rv
             return p;
         }
 
-        TwkFB::linearRGBA709pixelValue(fb, int(x), int(y), &p[0]);
+        int ignoreChroma = 0;
+        std::vector<TwkContainer::IntProperty*> chromaProps;
+        s->findPropertyOfType<TwkContainer::IntProperty>(chromaProps, "#RVLinearize.color.ignoreChromaticities");
+        if (!chromaProps.empty() && !chromaProps.front()->empty())
+            ignoreChroma = chromaProps.front()->front();
+
+        if (ignoreChroma)
+            TwkFB::linearRGBARawPixelValue(fb, int(x), int(y), &p[0]);
+        else
+            TwkFB::linearRGBA709pixelValue(fb, int(x), int(y), &p[0]);
+
         NODE_RETURN(p);
     }
 

--- a/src/lib/image/TwkFB/Operations.cpp
+++ b/src/lib/image/TwkFB/Operations.cpp
@@ -3481,7 +3481,7 @@ namespace TwkFB
         return nfb;
     }
 
-    void linearRGBA709pixelValue(const FrameBuffer* fb, int x, int y, float* p)
+    void linearRGBARawPixelValue(const FrameBuffer* fb, int x, int y, float* p)
     {
         p[3] = 1.0;
 
@@ -3514,6 +3514,15 @@ namespace TwkFB
         {
             fb->getPixel4f(x, y, p);
         }
+    }
+
+    void linearRGBA709pixelValue(const FrameBuffer* fb, int x, int y, float* p)
+    {
+        // Populate p[] with raw pixel values
+        linearRGBARawPixelValue(fb, x, y, p);
+
+        bool YUVp = fb->isYUVPlanar();
+        bool YRYBYp = fb->isYRYBYPlanar();
 
         float& r = p[0];
         float& g = p[1];

--- a/src/lib/image/TwkFB/TwkFB/Operations.h
+++ b/src/lib/image/TwkFB/TwkFB/Operations.h
@@ -327,6 +327,11 @@ namespace TwkFB
 
     TWKFB_EXPORT void linearRGBA709pixelValue(const FrameBuffer* fb, int x, int y, float* result);
 
+    // get a raw linear pixel value. I don't see the value of converting pixel sampler
+    // values to a Rec.709 gamut.
+
+    TWKFB_EXPORT void linearRGBARawPixelValue(const FrameBuffer* fb, int x, int y, float* result);
+
 } // namespace TwkFB
 
 #endif // __TwkFB__Operations__h__


### PR DESCRIPTION
This change modifies CommandsModule::sourcePixelValue() so that it returns the viewed file's raw pixel values when "Ignore File Primaries" is checked in RV's color menu. The normal behavior is to convert the linear RGB values in the file to a Rec709 gamut if the color primaries of the input file pixels are known. 

This is particularly useful when viewing ACES EXR media and verifying that a sampled pixel value is the same as when sampled in other applications such as Nuke or OpenImageIO

Three source files are changed:

    • src/lib/image/TwkFB/TwkFB/Operations.h
    • src/lib/image/TwkFB/Operations.cpp
    • src/lib/app/RvApp/CommandsModule.cpp

This has been tested on MacOS Sequoia 15.3.1 using the 2024 VFX platform configuration. 