### PR TITLE
build: Fix stale FFmpeg libs not restaged after decoder config change

### DIFF
--- a/cmake/dependencies/ffmpeg.cmake
+++ b/cmake/dependencies/ffmpeg.cmake
@@ -193,11 +193,6 @@ IF(FALSE)
   LIST(APPEND RV_FFMPEG_COMMON_CONFIG_OPTIONS "--disable-stripping")
 ENDIF()
 
-# Controls the EXTERNALPROJECT_ADD/BUILD_ALWAYS option
-SET(${_force_rebuild}
-    FALSE
-)
-
 IF(RV_TARGET_APPLE_ARM64)
   SET(RV_FFMPEG_USE_VIDEOTOOLBOX_DEFAULT_VALUE
       ON
@@ -295,16 +290,6 @@ IF(NOT RV_FFMPEG_CONFIG_OPTIONS)
   SET(RV_FFMPEG_CONFIG_OPTIONS
       ${_disabled_decoders} ${_disabled_encoders} ${_disabled_filters} ${_disabled_parsers} ${_disabled_protocols}
   )
-
-  IF(NOT RV_FFMPEG_CONFIG_OPTIONS STREQUAL RV_FFMPEG_CONFIG_OPTIONS_CACHE)
-    SET(${_force_rebuild}
-        TRUE
-    )
-    SET(RV_FFMPEG_CONFIG_OPTIONS_CACHE
-        ${RV_FFMPEG_CONFIG_OPTIONS}
-        CACHE STRING "FFmpeg config options" FORCE
-    )
-  ENDIF()
 ENDIF()
 
 LIST(REMOVE_DUPLICATES RV_FFMPEG_DEPENDS)
@@ -367,7 +352,6 @@ EXTERNALPROJECT_ADD(
   BUILD_COMMAND ${_make_command} -j${_cpu_count}
   INSTALL_COMMAND ${_make_command} install
   BUILD_IN_SOURCE TRUE
-  BUILD_ALWAYS ${_force_rebuild}
   BUILD_BYPRODUCTS ${_build_byproducts}
   USES_TERMINAL_BUILD TRUE
 )

--- a/cmake/macros/rv_stage_dependency_libs.cmake
+++ b/cmake/macros/rv_stage_dependency_libs.cmake
@@ -130,6 +130,7 @@ FUNCTION(RV_STAGE_DEPENDENCY_LIBS)
      AND NOT _ARG_OUTPUTS
   )
     SET(_rsdl_resolved_outputs)
+    SET(_rsdl_source_files)
     SET(_rsdl_failed
         FALSE
     )
@@ -142,6 +143,7 @@ FUNCTION(RV_STAGE_DEPENDENCY_LIBS)
       RV_RESOLVE_IMPORTED_LOCATION(${_rsdl_tgt} _rsdl_loc _rsdl_resolved_tgt)
 
       IF(_rsdl_loc)
+        LIST(APPEND _rsdl_source_files "${_rsdl_loc}")
         GET_FILENAME_COMPONENT(_rsdl_fname "${_rsdl_loc}" NAME)
         IF(RV_TARGET_WINDOWS)
           LIST(APPEND _rsdl_resolved_outputs "${RV_STAGE_BIN_DIR}/${_rsdl_fname}")
@@ -157,6 +159,7 @@ FUNCTION(RV_STAGE_DEPENDENCY_LIBS)
             ENDIF()
           ENDFOREACH()
           IF(_rsdl_implib)
+            LIST(APPEND _rsdl_source_files "${_rsdl_implib}")
             GET_FILENAME_COMPONENT(_rsdl_impfname "${_rsdl_implib}" NAME)
             LIST(APPEND _rsdl_resolved_outputs "${_ARG_STAGE_LIB_DIR}/${_rsdl_impfname}")
           ENDIF()
@@ -513,6 +516,18 @@ FUNCTION(RV_STAGE_DEPENDENCY_LIBS)
     SET(_tracking_outputs
         ${_ARG_OUTPUTS}
     )
+    # Mark the staged files as up to date. Without this, any file that copy_if_different skipped (because it was already identical) keeps its old timestamp, so
+    # the build system still sees this step as pending and re-runs the whole staging on every build. touch_nocreate is used rather than touch so a file that
+    # failed to stage is never replaced by an empty placeholder.
+    LIST(
+      APPEND
+      _commands
+      COMMAND
+      ${CMAKE_COMMAND}
+      -E
+      touch_nocreate
+      ${_tracking_outputs}
+    )
   ELSE()
     MESSAGE(FATAL_ERROR "RV_STAGE_DEPENDENCY_LIBS: Either OUTPUTS or USE_FLAG_FILE is required")
   ENDIF()
@@ -523,7 +538,7 @@ FUNCTION(RV_STAGE_DEPENDENCY_LIBS)
   ADD_CUSTOM_COMMAND(
     COMMENT "Staging ${_ARG_TARGET} libs into ${_ARG_STAGE_LIB_DIR}"
     OUTPUT ${_tracking_outputs} ${_commands}
-    DEPENDS ${_ARG_DEPENDS}
+    DEPENDS ${_ARG_DEPENDS} ${_rsdl_source_files}
     VERBATIM
   )
 


