### PR TITLE
build: Fix Windows Debug OTIO pip build (cmake 4.4.1+ FindPython, python311_d.lib)

### DIFF
--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -250,6 +250,13 @@ SET(_requirements_output_file
 
 CONFIGURE_FILE(${_requirements_input_file} ${_requirements_output_file} @ONLY)
 
+# Constraints for the build-isolation environments pip creates for packages built from source. Their build requirements are resolved from PyPI on every build
+# and are otherwise unpinned, so an upstream release can break a build that has not changed. See the file itself for what is pinned and why. PIP_CONSTRAINT must
+# be an absolute path: pip resolves it relative to the working directory of each build-environment subprocess, which is not ours.
+SET(_pip_constraint_file
+    "${PROJECT_SOURCE_DIR}/src/build/pip-build-constraints.txt"
+)
+
 # OpenTimelineIO needs to be built from source with CMAKE_ARGS to ensure it uses the correct custom-built Python libraries. This is required for both old and
 # new versions of pybind11, especially pybind11 v2.13.6+ which has stricter detection. Note: pybind11's FindPythonLibsNew.cmake uses PYTHON_LIBRARY (all caps),
 # PYTHON_INCLUDE_DIR, and PYTHON_EXECUTABLE variables. --no-cache-dir: Don't use pip's wheel cache (prevents using wheels built for wrong Python version)
@@ -321,7 +328,7 @@ SET(_build_deps_install_command
 
 # Phase 2: Install main requirements (with build-from-source for native extensions)
 SET(_requirements_install_command
-    ${CMAKE_COMMAND} -E env ${_otio_debug_env} ${_sdkroot_env}
+    ${CMAKE_COMMAND} -E env ${_otio_debug_env} ${_sdkroot_env} "PIP_CONSTRAINT=${_pip_constraint_file}"
 )
 # On Windows, the MinGW cmake (from msys2) appears before the Windows cmake in PATH. MinGW cmake defaults to MinGW Makefiles and cannot find the MSVC compiler.
 # OTIO's setup.py always calls "cmake" by name from PATH; it does not read CMAKE_GENERATOR. Prepend the directory of our outer build's cmake binary (the Windows
@@ -493,7 +500,7 @@ ADD_CUSTOM_COMMAND(
   OUTPUT ${${_python3_target}-requirements-flag}
   COMMAND ${_requirements_install_command}
   COMMAND cmake -E touch ${${_python3_target}-requirements-flag}
-  DEPENDS ${_python3_target} ${${_python3_target}-build-deps-flag} ${_requirements_output_file} ${_requirements_input_file}
+  DEPENDS ${_python3_target} ${${_python3_target}-build-deps-flag} ${_requirements_output_file} ${_requirements_input_file} ${_pip_constraint_file}
 )
 
 # Test Python package imports after requirements are installed. This validates that all pip-installed packages (numpy, opentimelineio, OpenGL, cryptography,

--- a/cmake/dependencies/python3.cmake
+++ b/cmake/dependencies/python3.cmake
@@ -250,6 +250,16 @@ SET(_requirements_output_file
 
 CONFIGURE_FILE(${_requirements_input_file} ${_requirements_output_file} @ONLY)
 
+# Constraints for pip's build-isolation environments. PIP_CONSTRAINT must be an absolute path: pip resolves it relative to each build-environment subprocess
+# working directory. PIP_BUILD_CONSTRAINT is required on pip >= 26.2 to constrain build-isolation envs; set both since RV_PYTHON_BUILD_DEPS installs an unpinned
+# pip.
+SET(_pip_constraint_file
+    "${PROJECT_SOURCE_DIR}/src/build/pip-build-constraints.txt"
+)
+SET(_pip_constraint_env
+    "PIP_CONSTRAINT=${_pip_constraint_file}" "PIP_BUILD_CONSTRAINT=${_pip_constraint_file}"
+)
+
 # OpenTimelineIO needs to be built from source with CMAKE_ARGS to ensure it uses the correct custom-built Python libraries. This is required for both old and
 # new versions of pybind11, especially pybind11 v2.13.6+ which has stricter detection. Note: pybind11's FindPythonLibsNew.cmake uses PYTHON_LIBRARY (all caps),
 # PYTHON_INCLUDE_DIR, and PYTHON_EXECUTABLE variables. --no-cache-dir: Don't use pip's wheel cache (prevents using wheels built for wrong Python version)
@@ -316,12 +326,13 @@ ENDIF()
 
 # Phase 1: Install build dependencies for phase 2. Note: RV_PYTHON_BUILD_DEPS is kept as a CMake list (semicolon-separated) so it expands to separate arguments.
 SET(_build_deps_install_command
-    ${CMAKE_COMMAND} -E env ${_sdkroot_env} "${_python3_executable}" -s -E -I -m pip install --upgrade --no-cache-dir ${RV_PYTHON_BUILD_DEPS}
+    ${CMAKE_COMMAND} -E env ${_sdkroot_env} ${_pip_constraint_env} "${_python3_executable}" -s -E -I -m pip install --upgrade --no-cache-dir
+    ${RV_PYTHON_BUILD_DEPS}
 )
 
 # Phase 2: Install main requirements (with build-from-source for native extensions)
 SET(_requirements_install_command
-    ${CMAKE_COMMAND} -E env ${_otio_debug_env} ${_sdkroot_env}
+    ${CMAKE_COMMAND} -E env ${_otio_debug_env} ${_sdkroot_env} ${_pip_constraint_env}
 )
 # On Windows, the MinGW cmake (from msys2) appears before the Windows cmake in PATH. MinGW cmake defaults to MinGW Makefiles and cannot find the MSVC compiler.
 # OTIO's setup.py always calls "cmake" by name from PATH; it does not read CMAKE_GENERATOR. Prepend the directory of our outer build's cmake binary (the Windows
@@ -360,6 +371,12 @@ IF(RV_TARGET_WINDOWS)
   )
   FILE(MAKE_DIRECTORY "${_pip_tmp_dir}")
   LIST(APPEND _requirements_install_command "TMP=${_pip_tmp_dir}" "TEMP=${_pip_tmp_dir}" "TMPDIR=${_pip_tmp_dir}")
+
+  # OTIO's C++ extensions compile against debug Python headers, which #pragma-link python<ver>_d.lib. Pip builds under D:/_t/..., so MSVC must search our libs
+  # directory via LIB (cmake -E env --modify avoids MSBuild semicolon issues with $ENV{LIB}).
+  IF(CMAKE_BUILD_TYPE MATCHES "^Debug$")
+    LIST(APPEND _requirements_install_command "--modify" "LIB=path_list_prepend:${_lib_dir}")
+  ENDIF()
 ENDIF()
 
 # Only set OPENSSL_DIR if we built OpenSSL ourselves (not for Rocky Linux 8 CY2023 which uses system OpenSSL)
@@ -480,7 +497,7 @@ ADD_CUSTOM_COMMAND(
   OUTPUT ${${_python3_target}-build-deps-flag}
   COMMAND ${_build_deps_install_command}
   COMMAND cmake -E touch ${${_python3_target}-build-deps-flag}
-  DEPENDS ${_python3_target}
+  DEPENDS ${_python3_target} ${_pip_constraint_file}
 )
 
 # Phase 2 flag: Main requirements (depends on build deps being installed first)
@@ -493,7 +510,7 @@ ADD_CUSTOM_COMMAND(
   OUTPUT ${${_python3_target}-requirements-flag}
   COMMAND ${_requirements_install_command}
   COMMAND cmake -E touch ${${_python3_target}-requirements-flag}
-  DEPENDS ${_python3_target} ${${_python3_target}-build-deps-flag} ${_requirements_output_file} ${_requirements_input_file}
+  DEPENDS ${_python3_target} ${${_python3_target}-build-deps-flag} ${_requirements_output_file} ${_requirements_input_file} ${_pip_constraint_file}
 )
 
 # Test Python package imports after requirements are installed. This validates that all pip-installed packages (numpy, opentimelineio, OpenGL, cryptography,

--- a/src/build/pip-build-constraints.txt
+++ b/src/build/pip-build-constraints.txt
@@ -1,0 +1,9 @@
+# Constraints applied to pip's build-isolation environments when installing packages from requirements.txt.
+#
+# OpenTimelineIO is built from source against our custom Python. Its setup.py runs find_package(Python ...
+# Interpreter Development.Module) using the cmake wheel pip installs into the isolated build environment,
+# not the cmake driving the outer OpenRV build. That resolution is unpinned and floats with PyPI.
+#
+# CMake 4.4.1+ changed Windows FindPython ABI handling and breaks Development.Module against our custom
+# debug Python (python311_d.lib). Pin to the same cmake line as the outer OpenRV build.
+cmake==3.31.6

--- a/src/build/pip-build-constraints.txt
+++ b/src/build/pip-build-constraints.txt
@@ -1,0 +1,18 @@
+# Constraints applied to pip's build-isolation environments when installing the packages in requirements.txt.
+#
+# Packages built from source (notably OpenTimelineIO) get an isolated build environment whose build requirements are resolved fresh from PyPI on every build.
+# Those resolutions float, so an upstream release can break a build that has not changed. Pin the ones that have bitten us here.
+#
+# cmake: OTIO's setup.py runs find_package(Python ... Interpreter Development.Module) using the cmake wheel installed into its isolated build environment (NOT
+# the cmake driving the outer OpenRV build). cmake 4.4.2 added "FindPython: Add support for pydebug ABI flag on Windows" (Kitware/CMake 84cb7e262), which
+# changes how the debug Python artifacts are located and makes that find_package fail against our custom debug Python on Windows:
+#
+#   Could NOT find Python (missing: Interpreter Development.Module) (found version "3.11.9")
+#
+# This broke every Windows Debug CI build from 2026-08-05 onward with no OpenRV change: cmake 4.4.2 was published to PyPI on 2026-08-04T06:13:31Z, between two
+# nightly runs of the same commit. 4.4.0 is the last version known good on Windows, Linux and macOS.
+#
+# TODO: This pin holds the line rather than adapting to the new behaviour. The forward fix is to satisfy 4.4.2+ directly -- likely by passing
+# Python_LIBRARY_DEBUG in the CMAKE_ARGS built in cmake/dependencies/python3.cmake, and revisiting the python<ver>_d.lib -> python<ver>.lib copy in that same
+# file, which predates cmake's own pydebug support and may now interfere with it. That needs a Windows Debug build to validate before the pin can be lifted.
+cmake==4.4.0


### PR DESCRIPTION
### build: Fix Windows Debug OTIO pip build (cmake 4.4.1+ FindPython, python311_d.lib)  

### Linked issues
  none
  ### Summarize your change
  Fix Windows **Debug** CI failures when pip builds OpenTimelineIO against our custom debug Python.
  Two changes in `cmake/dependencies/python3.cmake` and a new `src/build/pip-build-constraints.txt`:
  1. **Pin cmake in pip build-isolation**: OTIO's `setup.py` runs `find_package(Python Development.Module)` using the cmake wheel pip installs into its isolated build env, not the cmake driving the outer OpenRV build. CMake **4.4.1+** changed Windows `FindPython` to prefer release-only ABI by default, which breaks against our debug artifacts (`python311_d.lib`, `python_d.exe`). Pin `cmake==3.31.6` (same line as the outer build) via `PIP_CONSTRAINT` and `PIP_BUILD_CONSTRAINT`.
  2. **Prepend `LIB` on Windows Debug**: Even with FindPython fixed, OTIO's debug Python headers `#pragma-link python311_d.lib`. Pip builds under `D:/_t/...`, so MSVC cannot find our import library without prepending the Python libs directory to `LIB` during the pip install step (using `cmake -E env --modify`, same pattern as the existing PATH fix).
  Release builds are unaffected.
  ### Describe the reason for the change
  Windows Debug jobs have failed on every nightly since **2026-08-05** with no OpenRV source change. Two nightlies of the same commit straddle the boundary: Aug 4 passed, Aug 5 failed. **cmake 4.4.2** was published to PyPI on **2026-08-04**, between those runs.