### PR TITLE
perf: SG-43585: Performance improvement of pyevaluate and pyexec

### DIFF
--- a/cmake/dependencies/crashpad.cmake
+++ b/cmake/dependencies/crashpad.cmake
@@ -72,6 +72,16 @@ SET(_crashpad_handler
 LIST(APPEND _configure_options "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
 LIST(APPEND _configure_options "-DCRASHPAD_BUILD_TESTS=OFF")
 
+# Pin the MSVC toolset to match the parent build. Without this, cmake auto-selects the newest installed toolset (e.g. 14.44) while the main build uses a pinned
+# version (e.g. 14.40). The mismatch causes LNK2019 for __std_find_end_1 and similar CRT symbols added only in newer toolsets. Only applies to Visual Studio
+# generators; the crashpad build dir must be clean.
+IF(CMAKE_GENERATOR MATCHES "Visual Studio"
+   AND CMAKE_GENERATOR_TOOLSET
+)
+  LIST(APPEND _configure_options "-T")
+  LIST(APPEND _configure_options "${CMAKE_GENERATOR_TOOLSET}")
+ENDIF()
+
 # Disable deprecation warnings on macOS — mini_chromium uses deprecated Security APIs
 IF(RV_TARGET_DARWIN)
   LIST(APPEND _configure_options "-DCMAKE_CXX_FLAGS=-Wno-error=deprecated-declarations -Wno-deprecated-declarations")

--- a/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-four.md
+++ b/docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-four.md
@@ -236,7 +236,9 @@ import rv.qtutils
 # Gets the current RV session windows as a PySide QMainWindow.
 rvSessionWindow = rv.qtutils.sessionWindow()
 
-# Gets the current RV session GL view as a PySide QGLWidget.
+# Gets the current RV session view host as a PySide QWidget. Note: the GL
+# viewport is now a native child window embedded in this host (via
+# createWindowContainer), so this is a plain QWidget, not a QOpenGLWidget.
 rvSessionGLView = rv.qtutils.sessionGLView()
 
 # Gets the current RV session top tool bar as a PySide QToolBar.

--- a/src/bin/apps/rv/CMakeLists.txt
+++ b/src/bin/apps/rv/CMakeLists.txt
@@ -20,9 +20,17 @@ SET(CMAKE_AUTORCC
     ON
 )
 
+SET(_rv_qt_components
+    Core Gui Widgets OpenGL
+)
+IF(RV_TARGET_WINDOWS)
+  # Quick: for QQuickWindow::setGraphicsApi(), which main.cpp uses to put Qt Quick on the same graphics API RV's windows composite with.
+  LIST(APPEND _rv_qt_components Quick)
+ENDIF()
+
 FIND_PACKAGE(
   ${RV_QT_PACKAGE_NAME}
-  COMPONENTS Core Gui Widgets OpenGL
+  COMPONENTS ${_rv_qt_components}
   REQUIRED
 )
 
@@ -76,6 +84,14 @@ IF(NOT RV_TARGET_WINDOWS)
   TARGET_LINK_LIBRARIES(
     ${_target}
     PRIVATE Qt::OpenGL
+  )
+ENDIF()
+
+IF(RV_TARGET_WINDOWS)
+  # QQuickWindow::setGraphicsApi() in main.cpp; Windows only, since Qt Quick already defaults to OpenGL elsewhere.
+  TARGET_LINK_LIBRARIES(
+    ${_target}
+    PRIVATE Qt::Quick
   )
 ENDIF()
 

--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -100,6 +100,11 @@
 #endif
 #include <QtWidgets/QtWidgets>
 #include <QtGui/QtGui>
+#ifdef PLATFORM_WINDOWS
+// For QQuickWindow::setGraphicsApi(); see the call site in utf8Main().
+#include <QtQuick/QQuickWindow>
+#include <QtQuick/QSGRendererInterface>
+#endif
 #include <RvCommon/RvDocument.h>
 
 // TODO_QT: Remove if everything works.
@@ -371,6 +376,44 @@ int utf8Main(int argc, char* argv[])
     // without an explicit, ordering-sensitive setShareContext() call. Must be
     // set before the QApplication is constructed.
     QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
+    // Render Qt Quick through OpenGL, matching the graphics API RV's windows
+    // composite with.
+    //
+    // Qt Quick's RHI backend defaults to Direct3D 11 on Windows. RV's top-level
+    // windows composite with OpenGL (GLView realizes the window up front, before
+    // any render-to-texture widget joins the tree), and a QQuickWidget cannot
+    // obtain a QRhi from a window using a different API. Without this, anything
+    // Quick-based inside an RV window -- most visibly a QWebEngineView, whose
+    // page is rendered by a QQuickWidget -- silently draws nothing and logs "The
+    // top-level window is not using the expected graphics API for composition"
+    // followed by "Attempted to render scene with no rhi".
+    //
+#ifdef PLATFORM_WINDOWS
+    // Put Qt Quick on the same graphics API RV's windows composite with.
+    //
+    // Qt Quick's RHI backend defaults to Direct3D 11 on Windows, while RV's
+    // top-level windows composite with OpenGL. A QQuickWidget cannot obtain a
+    // QRhi from a window using a different API, so anything Quick-based inside
+    // an RV window -- most visibly a QWebEngineView, whose page is rendered by a
+    // QQuickWidget -- draws nothing and logs "The top-level window is not using
+    // the expected graphics API for composition" followed by "Attempted to
+    // render scene with no rhi".
+    //
+    // Windows only: Quick already defaults to OpenGL on Linux. macOS defaults to
+    // Metal and so may need the same treatment, but that is untested here.
+    //
+    // Setting QSG_RHI_BACKEND from this point does not work -- by the time any
+    // code in main() runs, the backend has already been resolved, so only the
+    // environment RV was launched with is honoured. setGraphicsApi() is the
+    // documented way to choose it from the application, and is specified to work
+    // when called before the first QQuickWindow exists. It is skipped when the
+    // environment already chooses a backend, so QSG_RHI_BACKEND still overrides.
+    if (!getenv("QSG_RHI_BACKEND"))
+    {
+        QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+    }
+#endif
 
     TwkUtil::MemPool::initialize();
 

--- a/src/bin/apps/rv/main.cpp
+++ b/src/bin/apps/rv/main.cpp
@@ -353,11 +353,6 @@ int utf8Main(int argc, char* argv[])
 
     TwkFB::ThreadPool::initialize();
 
-    // Qt 5.12.1 specific
-    // Disable Qt Quick hardware rendering because QwebEngineView conflicts with
-    // QGLWidget
-    setEnvVar("QT_QUICK_BACKEND", "software");
-
 #if defined(PLATFORM_LINUX)
     // Work around for Wacom Tablet issue on linux
     // Note: This is a Qt 5.12.4 regression
@@ -368,6 +363,14 @@ int utf8Main(int argc, char* argv[])
     // Prevent crash at startup when multithreaded upload is enabled
     // (RV Preferences/Rendering/Multithread GPU Upload)
     QApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
+
+    // Share GL resources across every QOpenGLContext in the process. This is a
+    // documented QtWebEngine requirement, and it lets RV's auxiliary GL
+    // surfaces -- the second-output ScreenView and the multithreaded-upload
+    // worker device -- share textures/FBOs with the main viewport context
+    // without an explicit, ordering-sensitive setShareContext() call. Must be
+    // set before the QApplication is constructed.
+    QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 
     TwkUtil::MemPool::initialize();
 

--- a/src/bin/nsapps/RV/main.cpp
+++ b/src/bin/nsapps/RV/main.cpp
@@ -284,9 +284,34 @@ int main(int argc, char* argv[])
 
     setPlatformSpecificLocale();
 
-    // Qt 5.12.1 specific
-    // Disable Qt Quick hardware rendering because QwebEngineView conflicts with
-    // QGLWidget
+    //
+    //  Keep Qt Quick on the software backend. Do not remove this on macOS.
+    //
+    //  It was originally added because QWebEngineView conflicted with the
+    //  QGLWidget viewport, and src/bin/apps/rv/main.cpp has since dropped it for
+    //  Windows and Linux -- but on macOS it is now load bearing for a different
+    //  reason. The viewport is a native QOpenGLWindow embedded via
+    //  QWidget::createWindowContainer, which makes it a QObject child of the top
+    //  level window's QWidgetWindow. With the hardware Qt Quick backend, adding a
+    //  QWebEngineView to the widget tree makes Qt destroy and recreate that
+    //  native subtree; the viewport window is deleted with it rather than
+    //  reparented, and QWindowContainer then dereferences the window it just
+    //  lost. RV segfaults inside Qt, before it can react.
+    //
+    //  Reproducible in four lines from any docked panel -- with the software
+    //  backend this survives, with the hardware backend it crashes:
+    //
+    //      w = rv.qtutils.sessionWindow()
+    //      d = QtWidgets.QDockWidget('t', w)
+    //      v = QtWebEngineWidgets.QWebEngineView(d)
+    //      d.setWidget(v); w.addDockWidget(QtCore.Qt.RightDockWidgetArea, d)
+    //      v.setHtml('<b>hi</b>')
+    //
+    //  The cost of keeping it is that web panels composite in software on macOS,
+    //  so macOS gets the cheap-viewport-repaint half of SG-43585 but not the
+    //  hardware web panel half. Removing it needs the viewport to stop being
+    //  owned by the top level window's native subtree, not just a comment change.
+    //
     setenv("QT_QUICK_BACKEND", "software", 0 /* changeFlag : Do not change the existing value */);
 
     // Prevent usage of native sibling widgets on Mac. This attribute can be

--- a/src/lib/app/RvCommon/CMakeLists.txt
+++ b/src/lib/app/RvCommon/CMakeLists.txt
@@ -48,6 +48,7 @@ SET(_sources
     RvApplication.cpp
     DiagnosticsView.cpp
     GLView.cpp
+    GLWindow.cpp
     TwkQTAction.cpp
     MediaDirModel.cpp
     RvNetworkDialog.cpp

--- a/src/lib/app/RvCommon/DesktopVideoDevice.cpp
+++ b/src/lib/app/RvCommon/DesktopVideoDevice.cpp
@@ -157,10 +157,10 @@ namespace Rv
     {
         TWK_GLDEBUG;
 
-        QSurfaceFormat fmt = shareDevice()->widget()->format();
+        QSurfaceFormat fmt = shareDevice()->glSurfaceFormat();
         fmt.setSwapInterval(m_vsync ? 1 : 0);
 
-        ScreenView* vw = new ScreenView(fmt, 0, shareDevice()->widget(), Qt::Window);
+        ScreenView* vw = new ScreenView(fmt, 0, shareDevice()->glShareContext(), Qt::Window);
         setViewWidget(vw);
 
         QTGLVideoDevice* vd = new QTGLVideoDevice(0, "local view", vw);
@@ -747,11 +747,11 @@ namespace Rv
 
     void DesktopVideoDevice::sortVideoFormatsByWidth() { sort(m_videoFormats.begin(), m_videoFormats.end(), widthSort); }
 
-    DesktopVideoDevice::ScreenView::ScreenView(const QSurfaceFormat& fmt, QWidget* parent, QOpenGLWidget* glViewShare,
+    DesktopVideoDevice::ScreenView::ScreenView(const QSurfaceFormat& fmt, QWidget* parent, QOpenGLContext* glShareContext,
                                                Qt::WindowFlags flags)
         : QOpenGLWidget(parent, flags)
     {
-        m_glViewShare = glViewShare;
+        m_glShareContext = glShareContext;
         setFormat(fmt);
 
         // Important: set PartialUpdate, because otherwise
@@ -764,9 +764,9 @@ namespace Rv
     {
         QOpenGLWidget::initializeGL();
 
-        if (m_glViewShare && context() && context()->isValid())
+        if (m_glShareContext && context() && context()->isValid())
         {
-            context()->setShareContext(m_glViewShare->context());
+            context()->setShareContext(m_glShareContext);
         }
     }
 

--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -93,13 +93,54 @@ namespace Rv
         //  before anything else gets the chance to trigger it. Qt would create
         //  it on the first show anyway.
         //
+        //
+        //  Realize the top-level's window now, and watch for Qt replacing it.
+        //
+        //  Creating it here has a cost that is worth stating plainly: before any
+        //  render-to-texture widget is in the tree, the window's composition gets
+        //  pinned to OpenGL. Qt Quick defaults to Direct3D 11 on Windows, so
+        //  every QQuickWidget in the window -- which is what a QWebEngineView's
+        //  page is -- would then fail to get a QRhi and render nothing. RV
+        //  therefore also pins Qt Quick to OpenGL (see main.cpp), which is the
+        //  same pairing the QOpenGLWidget-based viewport produced before this
+        //  branch.
+        //
+        //  It is done up front because the container can only be detached safely
+        //  once a teardown has already happened at a benign point; arming later
+        //  puts the first teardown at the dangerous one, which faults inside
+        //  Qt's focus handling. See parentWindowDestroyed().
+        //
         if (QWidget* topLevel = window())
             topLevel->createWinId();
 
         watchParentWindow();
     }
 
-    GLView::~GLView() { delete m_videoDevice; }
+    GLView::~GLView()
+    {
+        //
+        //  Two things have to be undone before the device goes away, both of
+        //  them consequences of the viewport window outliving the widget tree in
+        //  the detached state (see parentWindowDestroyed()).
+        //
+        //  The window holds a raw back-pointer to the device and would keep
+        //  using it -- GLWindow::event() and paintGL() both dereference it -- so
+        //  clear that first. And while detached the container has no parent
+        //  widget, so it would not be destroyed along with this widget: it would
+        //  survive as a stray top-level owning the viewport window, still
+        //  pointing at a deleted device.
+        //
+        if (m_glWindow)
+            m_glWindow->setVideoDevice(nullptr);
+
+        if (m_container && !m_container->parentWidget())
+        {
+            delete m_container;
+            m_container = nullptr;
+        }
+
+        delete m_videoDevice;
+    }
 
     void GLView::showEvent(QShowEvent* event)
     {
@@ -172,6 +213,21 @@ namespace Rv
         //  without checking it -- and that is null from here until Qt recreates
         //  the window, which it does lazily on the next show. A layout pass runs
         //  before then. A container that is not in the tree is never visited.
+        //
+        //
+        //  Take the container out of the widget tree for the duration as well.
+        //  Qt reaches window containers through QWindowContainer::parentWasMoved()
+        //  on every layout pass and dereferences the top-level's windowHandle()
+        //  without checking it -- and that is null from here until Qt recreates
+        //  the window. A layout pass runs before then, inside this same reparent,
+        //  so a container left in the tree faults there.
+        //
+        //  This is the fragile part of the workaround: reparenting a widget from
+        //  inside Qt's window teardown runs its focus machinery against the
+        //  half-destroyed QWidgetWindow. It is safe here only because the window
+        //  is realized up front (see the constructor), which means the first of
+        //  these teardowns happens at a benign point and later ones find the
+        //  container already detached. See the note in the constructor.
         //
         if (m_container)
         {

--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -20,6 +20,7 @@
 #include <IPCore/Session.h>
 #include <QtWidgets/QVBoxLayout>
 #include <QOpenGLContext>
+#include <QTimer>
 #include <iostream>
 #include <sstream>
 
@@ -31,11 +32,14 @@ namespace Rv
                    int green, int blue, int alpha, bool noResize)
         : QWidget(parent)
         , m_doc(doc)
+        , m_glWindow(nullptr)
         , m_container(0)
         , m_videoDevice(0)
         , m_csize(1024, 576)
         , m_msize(128, 128)
         , m_sharedContext(sharedContext)
+        , m_watchedParentWindow(nullptr)
+        , m_reattachPending(false)
     {
         //
         //  Native GL viewport window (renders + presents on its own surface).
@@ -65,6 +69,13 @@ namespace Rv
         layout->addWidget(m_container);
 
         //
+        //  Last-resort guard: if the viewport window is destroyed anyway (i.e.
+        //  detaching it in parentWindowDestroyed() did not get there first),
+        //  make sure nothing here is left holding it.
+        //
+        connect(m_glWindow, &QObject::destroyed, this, [this]() { m_glWindow = nullptr; });
+
+        //
         //  The device drives the GL surface (the window) for rendering, and
         //  uses the container QWidget for event / coordinate translation
         //  (height-based y-flip, mapToGlobal, mouse grab).
@@ -76,13 +87,170 @@ namespace Rv
 
         setObjectName((m_doc->session()) ? m_doc->session()->name().c_str() : "no session");
         setFocusProxy(m_container);
+
+        //
+        //  Realize the top-level's window now so its destruction can be hooked
+        //  before anything else gets the chance to trigger it. Qt would create
+        //  it on the first show anyway.
+        //
+        if (QWidget* topLevel = window())
+            topLevel->createWinId();
+
+        watchParentWindow();
     }
 
     GLView::~GLView() { delete m_videoDevice; }
 
-    QOpenGLContext* GLView::context() const { return m_glWindow->context(); }
+    void GLView::showEvent(QShowEvent* event)
+    {
+        QWidget::showEvent(event);
 
-    QSurfaceFormat GLView::format() const { return m_glWindow->format(); }
+        //
+        //  The container parents the viewport window to the top-level window
+        //  while being shown, so the parent to watch only becomes known here --
+        //  and one turn of the event loop later, since the container's own show
+        //  is nested inside this one.
+        //
+        watchParentWindow();
+        QTimer::singleShot(0, this, &GLView::watchParentWindow);
+    }
+
+    void GLView::watchParentWindow()
+    {
+        //
+        //  Watch the top-level widget's window rather than the viewport window's
+        //  current parent: it is the object Qt destroys, and it is knowable
+        //  before the container gets around to re-parenting the viewport into
+        //  it. RV shows the document and runs its session initialisation (where
+        //  a plugin can create the QWebEngineView that triggers all this) within
+        //  a single call stack, so there is no turn of the event loop in which a
+        //  deferred hook could be installed.
+        //
+        QWidget* topLevel = window();
+        QWindow* topLevelWindow = topLevel ? topLevel->windowHandle() : nullptr;
+
+        if (topLevelWindow == m_watchedParentWindow)
+            return;
+
+        if (m_watchedParentConnection)
+            disconnect(m_watchedParentConnection);
+
+        m_watchedParentWindow = topLevelWindow;
+
+        if (topLevelWindow)
+            m_watchedParentConnection = connect(topLevelWindow, &QObject::destroyed, this, &GLView::parentWindowDestroyed);
+    }
+
+    void GLView::parentWindowDestroyed()
+    {
+        //
+        //  Emitted at the top of the window's ~QObject, before it deletes its
+        //  children, so detaching here is what saves the viewport from being
+        //  deleted along with it. The window becomes parentless for the moment;
+        //  it is hidden so it cannot flash on screen as a stray top-level, and
+        //  re-attached once the top-level has its new window.
+        //
+        QWindow* destroyedWindow = m_watchedParentWindow;
+        m_watchedParentWindow = nullptr;
+
+        //
+        //  Only the viewport's actual parent matters. Before the container has
+        //  re-parented it, the viewport still belongs to QWindowContainer's
+        //  internal placeholder parent, and pulling it off that would break the
+        //  container's own bookkeeping.
+        //
+        if (m_glWindow && m_glWindow->parent() == destroyedWindow)
+        {
+            m_glWindow->hide();
+            m_glWindow->setParent(nullptr);
+        }
+
+        //
+        //  Take the container out of the widget tree for the duration as well.
+        //  Qt reaches window containers through QWindowContainer::parentWasMoved()
+        //  on every layout pass and dereferences the top-level's windowHandle()
+        //  without checking it -- and that is null from here until Qt recreates
+        //  the window, which it does lazily on the next show. A layout pass runs
+        //  before then. A container that is not in the tree is never visited.
+        //
+        if (m_container)
+        {
+            if (layout())
+                layout()->removeWidget(m_container);
+
+            m_container->hide();
+            m_container->setParent(nullptr);
+        }
+
+        if (m_reattachPending)
+            return;
+
+        m_reattachPending = true;
+        QTimer::singleShot(0, this, &GLView::reattachGLWindow);
+    }
+
+    void GLView::reattachGLWindow()
+    {
+        m_reattachPending = false;
+
+        if (!m_glWindow)
+            return;
+
+        QWidget* topLevel = window();
+        QWindow* topLevelWindow = topLevel ? topLevel->windowHandle() : nullptr;
+
+        if (!topLevelWindow)
+        {
+            //
+            //  Qt recreates the top-level's window lazily (on the next show), so
+            //  keep waiting rather than forcing it here.
+            //
+            m_reattachPending = true;
+            QTimer::singleShot(0, this, &GLView::reattachGLWindow);
+            return;
+        }
+
+        //
+        //  Put the container back first: re-parenting it makes QWindowContainer
+        //  re-adopt the viewport window into the new top-level window itself.
+        //
+        if (m_container)
+        {
+            m_container->setParent(this);
+
+            if (layout())
+                layout()->addWidget(m_container);
+
+            m_container->show();
+            setFocusProxy(m_container);
+        }
+
+        if (m_glWindow->parent() != topLevelWindow)
+            m_glWindow->setParent(topLevelWindow);
+
+        m_glWindow->show();
+
+        watchParentWindow();
+
+        //
+        //  The container drives the viewport's geometry from its own, so nudge a
+        //  layout pass to put the re-attached window back in place.
+        //
+        if (m_container)
+        {
+            m_container->updateGeometry();
+
+            if (layout())
+                layout()->activate();
+        }
+
+        if (m_doc && m_doc->session())
+            m_doc->session()->askForRedraw();
+    }
+
+    QOpenGLContext* GLView::context() const { return m_glWindow ? m_glWindow->context() : nullptr; }
+
+    QSurfaceFormat GLView::format() const { return m_glWindow ? m_glWindow->format() : QSurfaceFormat(); }
 
     void GLView::makeCurrent()
     {
@@ -96,17 +264,31 @@ namespace Rv
 
     bool GLView::isValid() const { return m_glWindow != nullptr; }
 
-    void GLView::absolutePosition(int& x, int& y) const { m_glWindow->absolutePosition(x, y); }
+    void GLView::absolutePosition(int& x, int& y) const
+    {
+        x = 0;
+        y = 0;
 
-    void GLView::stopProcessingEvents() { m_glWindow->stopProcessingEvents(); }
+        if (m_glWindow)
+            m_glWindow->absolutePosition(x, y);
+    }
 
-    bool GLView::firstPaintCompleted() const { return m_glWindow->firstPaintCompleted(); }
+    void GLView::stopProcessingEvents()
+    {
+        if (m_glWindow)
+            m_glWindow->stopProcessingEvents();
+    }
+
+    bool GLView::firstPaintCompleted() const { return m_glWindow && m_glWindow->firstPaintCompleted(); }
 
     QSize GLView::sizeHint() const { return m_csize; }
 
     QSize GLView::minimumSizeHint() const { return m_msize; }
 
-    QImage GLView::readPixels(int x, int y, int w, int h) { return m_glWindow->readPixels(x, y, w, h); }
+    QImage GLView::readPixels(int x, int y, int w, int h)
+    {
+        return m_glWindow ? m_glWindow->readPixels(x, y, w, h) : QImage(0, 0, QImage::Format_RGBA8888);
+    }
 
     float GLView::devicePixelRatio() const { return videoDevice() ? videoDevice()->devicePixelRatio() : 1.0f; }
 

--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -13,189 +13,106 @@
 #endif
 
 #include <RvCommon/GLView.h>
+#include <RvCommon/GLWindow.h>
 #include <RvCommon/QTGLVideoDevice.h>
-#include <TwkGLF/GLFence.h>
-#include <RvCommon/InitGL.h>
 #include <RvCommon/RvDocument.h>
 #include <RvApp/Options.h>
+#include <IPCore/Session.h>
+#include <QtWidgets/QVBoxLayout>
+#include <QOpenGLContext>
 #include <iostream>
-#include <TwkApp/Event.h>
-#include <boost/thread/thread.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition_variable.hpp>
-
-#include <QtWidgets/QMenu>
+#include <sstream>
 
 namespace Rv
 {
-    using namespace boost;
     using namespace std;
-    using namespace TwkApp;
-    using namespace IPCore;
-
-    namespace
-    {
-
-        class SyncBufferThreadData
-        {
-        public:
-            explicit SyncBufferThreadData(const VideoDevice* device)
-                : m_device(device)
-                , m_done(false)
-                , m_doSync(false)
-                , m_running(false)
-                , m_mutex()
-                , m_cond()
-            {
-            }
-
-            void run()
-            {
-                while (!m_done)
-                {
-                    boost::mutex::scoped_lock lock(m_mutex);
-                    m_running = true;
-                    m_doSync = false;
-
-                    m_cond.wait(lock);
-
-                    if (m_device && m_doSync && !m_done)
-                        m_device->syncBuffers();
-
-                    m_doSync = false;
-                }
-            }
-
-            void notify(bool finish = false)
-            {
-                {
-                    boost::mutex::scoped_lock lock(m_mutex);
-                    if (finish)
-                        m_done = true;
-                    else
-                        m_doSync = true;
-                    if (!m_running)
-                        return;
-                }
-
-                m_cond.notify_one();
-            }
-
-            const VideoDevice* device() const { return m_device; }
-
-            void setDevice(const VideoDevice* d) { m_device = d; }
-
-        private:
-            SyncBufferThreadData(SyncBufferThreadData&) {}
-
-            void operator=(SyncBufferThreadData&) {}
-
-        private:
-            bool m_done;
-            bool m_doSync;
-            bool m_running;
-            boost::mutex m_mutex;
-            boost::condition_variable m_cond;
-            const VideoDevice* m_device;
-        };
-
-        class ThreadTrampoline
-        {
-        public:
-            ThreadTrampoline(GLView* view)
-                : m_view(view)
-            {
-            }
-
-            void operator()()
-            {
-                SyncBufferThreadData* closure = reinterpret_cast<SyncBufferThreadData*>(m_view->syncClosure());
-                closure->run();
-            }
-
-        private:
-            GLView* m_view;
-        };
-
-    } // namespace
 
     GLView::GLView(QWidget* parent, QOpenGLContext* sharedContext, RvDocument* doc, bool stereo, bool vsync, bool doubleBuffer, int red,
                    int green, int blue, int alpha, bool noResize)
-        : QOpenGLWidget(parent)
-        , m_sharedContext(sharedContext)
+        : QWidget(parent)
         , m_doc(doc)
-        , m_red(red)
-        , m_green(green)
-        , m_blue(blue)
-        , m_alpha(alpha)
-        , m_lastKey(0)
-        , m_lastKeyType(QEvent::None)
-        , m_userActive(true)
-        , m_renderCount(0)
-        , m_firstPaintCompleted(false)
+        , m_container(0)
+        , m_videoDevice(0)
         , m_csize(1024, 576)
         , m_msize(128, 128)
-        , m_postFirstNonEmptyRender(noResize)
-        , m_stopProcessingEvents(false)
-        , m_syncThreadData(0)
+        , m_sharedContext(sharedContext)
     {
-        setFormat(rvGLFormat(stereo, vsync, doubleBuffer, red, green, blue, alpha));
+        //
+        //  Native GL viewport window (renders + presents on its own surface).
+        //
+        m_glWindow = new GLWindow(sharedContext, doc, stereo, vsync, doubleBuffer, red, green, blue, alpha, noResize);
 
+        //
+        //  Embed the native window in the widget tree. The container is a
+        //  normal QWidget; there is no QOpenGLWidget in the window, so the
+        //  top-level window is not forced onto the OpenGL RHI backend.
+        //
+        m_container = QWidget::createWindowContainer(m_glWindow, this);
+        m_container->setFocusPolicy(Qt::StrongFocus);
+
+        //
+        //  Create the native platform surface up-front. Unlike a QOpenGLWidget
+        //  (which renders offscreen to an FBO), a QOpenGLWindow has no GL
+        //  context until its window surface exists; RV performs GL setup
+        //  (makeCurrent + capability queries) during startup before the window
+        //  is shown, so the surface must exist by then.
+        //
+        m_glWindow->create();
+
+        QVBoxLayout* layout = new QVBoxLayout(this);
+        layout->setContentsMargins(0, 0, 0, 0);
+        layout->setSpacing(0);
+        layout->addWidget(m_container);
+
+        //
+        //  The device drives the GL surface (the window) for rendering, and
+        //  uses the container QWidget for event / coordinate translation
+        //  (height-based y-flip, mapToGlobal, mouse grab).
+        //
         ostringstream str;
         str << UI_APPLICATION_NAME " Main Window" << "/" << m_doc;
-        m_videoDevice = new QTGLVideoDevice(0, str.str(), this);
+        m_videoDevice = new QTGLVideoDevice(0, str.str(), m_glWindow, m_container);
+        m_glWindow->setVideoDevice(m_videoDevice);
 
         setObjectName((m_doc->session()) ? m_doc->session()->name().c_str() : "no session");
-
-        m_activityTimer.start();
-        setMouseTracking(true);
-        setAcceptDrops(true);
-        setFocusPolicy(Qt::StrongFocus);
-
-        m_eventProcessingTimer.setSingleShot(true);
-        connect(&m_eventProcessingTimer, SIGNAL(timeout()), this, SLOT(eventProcessingTimeout()));
+        setFocusProxy(m_container);
     }
 
-    GLView::~GLView()
+    GLView::~GLView() { delete m_videoDevice; }
+
+    QOpenGLContext* GLView::context() const { return m_glWindow->context(); }
+
+    QSurfaceFormat GLView::format() const { return m_glWindow->format(); }
+
+    void GLView::makeCurrent()
     {
-        // delete m_frameBuffer;
-        delete m_videoDevice;
-
-        if (m_syncThreadData)
-        {
-            SyncBufferThreadData* closure = reinterpret_cast<SyncBufferThreadData*>(m_syncThreadData);
-            closure->notify(true);
-            m_swapThread.join();
-
-            delete closure;
-        }
+        // Route through the device, which guards on context validity. Unlike a
+        // QOpenGLWidget (which can render to its FBO before being shown), a
+        // QOpenGLWindow has no GL context until it is created/exposed, so a
+        // direct makeCurrent() here can deref a null context during startup.
+        if (m_videoDevice)
+            m_videoDevice->makeCurrent();
     }
 
-    void GLView::stopProcessingEvents() { m_stopProcessingEvents = true; }
+    bool GLView::isValid() const { return m_glWindow != nullptr; }
+
+    void GLView::absolutePosition(int& x, int& y) const { m_glWindow->absolutePosition(x, y); }
+
+    void GLView::stopProcessingEvents() { m_glWindow->stopProcessingEvents(); }
+
+    bool GLView::firstPaintCompleted() const { return m_glWindow->firstPaintCompleted(); }
 
     QSize GLView::sizeHint() const { return m_csize; }
 
     QSize GLView::minimumSizeHint() const { return m_msize; }
 
-    void GLView::absolutePosition(int& x, int& y) const
-    {
-        x = 0;
-        y = 0;
+    QImage GLView::readPixels(int x, int y, int w, int h) { return m_glWindow->readPixels(x, y, w, h); }
 
-        QPoint p(0, 0);
-        QPoint gp = mapToGlobal(p);
-
-        x = gp.x();
-        y = gp.y();
-    }
+    float GLView::devicePixelRatio() const { return videoDevice() ? videoDevice()->devicePixelRatio() : 1.0f; }
 
     QSurfaceFormat GLView::rvGLFormat(bool stereo, bool vsync, bool doubleBuffer, int red, int green, int blue, int alpha)
     {
-        const Rv::Options& opts = Rv::Options::sharedOptions();
-
         // NOTE_QT6: QGLFormat into QSurfaceFormat
-        // NOTE_QT6: setStencil, setDepth does not exist anymore. Trying to use
-        // setDepthBufferSize and setStencilBufferSize.
         QSurfaceFormat fmt;
         fmt.setDepthBufferSize(24);
         fmt.setSwapBehavior(doubleBuffer ? QSurfaceFormat::DoubleBuffer : QSurfaceFormat::SingleBuffer);
@@ -207,9 +124,6 @@ namespace Rv
         // NOTE_QT: Set to version 2.1 for now.
         fmt.setMajorVersion(2);
         fmt.setMinorVersion(1);
-
-        // fmt.setProfile(QSurfaceFormat::CoreProfile);
-        // fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
 
         //
         //  The default value for these buffer sizes is -1, but it is
@@ -231,604 +145,5 @@ namespace Rv
 
         return fmt;
     }
-
-    void GLView::initializeGL()
-    {
-        //
-        //  At this point the format is known. Can't do this in the constructor
-        //
-
-        // QUESTION_QT6: Should we use isValid from QOpenGLWidget or directly
-        // using from QOpenGLContext? NOTE_QT6: Returns true if the widget and
-        // OpenGL resources, like the context, have been successfully
-        // initialized.
-        //           Note that the return value is always false until the widget
-        //           is shown.
-        // NOTE_QT6: QOpenGLContext: Returns if this context is valid, i.e. has
-        // been successfully created.
-        if (context()->isValid())
-        {
-            initializeGLExtensions();
-            initializeOpenGLFunctions();
-
-            if (m_sharedContext)
-            {
-                context()->setShareContext(m_sharedContext);
-            }
-
-            if (m_doc)
-            {
-                m_doc->initializeSession();
-            }
-
-            // NOTE_QT6: QGLFormat is deprecated. Using QSurfaceFormat now.
-            QSurfaceFormat f = context()->format();
-
-#ifndef PLATFORM_DARWIN
-            //
-            //  Doesn't work on OS X
-            //
-            if (f.redBufferSize() != m_red && m_red != 0)
-            {
-                // QMessageBox box(this);
-                // box.setWindowTitle(tr("Ouput Display Format"));
-
-                ostringstream str;
-
-                str << "WARNING: asked for"
-                    << " " << m_red << " " << m_green << " " << m_blue << " " << m_alpha << " RGBA color but got"
-                    << " " << f.redBufferSize() << " " << f.greenBufferSize() << " " << f.blueBufferSize() << " "
-                    << (f.alphaBufferSize() <= 0 ? 0 : f.alphaBufferSize()) << " RGBA instead";
-
-                cout << str.str() << endl;
-
-                // box.setText(str.str().c_str());
-                // box.setDetailedText("You can change the default display color
-                // depth and target "
-                //                     "from the preferences under
-                //                     Rendering->Display Output Format.\n"
-                //                     "Choosing \"OpenGL Default Format\" will
-                //                     tell RV to ask for the " "default
-                //                     prefered format for this display.");
-                // box.setWindowModality(Qt::WindowModal);
-                // QPushButton* b1 = box.addButton(tr("Continue"),
-                // QMessageBox::AcceptRole); box.setIcon(QMessageBox::Critical);
-                // box.exec();
-            }
-#endif
-            if (f.stencilBufferSize() == 0)
-            {
-                cout << "WARNING: no stencil buffer available" << endl;
-            }
-        }
-        else
-        {
-            cout << "WARNING: invalid GL context" << endl;
-        }
-    }
-
-    void GLView::resizeGL(int w, int h)
-    {
-        if (m_doc)
-            m_doc->viewSizeChanged(w, h);
-#ifdef PLATFORM_WINDOWS
-        SetWindowRgn(reinterpret_cast<HWND>(this->winId()), 0, false);
-#endif
-    }
-
-    bool GLView::validateReadPixels(int x, int y, int w, int h)
-    {
-        int r = x + w;
-        int t = y + h;
-
-        // are the extents of the read region out of bounds?
-        if (x < 0 || y < 0 || r > width() * devicePixelRatio() || t > height() * devicePixelRatio())
-            return false;
-
-        return true;
-    }
-
-    QImage GLView::readPixels(int x, int y, int w, int h)
-    {
-        // If out of bounds, return an empty image.
-        if (validateReadPixels(x, y, w, h) == false)
-        {
-            QImage image(0, 0, QImage::Format_RGBA8888);
-            return image;
-        }
-
-        makeCurrent();
-
-        QImage image(w, h, QImage::Format_RGBA8888);
-        glReadPixels(x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image.bits());
-
-        return image;
-    }
-
-    void GLView::debugSaveFramebuffer()
-    {
-        // Create a QImage with the same size as the FBO
-        QImage image(width(), height(), QImage::Format_RGBA8888);
-        glReadPixels(0, 0, width(), height(), GL_RGBA, GL_UNSIGNED_BYTE, image.bits());
-
-        // image.save("/home/<username>>/<orv_folder>/fbo.png");
-    }
-
-    void GLView::paintGL()
-    {
-        TWK_GLDEBUG;
-
-        IPCore::Session* session = m_doc->session();
-        bool debug = IPCore::debugProfile && session;
-
-        if (!m_postFirstNonEmptyRender && session && session->postFirstNonEmptyRender())
-        {
-            m_postFirstNonEmptyRender = true;
-
-            if (!session->isFullScreen())
-            {
-                m_doc->resizeToFit(false, false);
-                m_doc->center();
-                TWK_GLDEBUG;
-            }
-        }
-
-        if (debug)
-        {
-            Session::ProfilingRecord& trecord = session->beginProfilingSample();
-            trecord.renderStart = session->profilingElapsedTime();
-        }
-
-        // should be no longer necessary, moved it to resize()
-#if 0
-    //
-    //  This is necessary to stop the Windows Desktop Window Manager
-    //  (new in Vista/win7) fromc caching portions of rv's glview
-    //  and holding them in the display even when rv redraws.  the
-    //  effect being that parts of previous displays will be "left
-    //  behind" and not updated even when rv plays.  especially when
-    //  going to/from fullscreen.
-    //
-#ifdef PLATFORM_WINDOWS
-    SetWindowRgn (this->winId(), 0, false);
-#endif
-#endif
-
-        if (m_doc && session && m_videoDevice)
-        {
-            // m_frameBuffer->makeCurrent();
-            TWK_GLDEBUG;
-            m_videoDevice->makeCurrent();
-            TWK_GLDEBUG;
-
-            if (m_userActive && m_activityTimer.elapsed() > 1.0)
-            {
-                if (m_doc->mainPopup() && !m_doc->mainPopup()->isVisible() && hasFocus())
-                {
-                    TwkApp::ActivityChangeEvent aevent("user-inactive", m_videoDevice);
-                    m_videoDevice->sendEvent(aevent);
-                    TWK_GLDEBUG;
-                    m_userActive = false;
-                }
-            }
-
-            //
-            //  Make sure the video device knows where it is on screen.
-            //
-            int x = 0, y = 0;
-            absolutePosition(x, y);
-            m_videoDevice->setAbsolutePosition(x, y);
-
-            TWK_GLDEBUG;
-            session->render();
-            TWK_GLDEBUG;
-
-            m_firstPaintCompleted = true;
-
-            // Starting with Qt 5.12.1, the resulting texture is later
-            // composited over white which creates undesirable artifacts. As a
-            // work around, we set the resulting alpha channel to 1 to make sure
-            // that the resulting texture is fully opaque.
-
-            // NOTE_QT: That code seems to fix an issue on MacOS only. (Not on
-            // Linux, not test on Windows)
-            //          The issue I see on MacOS that the background is brown
-            //          istead of black with the default background.
-            //
-            // Even on Qt6/QOpenGLWidget, we need to call
-            // glBindFramebuffer(); it otherwise complains and fails
-            // on glClear() on macOS
-            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, QOpenGLContext::currentContext()->defaultFramebufferObject());
-            TWK_GLDEBUG;
-
-            glPushAttrib(GL_COLOR_BUFFER_BIT);
-            TWK_GLDEBUG;
-            glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
-            TWK_GLDEBUG;
-            glClearColor(0.f, 0.f, 0.f, 1.0f);
-            TWK_GLDEBUG;
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            TWK_GLDEBUG;
-            glPopAttrib();
-            TWK_GLDEBUG;
-        }
-        else
-        {
-            glClearColor(0.f, 0.f, 0.f, 1.0f);
-            TWK_GLDEBUG;
-            glClear(GL_COLOR_BUFFER_BIT);
-            TWK_GLDEBUG;
-        }
-
-        if (m_stopProcessingEvents)
-            return;
-
-        //
-        //  We're done with drawing and about to (possibly) wait for
-        //  vsync before the buffer swaps, but if the driver is layzy,
-        //  it may not performs some requested gl actions until after
-        //  the wait on vsync, in which case we get tearing.
-        //
-        //  A glFlush here should make these gl actions happen during
-        //  the wait.
-        //
-        //  This could be a problem if further drawing is done to this
-        //  buffer by Qt, for example if it's doing it's graphics area
-        //  widget drawing.  Seems fine for now.
-        //
-        //  Update: We want to actually wait until the gfx operations are
-        //  complete.  glFlush just flushes the command buffer to
-        //  hardware, glFinish blocks until the hardware is finished
-        //  processing the commands.
-        //
-
-        // DONT
-        // glFlush();
-        // glFinish();
-
-        //
-        //  Do the swap, the vsync code is in the swapBuffers() code in
-        //  Qt. It should block here waiting for the refresh. The debug
-        //  code here is accumulating profiling information in the session
-        //  ProfilingRecord struct. This can be dumped on exit to figure out
-        //  what's going on.
-        //
-
-        // Note for Qt6 . QOpenGLWidget implementation:
-        //
-        // With the new QOpenGLWidget (Qt6 branch), all of the rendering of
-        // each widget is done in its own FBOs (aka: off-screen buffers), as
-        // opposed to the old Qt5/QGLWidget branch where the rendering was
-        // done in each GGLWidget's backbuffer (aka: GL_BACK, an on-screen
-        // framebuffer surface).
-        //
-        // With QOpenGLWidget, it is now the WainWindow's responsibility
-        // (more technically, the MainWindow's rendering backend, which
-        // happens to be Qt's OpenGL rendering backend when QOpenGLWidget are
-        // present in the children tree) to gather and composite all of the
-        // off-screen buffers (regardless of which image type they are, eg:
-        // cpu-memory images, gpu/opengl images, etc) and finally to call
-        // swapBuffers to show the final contents of the mainWindow.
-        //
-        // As a result, I'm not sure there's a point -- at all --
-        // in calling swapBuffers on the GLView anywhere amnymore. From old
-        // comments in the previous version of this tile, it appears that
-        // calling swapBuffers was done to force a quicker visual update, or
-        // to minimize visual tearing of some sort. This would have worked
-        // with the old QGLWidget (becayuse each QGLWidget had its own
-        // context, and its rendering target was directly the GL_BACK
-        // framebuffer, but, again, with QOpenGLWidget, the rendering target
-        // is no longer GL_BACK, it is an FBO that is meant to be used at
-        // the end of the application's drawing / visual update pipeline.
-
-        if (debug)
-        {
-            Session::ProfilingRecord& trecord = session->currentProfilingSample();
-            trecord.renderEnd = session->profilingElapsedTime();
-            trecord.swapStart = trecord.renderEnd;
-
-            if (session->outputVideoDevice() != videoDevice())
-            {
-                session->outputVideoDevice()->syncBuffers();
-            }
-            else
-            {
-                m_videoDevice->widget()->context()->swapBuffers(m_videoDevice->widget()->context()->surface());
-            }
-
-            trecord.swapEnd = session->profilingElapsedTime();
-            session->endProfilingSample();
-        }
-        else
-        {
-            if (session->outputVideoDevice() != videoDevice())
-            {
-                session->outputVideoDevice()->syncBuffers();
-            }
-        }
-
-        session->addSyncSample();
-
-        session->postRender();
-
-        m_eventProcessingTimer.start();
-
-        TWK_GLDEBUG;
-    }
-
-    void GLView::eventProcessingTimeout() { m_doc->session()->userGenericEvent("per-render-event-processing", ""); }
-
-    bool GLView::event(QEvent* event)
-    {
-        // qDebug() << "Event type: " << event->type();
-
-        bool keyevent = false;
-        Rv::Session* session = m_doc->session();
-
-        if (m_stopProcessingEvents)
-        {
-            event->accept();
-            return true;
-        }
-
-        //
-        //  We want to exclude the "click-through" clicks on
-        //  click-to-focus systems (like osX).  Turns out the event
-        //  sequence in these cases is exactly the same as a
-        //  tab-to-focus, then click sequence.  So the only way we have
-        //  to identify the "click-through" is by how quickly the click
-        //  (button push) follows the windowActivate event.
-        //
-
-        if (event->type() == QEvent::WindowActivate)
-            m_activationTimer.start();
-
-#if 0
-    //
-    //  This doesn't work.  Nothing I've tried will make a stylus
-    //  press raise and activate the window when we are handling
-    //  native tablet events.  It works fine when we are treating
-    //  stylus events as mouse events.
-    //
-    if (event->type() == QEvent::TabletPress && !isActiveWindow())
-    {
-        cerr << "activating window" << endl;
-        QEvent activateEvent(QEvent::WindowActivate);
-        //m_frameBuffer->translator().sendQTEvent(new QEvent(QEvent::WindowActivate));
-        session->setEventVideoDevice(videoDevice());
-        m_videoDevice->translator().sendQTEvent(new QEvent(QEvent::WindowActivate));
-        event->accept();
-        /*
-        activateWindow();
-        raise();
-        event->accept();
-        */
-        return true;
-    }
-#endif
-
-        float activationTime = 0.0;
-        if (m_activationTimer.isRunning())
-        {
-            if (event->type() == QEvent::MouseButtonPress)
-            {
-                //
-                //  Pass this time through with the event, so that
-                //  event handling code can decide witehr or not to ignore
-                //  this 'click-through' event.
-                //
-                activationTime = m_activationTimer.elapsed();
-                m_activationTimer.stop();
-            }
-            if (event->type() == QEvent::MouseMove)
-                m_activationTimer.stop();
-        }
-
-        if (event->type() != QEvent::Paint)
-        {
-            m_activityTimer.stop();
-            m_activityTimer.start();
-
-            if (!m_userActive)
-            {
-                TwkApp::ActivityChangeEvent aevent("user-active", m_videoDevice);
-
-                //
-                //  m_userActive set first will prevent recursive nightmare. In
-                //  Qt 4.4 an event may recursively produce more
-                //  events. For example, changing the cursor in 4.4 will
-                //  cause a Paint event immediately (not after the
-                //  previous event returns).
-                //
-
-                m_userActive = true;
-                m_videoDevice->sendEvent(aevent);
-            }
-        }
-
-        if (QKeyEvent* kevent = dynamic_cast<QKeyEvent*>(event))
-        {
-            keyevent = true;
-
-            //
-            //  Get around really annoying event bugs on Qt/Mac
-            //
-
-            if (m_lastKey == kevent->key()
-                && (m_lastKeyType == QEvent::ShortcutOverride && (kevent->type() == QEvent::KeyPress) || (m_lastKeyType == kevent->type())))
-            {
-                //
-                //  Qt 4.3.3 (4.5 too) will give both override and press events
-                //  even if key is not in menu. Filter that here.
-                //
-                //  Remember the new key/type, otherwise we filter out
-                //  any number of ShortcutOverride/Press pairs, and
-                //  auto-repeat doesn't work.
-                //
-                m_lastKey = kevent->key();
-                m_lastKeyType = kevent->type();
-
-                event->accept();
-                return true;
-            }
-
-            m_lastKeyType = kevent->type();
-            m_lastKey = kevent->key();
-        }
-
-        switch (event->type())
-        {
-        case QEvent::FocusIn:
-            m_videoDevice->translator().resetModifiers();
-        case QEvent::Enter:
-            setFocus(Qt::MouseFocusReason);
-            break;
-        default:
-            break;
-        }
-        if (event->type() == QEvent::Resize)
-        {
-            QResizeEvent* e = static_cast<QResizeEvent*>(event);
-
-            // QT5 BUG -- results in invalid drawable
-            if (!isVisible())
-                return true;
-
-            if (e->oldSize().width() != -1 && e->oldSize().height() != -1)
-            {
-                ostringstream contents;
-                contents << e->oldSize().width() << " " << e->oldSize().height() << "|" << e->size().width() << " " << e->size().height();
-
-                if (m_doc && session)
-                {
-                    session->userGenericEvent("view-resized", contents.str());
-                }
-            }
-            return QOpenGLWidget::event(event);
-        }
-
-        if (session && session->outputVideoDevice()
-            && session->outputVideoDevice()->displayMode() == TwkApp::VideoDevice::MirrorDisplayMode)
-        {
-            if (const TwkApp::VideoDevice* cdv = session->controlVideoDevice())
-            {
-                const TwkApp::VideoDevice* odv = session->outputVideoDevice();
-
-                if (odv && cdv != odv && cdv == videoDevice())
-                {
-                    const float w = width();
-                    const float h = height();
-                    const float ow = odv->width();
-                    const float oh = odv->height();
-
-                    const float aspect = w / h;
-                    const float oaspect = ow / oh;
-
-                    m_videoDevice->translator().setRelativeDomain(ow, oh);
-
-                    if (aspect >= oaspect)
-                    {
-                        const float yscale = oh / h;
-                        const float yoffset = 0.0;
-                        const float xscale = yscale;
-                        const float xoffset = -(w * yscale - ow) / 2.0;
-                        m_videoDevice->translator().setScaleAndOffset(xoffset, yoffset, xscale, yscale);
-                    }
-                    else
-                    {
-                        const float xscale = ow / w;
-                        const float xoffset = 0.0;
-                        const float yscale = xscale;
-                        const float yoffset = -(xscale * h - oh) / 2.0;
-                        m_videoDevice->translator().setScaleAndOffset(xoffset, yoffset, xscale, yscale);
-                    }
-                }
-                else
-                {
-                    m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0, 1.0);
-                    m_videoDevice->translator().setRelativeDomain(width(), height());
-                }
-            }
-            else
-            {
-                m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0, 1.0);
-                m_videoDevice->translator().setRelativeDomain(width(), height());
-            }
-        }
-        else
-        {
-            m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0, 1.0);
-            m_videoDevice->translator().setRelativeDomain(width(), height());
-        }
-
-        if (session)
-            session->setEventVideoDevice(videoDevice());
-
-        if (m_videoDevice->translator().sendQTEvent(event, activationTime))
-        {
-            event->accept();
-            return true;
-        }
-        else
-        {
-            bool result = QOpenGLWidget::event(event);
-
-            return result;
-        }
-    }
-
-    bool GLView::eventFilter(QObject* object, QEvent* event)
-    {
-        if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease || event->type() == QEvent::Shortcut
-            || event->type() == QEvent::ShortcutOverride)
-        {
-
-            //
-            //  Get around really annoying event bugs on Qt/Mac
-            //  (copied from GLView::event... same bug applies -lo)
-            //
-            //  Qt 4.3.3 (4.5 too) will give both override and press events even
-            //  if key is not in menu. Filter that here.
-            //
-            //  Remember the new key/type, otherwise we filter out
-            //  any number of ShortcutOverride/Press pairs, and
-            //  auto-repeat doesn't work.
-            //
-
-            if (QKeyEvent* kevent = dynamic_cast<QKeyEvent*>(event))
-            {
-                if (m_lastKey == kevent->key()
-                    && (m_lastKeyType == QEvent::ShortcutOverride && (kevent->type() == QEvent::KeyPress)
-                        || (m_lastKeyType == kevent->type())))
-                {
-                    m_lastKey = kevent->key();
-                    m_lastKeyType = kevent->type();
-
-                    event->accept();
-                    return true;
-                }
-
-                m_lastKeyType = kevent->type();
-                m_lastKey = kevent->key();
-            }
-
-            // if (m_frameBuffer->translator().sendQTEvent(event))
-            Session* session = m_doc->session();
-            session->setEventVideoDevice(videoDevice());
-            if (m_videoDevice->translator().sendQTEvent(event))
-            {
-
-                event->accept();
-                return true;
-            }
-
-            event->accept();
-            return true;
-        }
-
-        return false;
-    }
-
-    float GLView::devicePixelRatio() const { return videoDevice() ? videoDevice()->devicePixelRatio() : 1.0f; }
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/GLWindow.cpp
+++ b/src/lib/app/RvCommon/GLWindow.cpp
@@ -23,6 +23,7 @@
 #include <TwkApp/VideoDevice.h>
 #include <TwkGLF/GLVideoDevice.h>
 #include <QOpenGLContext>
+#include <QtGui/QGuiApplication>
 #include <QKeyEvent>
 #include <QResizeEvent>
 #include <QtWidgets/QMenu>
@@ -297,10 +298,48 @@ namespace Rv
         switch (event->type())
         {
         case QEvent::FocusIn:
+            //
+            //  Qt has already made this the focus window by the time FocusIn is
+            //  delivered, so there is nothing to activate here. The case exists
+            //  only to drop modifier state that went stale while the keyboard
+            //  was elsewhere. (The missing break let execution fall into the
+            //  hover case below.)
+            //
             m_videoDevice->translator().resetModifiers();
-        case QEvent::Enter:
-            requestActivate();
             break;
+
+        case QEvent::Enter:
+            //
+            //  Hovering hands the keyboard to the viewport as a *widget* focus
+            //  change, never as a window activation. QWidget::setFocus() only
+            //  delivers FocusIn when the top-level is already active; otherwise
+            //  it just records the window's focus_child and the keyboard arrives
+            //  once the user activates RV. That is what keeps a hover from
+            //  stealing activation from another top-level of ours (the Console)
+            //  or from another application: requestActivate() on a native child
+            //  window activates the whole top-level, and on Windows it will even
+            //  AttachThreadInput/SetForegroundWindow when RV is not the active
+            //  application.
+            //
+            //  The container is GLView's focus proxy, so setFocus() on the view
+            //  lands on it, and QWindowContainer turns its FocusIn into the
+            //  QWindow::requestActivate() that hands the keyboard to this
+            //  window -- the same path RvDocument and the Mu commands use.
+            //
+            //  Skipped when this window already holds focus: QWindowContainer
+            //  clears the container's widget focus once it has handed focus
+            //  over, so a repeat FocusIn would take its "return to the normal
+            //  focus chain" branch and push the keyboard to the next widget in
+            //  the tab chain instead. QWidget::setFocus()'s own focusWidget()
+            //  early-out did this for us on the widget-based viewport.
+            //
+            if (QGuiApplication::focusWindow() != this)
+            {
+                if (GLView* view = m_doc ? m_doc->view() : nullptr)
+                    view->setFocus(Qt::MouseFocusReason);
+            }
+            break;
+
         default:
             break;
         }

--- a/src/lib/app/RvCommon/GLWindow.cpp
+++ b/src/lib/app/RvCommon/GLWindow.cpp
@@ -1,0 +1,372 @@
+//******************************************************************************
+// Copyright (c) 2007 Tweak Inc.
+// All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//******************************************************************************
+
+#ifdef PLATFORM_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#endif
+
+#include <RvCommon/GLWindow.h>
+#include <RvCommon/GLView.h>
+#include <RvCommon/QTGLVideoDevice.h>
+#include <RvCommon/InitGL.h>
+#include <RvCommon/RvDocument.h>
+#include <RvApp/Options.h>
+#include <IPCore/Session.h>
+#include <TwkApp/Event.h>
+#include <TwkApp/VideoDevice.h>
+#include <TwkGLF/GLVideoDevice.h>
+#include <QOpenGLContext>
+#include <QKeyEvent>
+#include <QResizeEvent>
+#include <QtWidgets/QMenu>
+#include <iostream>
+#include <sstream>
+
+namespace Rv
+{
+    using namespace std;
+    using namespace TwkApp;
+    using namespace IPCore;
+
+    GLWindow::GLWindow(QOpenGLContext* sharedContext, RvDocument* doc, bool stereo, bool vsync, bool doubleBuffer, int red, int green,
+                       int blue, int alpha, bool noResize)
+        : QOpenGLWindow(QOpenGLWindow::NoPartialUpdate)
+        , m_doc(doc)
+        , m_red(red)
+        , m_green(green)
+        , m_blue(blue)
+        , m_alpha(alpha)
+        , m_lastKey(0)
+        , m_lastKeyType(QEvent::None)
+        , m_userActive(true)
+        , m_firstPaintCompleted(false)
+        , m_postFirstNonEmptyRender(noResize)
+        , m_stopProcessingEvents(false)
+        , m_sharedContext(sharedContext)
+    {
+        setFormat(GLView::rvGLFormat(stereo, vsync, doubleBuffer, red, green, blue, alpha));
+
+        m_videoDevice = nullptr; // set later by the hosting GLView
+
+        m_activityTimer.start();
+
+        m_eventProcessingTimer.setSingleShot(true);
+        connect(&m_eventProcessingTimer, SIGNAL(timeout()), this, SLOT(eventProcessingTimeout()));
+    }
+
+    GLWindow::~GLWindow() {}
+
+    void GLWindow::stopProcessingEvents() { m_stopProcessingEvents = true; }
+
+    void GLWindow::eventProcessingTimeout() { m_doc->session()->userGenericEvent("per-render-event-processing", ""); }
+
+    float GLWindow::devicePixelRatioF() const { return static_cast<float>(devicePixelRatio()); }
+
+    void GLWindow::absolutePosition(int& x, int& y) const
+    {
+        QPoint gp = mapToGlobal(QPoint(0, 0));
+        x = gp.x();
+        y = gp.y();
+    }
+
+    void GLWindow::initializeGL()
+    {
+        if (context()->isValid())
+        {
+            initializeGLExtensions();
+            initializeOpenGLFunctions();
+
+            if (m_sharedContext)
+            {
+                context()->setShareContext(m_sharedContext);
+            }
+
+            //
+            //  NOTE: session initialization is deliberately NOT driven from
+            //  here. Loading packages creates web panels, and adding a
+            //  QWebEngineView makes Qt tear down the main window's native
+            //  subtree -- destroying this very window while this method is
+            //  still on the stack, so every later member access is a
+            //  use-after-free. RvApplication::newSessionFromFiles() calls
+            //  RvDocument::initializeSession() after show() instead, with no
+            //  GL callback in the call chain.
+            //
+
+            QSurfaceFormat f = context()->format();
+
+#ifndef PLATFORM_DARWIN
+            if (f.redBufferSize() != m_red && m_red != 0)
+            {
+                ostringstream str;
+                str << "WARNING: asked for"
+                    << " " << m_red << " " << m_green << " " << m_blue << " " << m_alpha << " RGBA color but got"
+                    << " " << f.redBufferSize() << " " << f.greenBufferSize() << " " << f.blueBufferSize() << " "
+                    << (f.alphaBufferSize() <= 0 ? 0 : f.alphaBufferSize()) << " RGBA instead";
+                cout << str.str() << endl;
+            }
+#endif
+            if (f.stencilBufferSize() == 0)
+            {
+                cout << "WARNING: no stencil buffer available" << endl;
+            }
+        }
+        else
+        {
+            cout << "WARNING: invalid GL context" << endl;
+        }
+    }
+
+    void GLWindow::resizeGL(int w, int h)
+    {
+        if (m_doc)
+            m_doc->viewSizeChanged(w, h);
+    }
+
+    QImage GLWindow::readPixels(int x, int y, int w, int h)
+    {
+        const int pw = width() * devicePixelRatio();
+        const int ph = height() * devicePixelRatio();
+
+        // If out of bounds, return an empty image.
+        if (x < 0 || y < 0 || (x + w) > pw || (y + h) > ph)
+            return QImage(0, 0, QImage::Format_RGBA8888);
+
+        if (m_videoDevice)
+            m_videoDevice->makeCurrent();
+        else
+            makeCurrent();
+
+        QImage image(w, h, QImage::Format_RGBA8888);
+        glReadPixels(x, y, w, h, GL_RGBA, GL_UNSIGNED_BYTE, image.bits());
+
+        return image;
+    }
+
+    void GLWindow::paintGL()
+    {
+        TWK_GLDEBUG;
+
+        IPCore::Session* session = m_doc->session();
+
+        if (!m_postFirstNonEmptyRender && session && session->postFirstNonEmptyRender())
+        {
+            m_postFirstNonEmptyRender = true;
+
+            if (!session->isFullScreen())
+            {
+                m_doc->resizeToFit(false, false);
+                m_doc->center();
+                TWK_GLDEBUG;
+            }
+        }
+
+        if (m_doc && session && m_videoDevice)
+        {
+            m_videoDevice->makeCurrent();
+            TWK_GLDEBUG;
+
+            if (m_userActive && m_activityTimer.elapsed() > 1.0)
+            {
+                if (m_doc->mainPopup() && !m_doc->mainPopup()->isVisible())
+                {
+                    TwkApp::ActivityChangeEvent aevent("user-inactive", m_videoDevice);
+                    m_videoDevice->sendEvent(aevent);
+                    TWK_GLDEBUG;
+                    m_userActive = false;
+                }
+            }
+
+            //
+            //  Make sure the video device knows where it is on screen.
+            //
+            int x = 0, y = 0;
+            absolutePosition(x, y);
+            m_videoDevice->setAbsolutePosition(x, y);
+
+            TWK_GLDEBUG;
+            session->render();
+            TWK_GLDEBUG;
+
+            m_firstPaintCompleted = true;
+
+            // Force the resulting alpha channel to 1 so the surface is fully
+            // opaque (matches the former GLView behavior).
+            glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, QOpenGLContext::currentContext()->defaultFramebufferObject());
+            TWK_GLDEBUG;
+            glPushAttrib(GL_COLOR_BUFFER_BIT);
+            glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE);
+            glClearColor(0.f, 0.f, 0.f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            glPopAttrib();
+            TWK_GLDEBUG;
+        }
+        else
+        {
+            glClearColor(0.f, 0.f, 0.f, 1.0f);
+            glClear(GL_COLOR_BUFFER_BIT);
+            TWK_GLDEBUG;
+        }
+
+        if (m_stopProcessingEvents)
+            return;
+
+        // If a separate output device is presenting, sync it. The control
+        // (window) surface presents itself: QOpenGLWindow swaps automatically
+        // after paintGL returns.
+        if (session->outputVideoDevice() != m_videoDevice)
+        {
+            session->outputVideoDevice()->syncBuffers();
+        }
+
+        session->addSyncSample();
+        session->postRender();
+
+        m_eventProcessingTimer.start();
+
+        TWK_GLDEBUG;
+    }
+
+    bool GLWindow::event(QEvent* event)
+    {
+        // The device (and its translator) is wired by the hosting GLView just
+        // after construction; ignore any events that arrive before then.
+        if (!m_videoDevice)
+            return QOpenGLWindow::event(event);
+
+        bool keyevent = false;
+        Rv::Session* session = m_doc->session();
+
+        if (m_stopProcessingEvents)
+        {
+            event->accept();
+            return true;
+        }
+
+        if (event->type() == QEvent::WindowActivate)
+            m_activationTimer.start();
+
+        float activationTime = 0.0;
+        if (m_activationTimer.isRunning())
+        {
+            if (event->type() == QEvent::MouseButtonPress)
+            {
+                activationTime = m_activationTimer.elapsed();
+                m_activationTimer.stop();
+            }
+            if (event->type() == QEvent::MouseMove)
+                m_activationTimer.stop();
+        }
+
+        if (event->type() != QEvent::Paint && event->type() != QEvent::UpdateRequest)
+        {
+            m_activityTimer.stop();
+            m_activityTimer.start();
+
+            if (!m_userActive)
+            {
+                TwkApp::ActivityChangeEvent aevent("user-active", m_videoDevice);
+                m_userActive = true;
+                m_videoDevice->sendEvent(aevent);
+            }
+        }
+
+        if (QKeyEvent* kevent = dynamic_cast<QKeyEvent*>(event))
+        {
+            keyevent = true;
+
+            if (m_lastKey == kevent->key()
+                && (m_lastKeyType == QEvent::ShortcutOverride && (kevent->type() == QEvent::KeyPress) || (m_lastKeyType == kevent->type())))
+            {
+                m_lastKey = kevent->key();
+                m_lastKeyType = kevent->type();
+                event->accept();
+                return true;
+            }
+
+            m_lastKeyType = kevent->type();
+            m_lastKey = kevent->key();
+        }
+
+        switch (event->type())
+        {
+        case QEvent::FocusIn:
+            m_videoDevice->translator().resetModifiers();
+        case QEvent::Enter:
+            requestActivate();
+            break;
+        default:
+            break;
+        }
+
+        if (session && session->outputVideoDevice()
+            && session->outputVideoDevice()->displayMode() == TwkApp::VideoDevice::MirrorDisplayMode)
+        {
+            if (const TwkApp::VideoDevice* cdv = session->controlVideoDevice())
+            {
+                const TwkApp::VideoDevice* odv = session->outputVideoDevice();
+
+                if (odv && cdv != odv && cdv == m_videoDevice)
+                {
+                    const float w = width();
+                    const float h = height();
+                    const float ow = odv->width();
+                    const float oh = odv->height();
+
+                    const float aspect = w / h;
+                    const float oaspect = ow / oh;
+
+                    m_videoDevice->translator().setRelativeDomain(ow, oh);
+
+                    if (aspect >= oaspect)
+                    {
+                        const float yscale = oh / h;
+                        const float xscale = yscale;
+                        const float xoffset = -(w * yscale - ow) / 2.0;
+                        m_videoDevice->translator().setScaleAndOffset(xoffset, 0.0, xscale, yscale);
+                    }
+                    else
+                    {
+                        const float xscale = ow / w;
+                        const float yscale = xscale;
+                        const float yoffset = -(xscale * h - oh) / 2.0;
+                        m_videoDevice->translator().setScaleAndOffset(0.0, yoffset, xscale, yscale);
+                    }
+                }
+                else
+                {
+                    m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0, 1.0);
+                    m_videoDevice->translator().setRelativeDomain(width(), height());
+                }
+            }
+            else
+            {
+                m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0, 1.0);
+                m_videoDevice->translator().setRelativeDomain(width(), height());
+            }
+        }
+        else
+        {
+            m_videoDevice->translator().setScaleAndOffset(0, 0, 1.0, 1.0);
+            m_videoDevice->translator().setRelativeDomain(width(), height());
+        }
+
+        if (session)
+            session->setEventVideoDevice(m_videoDevice);
+
+        if (m_videoDevice->translator().sendQTEvent(event, activationTime))
+        {
+            event->accept();
+            return true;
+        }
+
+        return QOpenGLWindow::event(event);
+    }
+
+} // namespace Rv