### PR DESCRIPTION
### Linked issues

Related to #689 (may also need a docs fix for the `prores_ks` vs `prores` decoder name).

### Summarize your change.

When a developer reconfigures with a changed `RV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE`
(e.g. `rvcfg -DRV_FFMPEG_NON_FREE_DECODERS_TO_ENABLE="aac"`) and rebuilds, the freshly
rebuilt FFmpeg libraries were never copied into the stage directory, so the running app
kept using the old binaries with the decoder still disabled.

### Describe the reason for the change.

**1. Staging never re-ran (the reported bug).**
`RV_STAGE_DEPENDENCY_LIBS` (in `cmake/macros/rv_stage_dependency_libs.cmake`) staged
FFmpeg's libraries via a custom command whose `DEPENDS` only referenced the
`RV_DEPS_FFMPEG` `ExternalProject` target name. CMake only creates an order-only
dependency for a target like this (not an executable/library), so once the staged
output filenames already existed from a prior build, Ninja considered the copy command
up to date and skipped it — even though FFmpeg itself was correctly reconfigured and
rebuilt with the new decoder enabled.

The fix adds the resolved source library paths (the same paths already registered as
`BUILD_BYPRODUCTS` on the FFmpeg `ExternalProject`) to the staging custom command's
`DEPENDS`, giving it a real file-level dependency. This macro is shared by 14 other
dependencies (boost, openssl, zlib, etc.), so they all benefit from the same
correctness fix, not just FFmpeg.

**2. Staged outputs are now touched.**
`copy_if_different` skips the copy when a rebuilt dependency produced byte-identical
output, which would leave the staged files *older* than the sources they now depend on
and keep the staging command dirty on every build. macOS happens to avoid this because
`install_name_tool` + `codesign` always rewrite the staged file, but Linux and Windows
do not (`rv_create_soname_symlink.cmake` only creates a symlink). A final
`cmake -E touch_nocreate` on the staged outputs makes the graph converge on all
platforms.

**3. Removed the dead `_force_rebuild` / `BUILD_ALWAYS` mechanism in `ffmpeg.cmake`.**
`SET(${_force_rebuild} ...)` dereferenced an undefined variable, so `BUILD_ALWAYS` was
silently never set. Actually enabling it turns out to be actively harmful: `BUILD_ALWAYS`
makes CMake mark the ExternalProject build/install stamps `SYMBOLIC` (dropping their
`cmake -E touch`), so FFmpeg's `make` / `make install` re-run on *every* build and dirty
every downstream link edge — a perpetual rebuild loop. It is also unnecessary:
ExternalProject already writes the resolved `CONFIGURE_COMMAND` to `<target>-cfgcmd.txt`
and makes it a file dependency of the configure stamp, and that is what actually
triggers the reconfigure+rebuild when the decoder options change. So the whole mechanism
(including the now-unused `RV_FFMPEG_CONFIG_OPTIONS_CACHE`) is removed, with a comment
to stop it being reintroduced.

### Describe what you have tested and on which operating system.

Tested on macOS (arm64, Ninja, FFmpeg 8):

- `pre-commit run cmake-format` on both changed files.
- Reconfigured and confirmed the FFmpeg build/install ninja edges once again end with
  `cmake -E touch <stamp>` (i.e. `BUILD_ALWAYS` is gone), matching the DAV1D/OpenSSL edges.
- **No-op check:** ran consecutive builds until settled — FFmpeg now contributes
  **0 edges** to an up-to-date build (previously `make install` + staging + ~77 relinks
  every single time). The residual edges in an idle build come from the pre-existing
  `RV_DEPS_IMGUI` git-update cascade, which is unrelated to this PR.
- **Fix still works:** touched `RV_DEPS_FFMPEG/install/lib/libavcodec.62.dylib` and
  confirmed the staging command re-ran and the staged
  `stage/app/RV.app/Contents/lib/libavcodec.62.dylib` was actually refreshed, then that
  the build converged again on the next run.

Not tested: Windows and Linux. In particular the Windows import-lib branch and the
`touch_nocreate` convergence path (which only *matters* on Linux/Windows) were not
exercised locally — worth confirming in CI.

### Add a list of changes, and note any that might need special attention during the review.

- `cmake/macros/rv_stage_dependency_libs.cmake`
  - add resolved `TARGET_LIBS` source paths to the staging `ADD_CUSTOM_COMMAND`'s `DEPENDS`
  - `touch_nocreate` the staged outputs so the graph converges when `copy_if_different` skips
- `cmake/dependencies/ffmpeg.cmake`
  - remove the `_force_rebuild` / `BUILD_ALWAYS` / `RV_FFMPEG_CONFIG_OPTIONS_CACHE` mechanism

Please pay attention to the Linux/Windows behaviour of the two staging changes, since
both were only verified on macOS.

### If possible, provide screenshots.

N/A (build-system change).