### PR TITLE
fix: SG-44913: Fix QOpenGLWidget import for PySide6

### DIFF
--- a/src/lib/app/py_rvui/rv/qtutils.py
+++ b/src/lib/app/py_rvui/rv/qtutils.py
@@ -16,6 +16,7 @@ except ImportError:
         from PySide6 import QtGui, QtWidgets
         from PySide6.QtGui import *
         from PySide6.QtWidgets import *
+        from PySide6.QtOpenGLWidgets import QOpenGLWidget
         from shiboken6 import wrapInstance
         from shiboken6 import getCppPointer
     except ImportError:


### PR DESCRIPTION
### Summarize your change.

Fixed import for QOpenGLWidget in PySide6.

### Describe the reason for the change.

In PySide6, QOpenGLWidget (used by rv.qtutils.sessionGLView) was moved from PySide6.QtWidgets to PySide6.QtOpenGLWidgets. 

### Describe what you have tested and on which operating system.

Tested with a CY2025 build on Rocky Linux 9.7