### PR TITLE
build: SG-44926: add PySide6 fallback mappings for clang 18 through 22

### DIFF
--- a/src/build/make_pyside6.py
+++ b/src/build/make_pyside6.py
@@ -104,6 +104,16 @@ def prepare() -> None:
                 return "15.0.0-based-macos-universal.7z"
             elif major_minor_version_str == "17.0":
                 return "17.0.1-based-macos-universal.7z"
+            elif major_minor_version_str == "18.0":
+                return "18.1.7-based-macos-universal.7z"
+            elif major_minor_version_str == "19.0":
+                return "19.1.6-based-macos-universal.7z"
+            elif major_minor_version_str == "20.0":
+                return "20.1.3-based-macos-universal.7z"
+            elif major_minor_version_str == "21.0":
+                return "21.1.2-based-macos-universal.7z"
+            elif major_minor_version_str == "22.0":
+                return "22.1.2-based-macos-universal.7z"
             return None
 
         clang_version = get_clang_version()


### PR DESCRIPTION
### Linked issues

None — small additive build fix.

### Summarize your change.

Adds PySide6 fallback filename mappings for clang major versions 18 through 22 in `get_fallback_clang_filename_suffix()`.
Adds the 18.0 through 22.0 entries following the existing pattern. Purely additive - no existing mapping is changed, so behavior on clang 17 and older is unaffected.

### Describe the reason for the change.

get_fallback_clang_filename_suffix() stops at clang 17, so a newer toolchain falls through with None and no matching universal PySide6 build is resolved. Xcode 16 ships clang 18 and Xcode 26 ships clang 21, so this affects any current macOS toolchain.

The dispatch stopped at clang 17 and returned `None` for anything newer, so no fallback PySide6 universal build was resolved on any current macOS toolchain. Xcode 16 ships Apple clang 18; Xcode 26 ships Apple clang 21.

### Describe what you have tested and on which operating system.

Built on macOS 26.5.1 (arm64) with Apple clang 21.0.0 (clang-2100.1.1.101),
Xcode 26.6. The clang 21 path is the one exercised directly.

The 18.0, 19.0, 20.0 and 22.0 entries follow the same naming scheme as the existing entries but have not been built against those toolchains — happy to narrow this to just 21.0 if you would rather only land what is verified.

Not tested on Linux or Windows. The change is inside the macOS branch of the function, so other platforms are unaffected.

### Add a list of changes, and note any that might need special attention during the review.

- `src/build/make_pyside6.py`: five `elif` branches added to `get_fallback_clang_filename_suffix()`. 10 insertions, 0 deletions.
 
Worth a reviewer's attention: the PySide6 build strings for 18–22 follow the established convention, but please confirm those artifacts exist for each version.

### If possible, provide screenshots.