### PR TITLE
fix: crashpad_handler corrupted by install-time strip on Rocky Linux 8

### DIFF
--- a/cmake/install/pre_install_linux.cmake
+++ b/cmake/install/pre_install_linux.cmake
@@ -46,6 +46,11 @@ SET(STRIP_IGNORE_LIST
     "zip"
 )
 
+# Resolved at file scope (not inside the function) so it does not depend on which listfile is executing when after_copy_platform() is called.
+SET(RV_STRIP_DEBUG_SAFE_SCRIPT
+    "${CMAKE_CURRENT_LIST_DIR}/../scripts/strip_debug_safe.sh"
+)
+
 FUNCTION(after_copy_platform FILE_PATH FILES_TO_FIX_RPATH)
   IF(CMAKE_INSTALL_CONFIG_NAME MATCHES "^Release$")
     EXECUTE_PROCESS(
@@ -54,12 +59,35 @@ FUNCTION(after_copy_platform FILE_PATH FILES_TO_FIX_RPATH)
     )
     IF(${FILE_CMD_OUT} MATCHES ": application\/(.+)\n")
       IF(NOT "${CMAKE_MATCH_1}" IN_LIST STRIP_IGNORE_LIST)
-        EXECUTE_PROCESS(
-          COMMAND strip -S ${FILE_PATH}
-          RESULT_VARIABLE STRIP_EXIT_CODE
+        # Saved before any later MATCHES below, which would overwrite CMAKE_MATCH_1 and put the wrong mime type in the warning message.
+        SET(_rv_mime_subtype
+            "${CMAKE_MATCH_1}"
         )
-        IF(NOT STRIP_EXIT_CODE EQUAL 0)
-          MESSAGE(WARNING "Unable to strip ${FILE_PATH} with mime type application/${CMAKE_MATCH_1}. Consider adding it to the ignore list.")
+        # strip_debug_safe.sh (not a bare `strip -S`) guards against a GNU strip bug that corrupts binaries whose layout makes strip emit "allocated section
+        # `.dynstr' not in segment": strip relocates .dynstr to the end of the file while leaving its virtual address inside a PT_LOAD segment that no longer
+        # covers it, so at runtime the whole dynamic string table reads as zeros. The binary then fails to load with exit 127. strip exits 0 while doing this,
+        # so the previous RESULT_VARIABLE check could not catch it.
+        #
+        # This mattered in practice: `strip -S` here silently destroyed bin/crashpad_handler in the packaged Linux build, which is why RV reported "Failed to
+        # start Crashpad handler" / "Failed to initialize crash handler" from installed packages while the same build ran fine out of the stage tree (the stage
+        # tree never goes through install). PySide6's lupdate is affected the same way. Both keep their debug info now; the size cost is negligible because such
+        # binaries carry little or no DWARF. See also cmake/macros/rv_stage.cmake, which uses the same guard for RV's own targets.
+        EXECUTE_PROCESS(
+          COMMAND bash ${RV_STRIP_DEBUG_SAFE_SCRIPT} ${FILE_PATH}
+          RESULT_VARIABLE STRIP_EXIT_CODE
+          ERROR_VARIABLE STRIP_ERROR_OUT
+        )
+        # The guard always exits 0, so the file-was-left-alone signal is its stderr, not the exit code. Report the known-benign ".dynstr not in segment" skip at
+        # STATUS (expected, by design, nothing to action), and keep everything else at WARNING so a genuine strip failure stays as visible as it was before.
+        IF(STRIP_EXIT_CODE EQUAL 0
+           AND STRIP_ERROR_OUT MATCHES "not in segment"
+        )
+          MESSAGE(STATUS "${STRIP_ERROR_OUT}")
+        ELSEIF(
+          NOT STRIP_EXIT_CODE EQUAL 0
+          OR STRIP_ERROR_OUT
+        )
+          MESSAGE(WARNING "Unable to strip ${FILE_PATH} with mime type application/${_rv_mime_subtype}. Consider adding it to the ignore list.")
         ENDIF()
       ENDIF()
     ENDIF()


### PR DESCRIPTION
## Problem

Packaged Linux Release builds shipped an **unloadable** `bin/crashpad_handler`, so RV printed this at every launch on Rocky Linux 8:

```
ERROR: Failed to start Crashpad handler
ERROR: Failed to initialize crash handler
```

The shipped binary cannot be executed at all — it fails with exit 127 — so `CrashpadClient::StartHandler()` fails and no crash dumps are ever captured.

## Root cause

`after_copy_platform()` in `cmake/install/pre_install_linux.cmake` ran a bare `strip -S` on every installed ELF. On binaries whose layout makes GNU strip emit

```
warning: allocated section `.dynstr' not in segment
```

strip relocates `.dynstr` to the end of the file but leaves its virtual address unchanged, so no `PT_LOAD` covers it any more:

| | `.dynstr` addr | file offset | first `LOAD` filesz |
|---|---|---|---|
| healthy | `0x3ff5b0` | `0x0005b0` ✅ | `0x1000` |
| as shipped | `0x3ff5b0` | `0x0ce5b0` ❌ | `0x5b0` |

At runtime `0x3ff5b0` maps from file offset `0x5b0`, which is now all zeros, so every library/symbol/version name reads as an empty string. **strip exits 0 while doing this**, which is why the existing `RESULT_VARIABLE` check could not catch it.

`crashpad_handler` is exposed because `cmake/dependencies/crashpad.cmake` runs `patchelf --set-rpath` on it. patchelf has no `DT_RUNPATH` to overwrite, so it grows `.dynstr` and inserts a new RW `PT_LOAD` below the image base, leaving `.dynstr` straddling a segment boundary. The pristine pre-patchelf binary is well formed. It is the only patchelf'd binary in `bin/`, which is why the neighbouring Breakpad tools strip fine.

## Fix

Use the existing `cmake/scripts/strip_debug_safe.sh` guard instead of a bare `strip -S`, exactly as `cmake/macros/rv_stage.cmake` already does for RV's own targets. It strips to a temp copy and only replaces the original when strip is warning- and error-free.

The mime-type ignore list could not be used: `crashpad_handler` is plain `application/x-executable` like every other RV binary.

## Verification

Root cause proven three ways:

1. `strip -S` on a known-good handler reproduces a byte-identical corruption signature and turns exit 0 into exit 127.
2. Moving `.dynstr` back to offset `0x5b0` in the shipped binary — a single ELF field edit, nothing else — makes it work again.
3. End to end: the shipped build prints both errors and captures 0 dumps; with a repaired handler it prints `INFO: Crash handler initialized successfully` and captures a real 589664-byte minidump.

## Blast radius

Linux only, Release installs only, no runtime/C++ changes. Measured over the full staged tree (803 strip candidates):

- **796** strip cleanly and are **byte-identical** to the previous in-place `strip -S` output (md5-verified sample including `rv.bin`, `libQt6Core.so.6`, `dump_syms`)
- **2** real ELFs now left unstripped: `bin/crashpad_handler` and `PySide6/lupdate` — both were shipping corrupted
- **5** non-ELF files already failed and were already left untouched; outcome unchanged

Net package size impact is **-26712 bytes** — "stripping" those two binaries was *growing* them. Normal stripping is unaffected (`dump_syms` 9596480 -> 453976, matching the shipped size). File modes are preserved (`755`, `644`, `664` all verified) and the step is idempotent.

## Platform note

Only Rocky 8 was affected in the field. Rocky 9's strip leaves both binaries alone instead of mis-writing them, so its packages were already healthy — confirmed with same-version, same-day Rocky 8 and Rocky 9 artifacts (Rocky 8: 2 corrupted files; Rocky 9: 0). Rocky 9 has therefore been shipping these two binaries unstripped all along; this change makes Rocky 8 consistent with that rather than changing Rocky 9.

Because the guard always exits 0, genuine strip failures would have been downgraded from `WARNING` to `STATUS`. The known-benign `.dynstr not in segment` skip is reported at `STATUS` and everything else stays at `WARNING`. `CMAKE_MATCH_1` is saved beforehand, since the added `MATCHES` would otherwise clobber the mime type in that warning message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)