--- a/src/lib/app/RvCommon/QTGLVideoDevice.cpp
+++ b/src/lib/app/RvCommon/QTGLVideoDevice.cpp
@@ -47,6 +47,18 @@ namespace Rv
     {
     }
 
+    QTGLVideoDevice::QTGLVideoDevice(VideoModule* m, const string& name, QOpenGLWindow* window, QWidget* eventWidget)
+        : GLVideoDevice(m, name, ImageOutput | ProvidesSync | SubWindow)
+        , m_view(0)
+        , m_window(window)
+        , m_translator(new QTTranslator(this, eventWidget))
+        , m_x(0)
+        , m_y(0)
+        , m_refresh(-1.0)
+    {
+        assert(window);
+    }
+
     QTGLVideoDevice::QTGLVideoDevice(const string& name, QOpenGLWidget* view)
         : GLVideoDevice(NULL, name, NoCapabilities)
         , m_view(view)
@@ -68,16 +80,36 @@ namespace Rv
 
     GLVideoDevice* QTGLVideoDevice::newSharedContextWorkerDevice() const
     {
-        // NOTE_QT: QOpenGLWidget does not take a share parameter anymore. Try
-        // to share with setShareContext.
-        QOpenGLWidget* openGLWidget = new QOpenGLWidget(m_view->parentWidget());
-        openGLWidget->context()->setShareContext(m_view->context());
+        // A freshly constructed QOpenGLWidget has no context() yet -- it is
+        // created lazily on first show/makeCurrent -- so the previous
+        // openGLWidget->context()->setShareContext(...) here dereferenced a null
+        // context and crashed (reachable via ImageRenderer::createGLContexts()
+        // when "Multithread GPU Upload" is enabled). Explicit sharing is also
+        // unnecessary: Qt::AA_ShareOpenGLContexts (set in main.cpp) makes all GL
+        // contexts in the process share resources, so this worker context shares
+        // with the control viewport automatically.
+        QOpenGLWidget* openGLWidget = new QOpenGLWidget(m_view ? m_view->parentWidget() : nullptr);
         return new QTGLVideoDevice(name() + "-workerContextDevice", openGLWidget);
     }
 
     void QTGLVideoDevice::makeCurrent() const
     {
-        if (m_view->context() && m_view->context()->isValid())
+        if (m_window)
+        {
+            // QOpenGLWindow creates its GL context lazily on the first
+            // makeCurrent(), provided the platform window (surface) exists.
+            if (m_window->handle())
+            {
+                m_window->makeCurrent();
+                TWK_GLDEBUG;
+
+                GLint surfaceFBO = m_window->defaultFramebufferObject();
+                if (surfaceFBO != 0)
+                    glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, surfaceFBO);
+                TWK_GLDEBUG;
+            }
+        }
+        else if (m_view && m_view->context() && m_view->context()->isValid())
         {
             m_view->makeCurrent();
             TWK_GLDEBUG;
@@ -94,6 +126,8 @@ namespace Rv
 
     GLuint QTGLVideoDevice::fboID() const
     {
+        if (m_window)
+            return m_window->defaultFramebufferObject();
         if (m_view)
             return m_view->defaultFramebufferObject();
 
@@ -129,14 +163,27 @@ namespace Rv
     {
         if (!isWorkerDevice())
         {
-            QSize s = m_view->size();
-            m_view->update();
+            if (m_window)
+                m_window->update();
+            else if (m_view)
+                m_view->update();
         }
     }
 
     void QTGLVideoDevice::redrawImmediately() const
     {
-        if (!isWorkerDevice())
+        if (isWorkerDevice())
+            return;
+
+        if (m_window)
+        {
+            if (m_window->isVisible())
+                m_window->update();
+            else
+                redraw();
+            return;
+        }
+
         {
             if (m_view->isVisible())
             {
@@ -166,12 +213,16 @@ namespace Rv
 
     VideoDevice::Resolution QTGLVideoDevice::resolution() const
     {
-        return Resolution(m_view->width() * devicePixelRatio(), m_view->height() * devicePixelRatio(), 1.0f, 1.0f);
+        const int w = m_window ? m_window->width() : m_view->width();
+        const int h = m_window ? m_window->height() : m_view->height();
+        return Resolution(w * devicePixelRatio(), h * devicePixelRatio(), 1.0f, 1.0f);
     }
 
     VideoDevice::Resolution QTGLVideoDevice::internalResolution() const
     {
-        return Resolution(m_view->width(), m_view->height(), 1.0f, 1.0f);
+        const int w = m_window ? m_window->width() : m_view->width();
+        const int h = m_window ? m_window->height() : m_view->height();
+        return Resolution(w, h, 1.0f, 1.0f);
     }
 
     VideoDevice::Offset QTGLVideoDevice::offset() const { return Offset(m_x, m_y); }
@@ -180,45 +231,52 @@ namespace Rv
 
     VideoDevice::VideoFormat QTGLVideoDevice::format() const
     {
-        return VideoFormat(m_view->width() * devicePixelRatio(), m_view->height() * devicePixelRatio(), 1.0, 1.0,
-                           (m_refresh != -1.0) ? m_refresh : 0.0, hardwareIdentification());
+        const int w = m_window ? m_window->width() : m_view->width();
+        const int h = m_window ? m_window->height() : m_view->height();
+        return VideoFormat(w * devicePixelRatio(), h * devicePixelRatio(), 1.0, 1.0, (m_refresh != -1.0) ? m_refresh : 0.0,
+                           hardwareIdentification());
     }
 
     void QTGLVideoDevice::open(const StringVector& args)
     {
-        if (!isWorkerDevice())
+        if (isWorkerDevice())
+            return;
+        if (m_window)
+            m_window->show();
+        else
             m_view->show();
     }
 
     void QTGLVideoDevice::close()
     {
-        if (!isWorkerDevice())
+        if (isWorkerDevice())
+            return;
+        if (m_window)
+            m_window->hide();
+        else
             m_view->hide();
     }
 
     bool QTGLVideoDevice::isOpen() const
     {
         if (isWorkerDevice())
-        {
             return false;
-        }
-        else
-        {
-            return m_view->isVisible();
-        }
+        return m_window ? m_window->isVisible() : m_view->isVisible();
     }
 
-    size_t QTGLVideoDevice::width() const { return m_view->width() * devicePixelRatio(); }
+    size_t QTGLVideoDevice::width() const { return (m_window ? m_window->width() : m_view->width()) * devicePixelRatio(); }
 
-    size_t QTGLVideoDevice::height() const { return m_view->height() * devicePixelRatio(); }
+    size_t QTGLVideoDevice::height() const { return (m_window ? m_window->height() : m_view->height()) * devicePixelRatio(); }
 
     void QTGLVideoDevice::syncBuffers() const
     {
-        if (!isWorkerDevice())
-        {
-            makeCurrent();
+        if (isWorkerDevice())
+            return;
+        makeCurrent();
+        if (m_window)
+            m_window->context()->swapBuffers(m_window);
+        else
             m_view->context()->swapBuffers(m_view->context()->surface());
-        }
     }
 
     void QTGLVideoDevice::setAbsolutePosition(int x, int y)

--- a/src/lib/app/RvCommon/QTGLVideoDevice.cpp
+++ b/src/lib/app/RvCommon/QTGLVideoDevice.cpp
@@ -78,6 +78,16 @@ namespace Rv
         m_translator = new QTTranslator(this, m_view);
     }
 
+    void QTGLVideoDevice::setWindow(QOpenGLWindow* window, QWidget* eventWidget)
+    {
+        m_window = window;
+
+        if (m_translator)
+            m_translator->setWidet(eventWidget);
+        else
+            m_translator = new QTTranslator(this, eventWidget);
+    }
+
     GLVideoDevice* QTGLVideoDevice::newSharedContextWorkerDevice() const
     {
         // A freshly constructed QOpenGLWidget has no context() yet -- it is
@@ -184,6 +194,7 @@ namespace Rv
             return;
         }
 
+        if (m_view)
         {
             if (m_view->isVisible())
             {
@@ -211,17 +222,21 @@ namespace Rv
         }
     }
 
+    int QTGLVideoDevice::surfaceWidth() const { return m_window ? m_window->width() : (m_view ? m_view->width() : 1); }
+
+    int QTGLVideoDevice::surfaceHeight() const { return m_window ? m_window->height() : (m_view ? m_view->height() : 1); }
+
     VideoDevice::Resolution QTGLVideoDevice::resolution() const
     {
-        const int w = m_window ? m_window->width() : m_view->width();
-        const int h = m_window ? m_window->height() : m_view->height();
+        const int w = surfaceWidth();
+        const int h = surfaceHeight();
         return Resolution(w * devicePixelRatio(), h * devicePixelRatio(), 1.0f, 1.0f);
     }
 
     VideoDevice::Resolution QTGLVideoDevice::internalResolution() const
     {
-        const int w = m_window ? m_window->width() : m_view->width();
-        const int h = m_window ? m_window->height() : m_view->height();
+        const int w = surfaceWidth();
+        const int h = surfaceHeight();
         return Resolution(w, h, 1.0f, 1.0f);
     }
 
@@ -231,8 +246,8 @@ namespace Rv
 
     VideoDevice::VideoFormat QTGLVideoDevice::format() const
     {
-        const int w = m_window ? m_window->width() : m_view->width();
-        const int h = m_window ? m_window->height() : m_view->height();
+        const int w = surfaceWidth();
+        const int h = surfaceHeight();
         return VideoFormat(w * devicePixelRatio(), h * devicePixelRatio(), 1.0, 1.0, (m_refresh != -1.0) ? m_refresh : 0.0,
                            hardwareIdentification());
     }
@@ -243,7 +258,7 @@ namespace Rv
             return;
         if (m_window)
             m_window->show();
-        else
+        else if (m_view)
             m_view->show();
     }
 
@@ -253,7 +268,7 @@ namespace Rv
             return;
         if (m_window)
             m_window->hide();
-        else
+        else if (m_view)
             m_view->hide();
     }
 
@@ -261,12 +276,12 @@ namespace Rv
     {
         if (isWorkerDevice())
             return false;
-        return m_window ? m_window->isVisible() : m_view->isVisible();
+        return m_window ? m_window->isVisible() : (m_view ? m_view->isVisible() : false);
     }
 
-    size_t QTGLVideoDevice::width() const { return (m_window ? m_window->width() : m_view->width()) * devicePixelRatio(); }
+    size_t QTGLVideoDevice::width() const { return surfaceWidth() * devicePixelRatio(); }
 
-    size_t QTGLVideoDevice::height() const { return (m_window ? m_window->height() : m_view->height()) * devicePixelRatio(); }
+    size_t QTGLVideoDevice::height() const { return surfaceHeight() * devicePixelRatio(); }
 
     void QTGLVideoDevice::syncBuffers() const
     {
@@ -275,7 +290,7 @@ namespace Rv
         makeCurrent();
         if (m_window)
             m_window->context()->swapBuffers(m_window);
-        else
+        else if (m_view)
             m_view->context()->swapBuffers(m_view->context()->surface());
     }
 

--- a/src/lib/app/RvCommon/RvApplication.cpp
+++ b/src/lib/app/RvCommon/RvApplication.cpp
@@ -734,6 +734,16 @@ namespace Rv
         doc->raise();
 #endif
 
+        //
+        //  Create the session now that the viewport window exists and its GL
+        //  context has been created by show(). This must happen here rather
+        //  than from GLWindow::initializeGL(): loading packages creates web
+        //  panels, and adding a QWebEngineView makes Qt destroy the main
+        //  window's native subtree -- including the viewport window -- which
+        //  is fatal if a GLWindow method is still on the call stack.
+        //
+        doc->initializeSession();
+
         // doc->ensurePolished();
         Rv::RvSession* s = doc->session();
 

--- a/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/DesktopVideoDevice.h
@@ -18,6 +18,7 @@
 #include <RvCommon/QTGLVideoDevice.h>
 #include <QtWidgets/QWidget>
 #include <QOpenGLWidget>
+#include <QOpenGLContext>
 #include <QGuiApplication>
 
 namespace Rv
@@ -57,13 +58,19 @@ namespace Rv
         class ScreenView : public QOpenGLWidget
         {
         public:
-            ScreenView(const QSurfaceFormat& fmt, QWidget* parent, QOpenGLWidget* glViewShare, Qt::WindowFlags flags);
+            //
+            //  glShareContext is the control view's GL context to share with
+            //  (so blits/FBOs are usable across the two surfaces). It comes
+            //  from QTGLVideoDevice::glShareContext() and is backing-agnostic:
+            //  the control view may be a QOpenGLWidget or a QOpenGLWindow.
+            //
+            ScreenView(const QSurfaceFormat& fmt, QWidget* parent, QOpenGLContext* glShareContext, Qt::WindowFlags flags);
 
             void initializeGL() override;
             void paintGL() override;
 
         private:
-            QOpenGLWidget* m_glViewShare = nullptr;
+            QOpenGLContext* m_glShareContext = nullptr;
         };
 
     public:

--- a/src/lib/app/RvCommon/RvCommon/GLView.h
+++ b/src/lib/app/RvCommon/RvCommon/GLView.h
@@ -14,6 +14,7 @@
 #include <QSize>
 
 class QOpenGLContext;
+class QWindow;
 
 namespace Rv
 {
@@ -84,6 +85,32 @@ namespace Rv
         float devicePixelRatio() const;
 
     private:
+        //
+        //  Keeping the viewport window alive across top-level window churn.
+        //
+        //  createWindowContainer() transfers ownership of the viewport window to
+        //  the container, which parents it to the top-level QWidgetWindow. Qt
+        //  destroys and recreates that QWidgetWindow when a widget is reparented
+        //  into the window -- QWidget::setParent() -> destroy() -> ~QWidgetWindow
+        //  -- as happens when a plugin adds a QWebEngineView to a layout, and
+        //  ~QObject deletes its child QWindows, viewport included. Nothing in Qt
+        //  puts it back, and QWindowContainer then dereferences the window it no
+        //  longer has on the next layout pass.
+        //
+        //  QObject::destroyed is emitted at the top of ~QObject, before
+        //  deleteChildren() runs, so watching the parent window gives us a
+        //  moment where the viewport can still be detached and kept -- which is
+        //  much cheaper than rebuilding it, and keeps the GL context, the device
+        //  wiring and the uploaded textures intact.
+        //
+        void watchParentWindow();
+        void parentWindowDestroyed();
+        void reattachGLWindow();
+
+    protected:
+        void showEvent(QShowEvent*) override;
+
+    private:
         RvDocument* m_doc;
         GLWindow* m_glWindow;
         QWidget* m_container;
@@ -91,6 +118,15 @@ namespace Rv
         QSize m_csize;
         QSize m_msize;
         QOpenGLContext* m_sharedContext;
+
+        //
+        //  The parent QWindow whose destruction is being watched, plus the
+        //  connection to it so it can be rewired when the viewport window is
+        //  re-parented. See watchParentWindow().
+        //
+        QWindow* m_watchedParentWindow;
+        QMetaObject::Connection m_watchedParentConnection;
+        bool m_reattachPending;
     };
 
 } // namespace Rv

--- a/src/lib/app/RvCommon/RvCommon/GLView.h
+++ b/src/lib/app/RvCommon/RvCommon/GLView.h
@@ -8,55 +8,74 @@
 #ifndef __rv_qt__GLView__h__
 #define __rv_qt__GLView__h__
 #include <TwkGLF/GL.h>
-#include <QOpenGLWidget>
-#include <QOpenGLFunctions>
+#include <QtWidgets/QWidget>
 #include <QSurfaceFormat>
-#include <QOffscreenSurface>
-#include <QtCore/QEvent>
-#include <QtCore/QTimer>
-#include <TwkUtil/Timer.h>
-#include <boost/thread/thread.hpp>
+#include <QImage>
+#include <QSize>
+
+class QOpenGLContext;
 
 namespace Rv
 {
     class RvDocument;
     class QTGLVideoDevice;
+    class GLWindow;
 
-    class GLView
-        : public QOpenGLWidget
-        , protected QOpenGLFunctions
+    //
+    //  GLView
+    //
+    //  Host QWidget that embeds the native GL viewport (GLWindow) via
+    //  QWidget::createWindowContainer(). GLView keeps the public API the rest
+    //  of RV expects -- view()->context()/format()/makeCurrent()/videoDevice()
+    //  etc. -- by delegating to the GLWindow.
+    //
+    //  Crucially, GLView is no longer a QOpenGLWidget. That keeps the top-level
+    //  QMainWindow off the OpenGL RHI backend (so docked QWebEngineView panels
+    //  render on the platform default backend), and lets the viewport present
+    //  on its own native surface instead of via the full-window widget
+    //  composite.
+    //
+
+    class GLView : public QWidget
     {
         Q_OBJECT
 
     public:
-        typedef TwkUtil::Timer Timer;
-
         GLView(QWidget* parent, QOpenGLContext* sharedContext, RvDocument* doc, bool stereo = false, bool vsync = true,
                bool doubleBuffer = true, int red = 0, int green = 0, int blue = 0, int alpha = 0, bool noResize = true);
-        ~GLView();
+        ~GLView() override;
 
         static QSurfaceFormat rvGLFormat(bool stereo = false, bool vsync = true, bool doubleBuffer = true, int red = 8, int green = 8,
                                          int blue = 8, int alpha = 8);
 
-        void absolutePosition(int& x, int& y) const;
+        GLWindow* glWindow() const { return m_glWindow; }
 
         QTGLVideoDevice* videoDevice() const { return m_videoDevice; }
 
+        //
+        //  Delegated QOpenGLWidget-compatible API still used across RV.
+        //
+        QOpenGLContext* context() const;
+        QSurfaceFormat format() const;
+        void makeCurrent();
+
+        //  Compatibility shim for the former QOpenGLWidget::isValid(): the
+        //  native GL window is created up-front, so the viewport is considered
+        //  valid once the window exists.
+        bool isValid() const;
+
+        void absolutePosition(int& x, int& y) const;
+
         void stopProcessingEvents();
 
-        virtual bool event(QEvent*);
-        virtual bool eventFilter(QObject* object, QEvent* event);
-
-        bool firstPaintCompleted() const { return m_firstPaintCompleted; };
+        bool firstPaintCompleted() const;
 
         void setContentSize(int w, int h) { m_csize = QSize(w, h); }
 
         void setMinimumContentSize(int w, int h) { m_msize = QSize(w, h); }
 
-        virtual QSize sizeHint() const;
-        virtual QSize minimumSizeHint() const;
-
-        void* syncClosure() const { return m_syncThreadData; }
+        QSize sizeHint() const override;
+        QSize minimumSizeHint() const override;
 
         QImage readPixels(int x, int y, int w, int h);
 
@@ -64,38 +83,13 @@ namespace Rv
         // For reference: https://doc.qt.io/qt-6/highdpi.html
         float devicePixelRatio() const;
 
-    public slots:
-        void eventProcessingTimeout();
-
-    protected:
-        void initializeGL();
-        void resizeGL(int w, int h);
-        void paintGL();
-        bool validateReadPixels(int x, int y, int w, int h);
-        void debugSaveFramebuffer();
-
     private:
         RvDocument* m_doc;
-        boost::thread m_swapThread;
+        GLWindow* m_glWindow;
+        QWidget* m_container;
         QTGLVideoDevice* m_videoDevice;
-        unsigned int m_lastKey;
-        QEvent::Type m_lastKeyType;
-        Timer m_activityTimer;
-        Timer m_renderTimer;
-        QTimer m_eventProcessingTimer;
-        bool m_userActive;
-        size_t m_renderCount;
-        Timer m_activationTimer;
-        bool m_firstPaintCompleted;
         QSize m_csize;
         QSize m_msize;
-        int m_red;
-        int m_green;
-        int m_blue;
-        int m_alpha;
-        bool m_postFirstNonEmptyRender;
-        bool m_stopProcessingEvents;
-        void* m_syncThreadData;
         QOpenGLContext* m_sharedContext;
     };
 

--- a/src/lib/app/RvCommon/RvCommon/GLWindow.h
+++ b/src/lib/app/RvCommon/RvCommon/GLWindow.h
@@ -1,0 +1,102 @@
+//******************************************************************************
+// Copyright (c) 2007 Tweak Inc.
+// All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//******************************************************************************
+#ifndef __rv_qt__GLWindow__h__
+#define __rv_qt__GLWindow__h__
+#include <TwkGLF/GL.h>
+#include <QOpenGLWindow>
+#include <QOpenGLFunctions>
+#include <QSurfaceFormat>
+#include <QtCore/QEvent>
+#include <QtCore/QTimer>
+#include <QImage>
+#include <TwkUtil/Timer.h>
+
+namespace Rv
+{
+    class RvDocument;
+    class QTGLVideoDevice;
+
+    //
+    //  GLWindow
+    //
+    //  The RV viewport rendered as a *native* GL surface (QOpenGLWindow)
+    //  instead of a composited QOpenGLWidget. Because it is a real window and
+    //  not a QOpenGLWidget in the main window's widget tree, the top-level
+    //  QMainWindow is no longer forced to the OpenGL RHI backend -- so docked
+    //  QWebEngineView panels render on the platform default backend -- and the
+    //  viewport presents on its own surface instead of via the ~90 ms
+    //  full-window widget composite.
+    //
+    //  It is embedded in the widget hierarchy by GLView via
+    //  QWidget::createWindowContainer(). Rendering and event routing are ported
+    //  from the former QOpenGLWidget-based GLView.
+    //
+
+    class GLWindow
+        : public QOpenGLWindow
+        , protected QOpenGLFunctions
+    {
+        Q_OBJECT
+
+    public:
+        typedef TwkUtil::Timer Timer;
+
+        GLWindow(QOpenGLContext* sharedContext, RvDocument* doc, bool stereo = false, bool vsync = true, bool doubleBuffer = true,
+                 int red = 0, int green = 0, int blue = 0, int alpha = 0, bool noResize = true);
+        ~GLWindow() override;
+
+        QTGLVideoDevice* videoDevice() const { return m_videoDevice; }
+
+        //  The device is created and owned by the hosting GLView (it needs the
+        //  container QWidget for event/coordinate translation), then handed
+        //  here. GLWindow does not take ownership.
+        void setVideoDevice(QTGLVideoDevice* d) { m_videoDevice = d; }
+
+        void stopProcessingEvents();
+
+        bool event(QEvent*) override;
+
+        bool firstPaintCompleted() const { return m_firstPaintCompleted; }
+
+        // Absolute (global) top-left position of the surface in pixels.
+        void absolutePosition(int& x, int& y) const;
+
+        float devicePixelRatioF() const;
+
+        QImage readPixels(int x, int y, int w, int h);
+
+    public slots:
+        void eventProcessingTimeout();
+
+    protected:
+        void initializeGL() override;
+        void resizeGL(int w, int h) override;
+        void paintGL() override;
+
+    private:
+        RvDocument* m_doc;
+        QTGLVideoDevice* m_videoDevice;
+        unsigned int m_lastKey;
+        QEvent::Type m_lastKeyType;
+        Timer m_activityTimer;
+        QTimer m_eventProcessingTimer;
+        bool m_userActive;
+        Timer m_activationTimer;
+        bool m_firstPaintCompleted;
+        int m_red;
+        int m_green;
+        int m_blue;
+        int m_alpha;
+        bool m_postFirstNonEmptyRender;
+        bool m_stopProcessingEvents;
+        QOpenGLContext* m_sharedContext;
+    };
+
+} // namespace Rv
+
+#endif // __rv_qt__GLWindow__h__

--- a/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
@@ -10,6 +10,9 @@
 #include <iostream>
 #include <TwkGLF/GLVideoDevice.h>
 #include <QOpenGLWidget>
+#include <QOpenGLWindow>
+#include <QOpenGLContext>
+#include <QSurfaceFormat>
 #include <QWindow>
 #include <QtWidgets/QWidget>
 #include <RvCommon/QTTranslator.h>
@@ -29,12 +32,32 @@ namespace Rv
     {
     public:
         QTGLVideoDevice(TwkApp::VideoModule*, const std::string& name, QOpenGLWidget* view);
+        //
+        //  Native-window backed variant. The GL surface is a QOpenGLWindow
+        //  (embedded in the widget tree via createWindowContainer); eventWidget
+        //  is the container QWidget used by the QTTranslator for coordinate
+        //  mapping (height/mapToGlobal) and mouse grab.
+        //
+        QTGLVideoDevice(TwkApp::VideoModule*, const std::string& name, QOpenGLWindow* window, QWidget* eventWidget);
         QTGLVideoDevice(TwkApp::VideoModule*, const std::string& name);
         virtual ~QTGLVideoDevice();
 
         void setWidget(QOpenGLWidget*);
 
         QOpenGLWidget* widget() const { return m_view; }
+
+        QOpenGLWindow* window() const { return m_window; }
+
+        //
+        //  Backing-agnostic accessors for the shareable GL context and its
+        //  surface format. The control view may be backed by either a
+        //  QOpenGLWidget (m_view) or, in the native-window port, a
+        //  QOpenGLWindow (m_window). Second-output devices (DesktopVideoDevice)
+        //  share the control context and need these without caring which.
+        //
+        QOpenGLContext* glShareContext() const { return m_window ? m_window->context() : (m_view ? m_view->context() : nullptr); }
+
+        QSurfaceFormat glSurfaceFormat() const { return m_window ? m_window->format() : (m_view ? m_view->format() : QSurfaceFormat()); }
 
         virtual void makeCurrent() const;
 
@@ -85,6 +108,7 @@ namespace Rv
         float m_refresh;
         float m_devicePixelRatio{1.0f};
         QOpenGLWidget* m_view;
+        QOpenGLWindow* m_window{nullptr};
         QTTranslator* m_translator;
     };
 

--- a/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
@@ -12,6 +12,7 @@
 #include <QOpenGLWidget>
 #include <QOpenGLWindow>
 #include <QOpenGLContext>
+#include <QPointer>
 #include <QSurfaceFormat>
 #include <QWindow>
 #include <QtWidgets/QWidget>
@@ -43,6 +44,17 @@ namespace Rv
         virtual ~QTGLVideoDevice();
 
         void setWidget(QOpenGLWidget*);
+
+        //
+        //  Re-point the device at a different viewport window and event widget.
+        //  The window is owned by the widget container that embeds it, so Qt can
+        //  destroy it independently of this device (see m_window); the hosting
+        //  GLView rebuilds both and calls this. Passing a null window leaves the
+        //  device backing-less until the next call, which the guards throughout
+        //  this class tolerate. The translator is reused rather than recreated so
+        //  its accumulated modifier/pointer state survives the swap.
+        //
+        void setWindow(QOpenGLWindow* window, QWidget* eventWidget);
 
         QOpenGLWidget* widget() const { return m_view; }
 
@@ -102,13 +114,28 @@ namespace Rv
     protected:
         QTGLVideoDevice(const std::string& name, QOpenGLWidget* view);
 
+        //
+        //  Logical size of whichever surface backs this device. Falls back to
+        //  1x1 when neither backing is alive, so callers computing an aspect
+        //  ratio cannot divide by zero. See m_window for why it can go away.
+        //
+        int surfaceWidth() const;
+        int surfaceHeight() const;
+
     protected:
         int m_x;
         int m_y;
         float m_refresh;
         float m_devicePixelRatio{1.0f};
         QOpenGLWidget* m_view;
-        QOpenGLWindow* m_window{nullptr};
+        //
+        //  Guarded: the window is embedded via QWidget::createWindowContainer(),
+        //  which owns it, so Qt can delete it independently of this device (and
+        //  of the GLView that created both). A QPointer makes the `if (m_window)`
+        //  checks below actual liveness checks instead of null checks -- without
+        //  it, redraw() would call update() on a freed QOpenGLWindow.
+        //
+        QPointer<QOpenGLWindow> m_window;
         QTTranslator* m_translator;
     };
 

--- a/src/lib/app/RvCommon/RvCommon/RvDocument.h
+++ b/src/lib/app/RvCommon/RvCommon/RvDocument.h
@@ -148,6 +148,12 @@ namespace Rv
         void mergeMenu(const TwkApp::Menu*, bool shortcuts = true);
         void convert(QMenu*, const TwkApp::Menu*, bool shortcuts);
 
+        // Position the UI blocking overlay over the main window's client area.
+        // The overlay is a frameless top-level window (not a child widget) so
+        // it can cover the native GL viewport window, which renders above
+        // sibling raster widgets and so cannot be dimmed by a child overlay.
+        void positionBlockingOverlay();
+
         void closeEvent(QCloseEvent*) override;
         void changeEvent(QEvent*) override;
         bool event(QEvent*) override;

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -264,16 +264,29 @@ namespace Rv
         }
 
         //
