### PR TITLE
fix: SG-44617: Build imgui with custom RV_DEPS_BASE_DIR

### DIFF
--- a/cmake/dependencies/imgui.cmake
+++ b/cmake/dependencies/imgui.cmake
@@ -50,7 +50,7 @@ EXTERNALPROJECT_ADD(
   GIT_TAG ${RV_DEPS_IMPLOT_TAG}
   DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  SOURCE_DIR ${CMAKE_BINARY_DIR}/${_target}/deps/implot
+  SOURCE_DIR ${_base_dir}/deps/implot
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
@@ -71,7 +71,7 @@ EXTERNALPROJECT_ADD(
   GIT_TAG ${RV_DEPS_IMGUI_BACKEND_QT_TAG}
   DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  SOURCE_DIR ${CMAKE_BINARY_DIR}/${_target}/deps/imgui-backend-qt
+  SOURCE_DIR ${_base_dir}/deps/imgui-backend-qt
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
@@ -87,7 +87,7 @@ EXTERNALPROJECT_ADD(
   GIT_TAG ${RV_DEPS_IMGUI_NODE_EDITOR_TAG}
   DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  SOURCE_DIR ${CMAKE_BINARY_DIR}/${_target}/deps/imgui-node-editor
+  SOURCE_DIR ${_base_dir}/deps/imgui-node-editor
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
@@ -120,12 +120,11 @@ EXTERNALPROJECT_ADD(
   DOWNLOAD_NAME ${_target}_${_version}.zip
   DOWNLOAD_DIR ${RV_DEPS_DOWNLOAD_DIR}
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-  SOURCE_DIR ${CMAKE_BINARY_DIR}/${_target}/src
+  SOURCE_DIR ${_base_dir}/src
   PATCH_COMMAND
-    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/imgui/CMakeLists.txt ${CMAKE_BINARY_DIR}/${_target}/src/CMakeLists.txt && ${CMAKE_COMMAND} -E
-    copy_directory ${CMAKE_BINARY_DIR}/${_target}/deps/implot ${CMAKE_BINARY_DIR}/${_target}/src/implot && ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_BINARY_DIR}/${_target}/deps/imgui-backend-qt/backends ${CMAKE_BINARY_DIR}/${_target}/src/backends && ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_BINARY_DIR}/${_target}/deps/imgui-node-editor ${CMAKE_BINARY_DIR}/${_target}/src/imgui-node-editor && ${_patch_command_for_imgui_backend_qt} &&
+    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/imgui/CMakeLists.txt ${_base_dir}/src/CMakeLists.txt && ${CMAKE_COMMAND} -E copy_directory
+    ${_base_dir}/deps/implot ${_base_dir}/src/implot && ${CMAKE_COMMAND} -E copy_directory ${_base_dir}/deps/imgui-backend-qt/backends ${_base_dir}/src/backends
+    && ${CMAKE_COMMAND} -E copy_directory ${_base_dir}/deps/imgui-node-editor ${_base_dir}/src/imgui-node-editor && ${_patch_command_for_imgui_backend_qt} &&
     ${_patch_command_for_imgui}
   CONFIGURE_COMMAND ${CMAKE_COMMAND} ${_configure_options} -DFIND_QT_VERSION=${_find_qt_version} -DCMAKE_PREFIX_PATH=${_qt_location}/lib/cmake
   BUILD_COMMAND ${_cmake_build_command}


### PR DESCRIPTION
### Linked issues

None

### Summarize your change.

Updated items in `imgui.cmake` to use the items created via the macro `RV_CREATE_STANDARD_DEPS_VARIABLES`.

### Describe the reason for the change.

Building OpenRV with a custom `RV_DEPS_BASE_DIR` set caused the configuration step for `RV_DEPS_IMGUI` to fail with unable to find the source directory.

### Describe what you have tested and on which operating system.

Tested on CY2024 on Rocky Linux 9.7.

### Add a list of changes, and note any that might need special attention during the review.

The configure command used to configure the OpenRV build was:

```shell
/usr/local/bin/cmake \
  --fresh \
  -B /build/openrv/build \
  -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DRV_DEPS_BASE_DIR=/build/openrv/3rdparty \
  -DRV_DEPS_DOWNLOAD_DIR=/build/openrv/downloads \
  -DRV_DEPS_QT_LOCATION=/opt/Qt/6.5.3/gcc_64 \
  -DRV_VFX_PLATFORM=CY2024
```

### If possible, provide screenshots.

N/A