-        //  Create UI blocking overlay - transparent widget that captures all input
+        //  Create UI blocking overlay - a transparent window that captures all
+        //  input and dims the UI.
         //
-        m_blockingOverlay = new QWidget(this);
+        //  It is a frameless top-level window (owned by this document) rather
+        //  than a child widget. The viewport is a native QOpenGLWindow, which
+        //  renders above any sibling raster child widget regardless of
+        //  raise()/stacking order, so a child overlay could never dim or block
+        //  the viewport. A top-level window sits above the main window and its
+        //  native child, so it covers the viewport too.
+        //
+        m_blockingOverlay = new QWidget(this, Qt::FramelessWindowHint | Qt::Tool);
         m_blockingOverlay->setObjectName("UIBlockingOverlay");
 
-        // Semi-transparent dark overlay for visual feedback
-        m_blockingOverlay->setStyleSheet("QWidget#UIBlockingOverlay { background-color: rgba(0, 0, 0, 100); }");
+        // Semi-transparent dark overlay for visual feedback. A top-level window
+        // has no per-pixel alpha unless WA_TranslucentBackground is set, and an
+        // rgba stylesheet fill does not reliably paint on a plain translucent
+        // top-level QWidget. Instead fill solid black and make the whole window
+        // see-through with window opacity, which is deterministic on all
+        // platforms and composites correctly above the native GL viewport.
+        m_blockingOverlay->setStyleSheet("QWidget#UIBlockingOverlay { background-color: rgb(0, 0, 0); }");
+        m_blockingOverlay->setWindowOpacity(0.4);
 
-        // Ensure it stays on top and captures input
-        m_blockingOverlay->raise();
+        // Capture input (mouse + keyboard) while shown
         m_blockingOverlay->setAttribute(Qt::WA_TransparentForMouseEvents, false);
         m_blockingOverlay->setFocusPolicy(Qt::StrongFocus);
 
@@ -281,10 +294,35 @@ namespace Rv
         m_blockingOverlay->hide();
     }
 
+    void RvDocument::positionBlockingOverlay()
+    {
+        if (!m_blockingOverlay)
+            return;
+
+        // Cover the main window's client area in global coordinates (the
+        // overlay is a top-level window, so it needs screen coordinates).
+        m_blockingOverlay->setGeometry(QRect(mapToGlobal(QPoint(0, 0)), size()));
+        m_blockingOverlay->raise();
+    }
+
     void RvDocument::initializeSession()
     {
+        //
+        //  Called by RvApplication::newSessionFromFiles() once the document has
+        //  been shown, so the viewport window exists and its GL context has
+        //  been created. Constructing an RvSession queries
+        //  GL_SHADING_LANGUAGE_VERSION and aborts without a current context, so
+        //  make the viewport context current first.
+        //
+        if (!m_glView)
+        {
+            return;
+        }
+
         if (!m_session)
         {
+            m_glView->makeCurrent();
+
             m_session = new RvSession;
             // m_session->setFrameBuffer(fb);
 
@@ -1959,6 +1997,10 @@ namespace Rv
     {
         if (m_session)
             m_session->askForRedraw();
+
+        // Keep the top-level overlay aligned with the window when visible.
+        if (m_blockingOverlay && m_blockingOverlay->isVisible())
+            positionBlockingOverlay();
     }
 
     void RvDocument::showEvent(QShowEvent* event)
@@ -1995,12 +2037,9 @@ namespace Rv
     {
         QMainWindow::resizeEvent(event);
 
-        // Keep overlay covering entire window when visible
+        // Keep overlay covering entire client area when visible
         if (m_blockingOverlay && m_blockingOverlay->isVisible())
-        {
-            m_blockingOverlay->setGeometry(0, 0, width(), height());
-            m_blockingOverlay->raise();
-        }
+            positionBlockingOverlay();
     }
 
     void RvDocument::setUIBlocked(bool blocked)
@@ -2012,12 +2051,13 @@ namespace Rv
 
         if (blocked)
         {
-            // Cover entire window
-            m_blockingOverlay->setGeometry(0, 0, width(), height());
-            m_blockingOverlay->raise(); // Bring to front, above everything
+            // Cover entire client area (top-level window, global coords)
+            positionBlockingOverlay();
             m_blockingOverlay->show();
+            m_blockingOverlay->raise(); // Bring to front, above everything
 
             // Grab focus to also block keyboard input
+            m_blockingOverlay->activateWindow();
             m_blockingOverlay->setFocus(Qt::OtherFocusReason);
         }
         else

--- a/src/lib/app/mu_rvui/mode_manager.mu
+++ b/src/lib/app/mu_rvui/mode_manager.mu
@@ -767,8 +767,40 @@ class: ModeManagerMode : MinorMode
 
         let vnode = viewNode(),
             vtype = nodeType(vnode),
-            name  = if vtype.substr(0,2) == "RV" then vtype.substr(2,0) + "_edit_mode" else "",
-            entry = findModeEntry(name);
+            name  = if vtype.substr(0,2) == "RV" then vtype.substr(2,0) + "_edit_mode" else "";
+
+        //
+        //  Avoid redundant deactivate->reactivate churn when the view-edit-mode
+        //  is not actually changing. Toggling an edit mode is expensive (it
+        //  rebuilds menus/event tables), and clearSession re-sets the same
+        //  default view twice with force=true -- so without this the same edit
+        //  mode is toggled off then on up to four times per clear for no net
+        //  change. On the 'before' event, event.contents() holds the node we
+        //  are switching TO while viewNode() is still the OLD view; if both map
+        //  to the same edit mode, skip the deactivation. The matching 'after'
+        //  event then finds the mode already active and no-ops in activateEntry.
+        //
+        if (!on)
+        {
+            try
+            {
+                let toName = event.contents();
+                if (toName != "")
+                {
+                    let toType     = nodeType(toName),
+                        toEditMode = if toType.substr(0,2) == "RV"
+                                        then toType.substr(2,0) + "_edit_mode"
+                                        else "";
+                    if (toEditMode == name)
+                    {
+                        return;
+                    }
+                }
+            }
+            catch (exception exc) { let ignore = exc; }
+        }
+
+        let entry = findModeEntry(name);
 
         if (entry neq nil)
         {

--- a/src/lib/app/py_rvui/rv/qtutils.py
+++ b/src/lib/app/py_rvui/rv/qtutils.py
@@ -36,12 +36,16 @@ def sessionWindow():
 
 def sessionGLView():
     """
-    Returns the QOpenGLWidget for the current RV session GL view.
+    Returns the QWidget hosting the current RV session GL view.
+
+    Note: as of the native-GL-window change (Direction C) the session view is a
+    plain QWidget host (it embeds the GL surface via createWindowContainer), no
+    longer a QOpenGLWidget.
     """
 
     rvPyLongPtr = rv.commands.sessionGLView()
     if rvPyLongPtr is not None:
-        return wrapInstance(rvPyLongPtr, QOpenGLWidget)
+        return wrapInstance(rvPyLongPtr, QWidget)
     else:
         return None
 

--- a/src/lib/ip/IPCore/Session.cpp
+++ b/src/lib/ip/IPCore/Session.cpp
@@ -2261,20 +2261,18 @@ namespace IPCore
     void Session::askForRedraw(bool force)
     {
         if (m_beingDeleted)
+        {
             return;
+        }
 
         m_wantsRedraw = true;
 
-        if (!isPlaying())
-        {
-            if (!m_stopTimer.isRunning())
-            {
-                m_stopTimer.stop();
-                m_stopTimer.start();
-                App()->startPlay(this);
-                send(startPlayMessage());
-            }
-        }
+        //
+        //  Non-playback redraws only need a single frame update via d->redraw()
+        //  below. Starting the 2s m_stopTimer/startPlay settle window kept
+        //  isUpdating() true and starved Qt6 QWebChannel delivery during spam
+        //  clicks, without providing further redraw work once wantsRedraw clears.
+        //
 
         if (!isRendering() || force)
         {
@@ -3223,7 +3221,24 @@ namespace IPCore
         //  This is the "heartbeat" entry point in the session
         //
 
-        if (force || isUpdating() || m_rangeDirty)
+        if (m_stopTimer.isRunning() && !isPlaying())
+        {
+            if (!m_wantsRedraw && !isEvalRunning() && !isBuffering() && !currentStateIsError())
+            {
+                stopCompletely();
+            }
+            else if (m_stopTimer.elapsed() > 2.0 && !isEvalRunning() && !isBuffering() && !currentStateIsError())
+            {
+                stopCompletely();
+            }
+        }
+
+        //
+        //  During non-playback settle, only redraw when something actually
+        //  requested it. The old isUpdating() guard repainted at heartbeat
+        //  rate for ~2s even with wantsRedraw=false, starving Qt6 QWebChannel.
+        //
+        if (force || isPlaying() || m_wantsRedraw || m_rangeDirty)
         {
             if (multipleVideoDevices() && outputVideoDevice()->willBlockOnTransfer()
                 && (outputVideoDevice()->capabilities() & TwkApp::VideoDevice::ASyncReadBack))


### PR DESCRIPTION
> **Credit:** the viewport refactor at the heart of this PR is **Cédrik Fuoco's** work — moving the
> RV viewport off `QOpenGLWidget` and onto a native `QOpenGLWindow`, and every knock-on change that
> followed from it (context sharing, presentation/second-output, blocking overlay). The additional
> commits here are the startup-ordering fix and documentation on top of that foundation.

### Linked issues

No GitHub issue — tracked internally as **SG-43585**

### Summarize your change.

After the Qt5 → Qt6 migration, JS ↔ Python web-panel bridge round-trips (`pyevaluate` / `pyexec`)
became slow whenever the JavaScript handler did real RV work such as `clearSession()` /
`addSourceVerbose()`. The bridge is delivered synchronously on the Qt main (GUI) thread, so any
redundant work RV does on that thread directly delays queued bridge calls.

**Nothing about the bridge itself changed between Qt5 and Qt6** — QWebChannel, QtWebEngine, the
2-second `askForRedraw()` settle window and the 120 Hz heartbeat are all identical in both trees.
The one difference that matters is that `QGLWidget` was removed in Qt6, so the viewport became a
`QOpenGLWidget`. A `QOpenGLWidget` renders to an offscreen FBO and forces the whole top-level window
onto the OpenGL/RHI path, so *every* viewport repaint recomposites *every* widget in the window —
toolbars, docks, and the web panel — and presents the whole window. Same redundant redraws as Qt5,
roughly 10× the cost each, on exactly the thread the bridge needs.

This PR gives the viewport its own surface back: it now renders as a native `QOpenGLWindow` (new
`GLWindow`) embedded via `QWidget::createWindowContainer`. `GLView` becomes a plain `QWidget` facade
that delegates to it, so nothing outside `RvCommon` had to change.

Measured with the `mre_plugin` reproducer at a 150 ms interactive cadence (playback + real session
work in the handler):

| Platform | Before | After | |
|---|---|---|---|
| Linux (X11) | ~15 ms | **~1.4 ms** | ~10× |
| macOS | ~7 ms | **~0.9 ms** | ~8× |
| Windows | — | not measured | |

### Describe the reason for the change.

A user reported that web-panel bridge calls became slow after the Qt6 migration. A three-way
isolation on Linux at interactive cadence pinned the cause to the surface, not the bridge and not
the repaint count:

| Tree | What it is | mean latency |
|---|---|---|
| A (`main`) | `QOpenGLWidget` viewport | ~15 ms |
| B | one-line heartbeat fix, still `QOpenGLWidget` | ~15 ms |
| C (this PR) | native GL window + ordering fix | **~1.4 ms** |

**B − A ≈ 0**, **C − B ≈ −13.6 ms.** The entire win is the surface change. A separate one-line
heartbeat fix (`isUpdating()` → `isPlaying() || m_wantsRedraw`) was evaluated and deliberately
**not** included here: it measured no benefit at interactive cadence, and it risks stopping
animation for anything that redraws during the settle window without calling `askForRedraw()` each
frame (cache/buffer progress indicators first). It can land separately on its own merits.

### Describe what you have tested and on which operating system.

**Windows (Release)** — the viewport refactor itself: flat bridge latency under playback spam, all
web panels render docked, and viewport / events / drag-and-drop / annotations / presentation /
blocking-overlay all work.

**Linux (X11)** — launches cleanly, docked `QWebEngineView` works, media loads; bridge latency
measured 15 → 1.4 ms at 150 ms cadence.

**macOS** — launches cleanly, session init/teardown and media load work, docked `QWebEngineView`
works; bridge latency measured 7 → 0.9 ms.

**Not yet covered — please weigh this in review:**

- **Windows has not been re-exercised since the startup-ordering commit**, which changes launch
  ordering. It is also the platform whose synchronous `initializeGL()` masked both original startup
  bugs, so it is the most likely place for a surprise.
- macOS feature sweep and an HDPI / mixed-DPI multi-monitor pass are still pending.
- Presentation mode / second output was reworked to share a context explicitly and wants an
  end-to-end test on real multi-display hardware.

### Add a list of changes, and note any that might need special attention during the review.

**The refactor**

- **New `GLWindow : QOpenGLWindow`** (`GLWindow.h/.cpp`, 372 new lines) — takes over `initializeGL`,
  `resizeGL`, `paintGL`, `event`, `eventProcessingTimeout`, `absolutePosition`, `readPixels`,
  `stopProcessingEvents`, `firstPaintCompleted`, `devicePixelRatioF`.
- **`GLView` becomes a plain `QWidget` facade** (−748 lines) — keeps `sizeHint`,
  `minimumSizeHint`, `rvGLFormat`, `setContentSize`; everything else forwards to `m_glWindow`. Its
  public surface is unchanged, so no caller outside `RvCommon` was touched.
- **`QTGLVideoDevice` gains a window-backed path** — two constructors, `m_view` XOR `m_window`, plus
  backing-agnostic `glShareContext()` / `glSurfaceFormat()` so callers no longer care which backing
  the control view uses.

**Knock-on changes forced by the new surface** — these are the parts most worth a careful read:

1. **`Qt::AA_ShareOpenGLContexts`** is now set before the `QApplication` (a documented QtWebEngine
   requirement). It also lets second-output and upload-worker GL surfaces share with the viewport
   without an ordering-sensitive `setShareContext()`, and retires a null-context dereference that
   crashed with *Multithread GPU Upload* enabled.
2. **Presentation / second output** — `DesktopVideoDevice::open()` no longer dereferences the control
   device's (now-null) `QOpenGLWidget`; `ScreenView` shares a `QOpenGLContext` through the new
   accessors.
3. **UI blocking overlay** reworked from a raster child widget into a frameless translucent
   **top-level window**. A native window renders above sibling raster widgets regardless of `raise()`
   order, so the old overlay could no longer dim the viewport.

**Startup-ordering fix** — `RvDocument::initializeSession()` used to run from
`GLWindow::initializeGL()`, so constructing the `RvSession` (and loading every package, which runs Mu
and Python) depended on when Qt delivered the viewport's first expose. The platforms disagree on
that: on macOS a `QOpenGLWindow` has no GL context until first exposed, so the session was built with
no current context and aborted in `IPCore::Shader::initGLSLVersion()`; on Linux/X11 `show()` is
async, so `doc->session()` returned null a few lines later and RV segfaulted in
`Session::queryAndStoreGLInfo()` with `this == nullptr` (confirmed under gdb); Windows appeared to
escape both because `initializeGL()` fires synchronously during construction there. Now
`RvApplication::newSessionFromFiles()` calls `initializeSession()` right after `show()`, and
`initializeSession()` makes the viewport context current itself. There is a single `RvDocument`
creation site, so that is the whole ordering, and `initializeGL()` no longer calls back into the
document.

**`QT_QUICK_BACKEND=software` — deliberately asymmetric, please do not "clean this up":**

- `src/bin/apps/rv/main.cpp` (Windows, Linux) — the block is dropped. It was already commented out,
  and Linux has since confirmed the setting is not needed.
- `src/bin/nsapps/RV/main.cpp` (macOS) — the setting **stays and is load bearing.** The viewport
  window is a `QObject` child of the top-level's `QWidgetWindow`; with the hardware Qt Quick backend,
  adding a `QWebEngineView` makes Qt destroy and recreate that native subtree, deleting the embedded
  window rather than reparenting it, after which Qt's own `QWindowContainer` dereferences the window
  it lost. Measured with the four-line reproducer now quoted in the comment: **software survives 2/2,
  hardware crashes 2/2.** The cost is that macOS web panels composite in software — macOS gets the
  cheap-viewport half of this win, not the hardware-web-panel half.

**Also in the diff:** crashpad's MSVC toolset is pinned to the parent build (fixes an LNK2019).

**Known risk areas for review**

- **Native-window vs widget stacking.** Anything that assumed it could draw over the viewport as a
  sibling widget needs checking — the blocking overlay already had to become a top-level window.
  Annotations, HUD-style widgets and full-screen transitions are the places to look.
- **HDPI.** Coordinate translation now goes through the container widget while rendering goes through
  the window, so `devicePixelRatio` paths deserve a mixed-DPI pass.
- **Windows startup ordering**, per the testing section above.

### If possible, provide screenshots.

A slide deck walking through the refactor class by class is attached: **`SG-43585_viewport_refactor.pptx`**.

[SG-43585_viewport_refactor.pptx](https://github.com/user-attachments/files/30909677/SG-43585_viewport_refactor.pptx)

