### PR TITLE
fix: SG-44910: defer HDPI resize workaround until after window is shown

### DIFF
--- a/src/lib/app/RvCommon/RvCommon/RvDocument.h
+++ b/src/lib/app/RvCommon/RvCommon/RvDocument.h
@@ -152,6 +152,7 @@ namespace Rv
         void changeEvent(QEvent*) override;
         bool event(QEvent*) override;
         void moveEvent(QMoveEvent*) override;
+        void showEvent(QShowEvent*) override;
         void resizeEvent(QResizeEvent*) override;
 
         void setBuildMenu();
@@ -187,6 +188,7 @@ namespace Rv
         bool m_currentlyClosing;
         bool m_closeEventReceived;
         bool m_vsyncDisabled;
+        bool m_hdpiResizeWorkaroundDone;
         RvSourceEditor* m_sourceEditor;
         DisplayLink* m_displayLink;
         QWidget* m_blockingOverlay;

--- a/src/lib/app/RvCommon/RvDocument.cpp
+++ b/src/lib/app/RvCommon/RvDocument.cpp
@@ -143,6 +143,7 @@ namespace Rv
         , m_currentlyClosing(false)
         , m_closeEventReceived(false)
         , m_vsyncDisabled(false)
+        , m_hdpiResizeWorkaroundDone(false)
         , m_oldGLView(0)
         , m_glView(0)
         , m_diagnosticsView(0)
@@ -222,25 +223,6 @@ namespace Rv
 
         m_glView->setFocus(Qt::OtherFocusReason);
         // qApp->installEventFilter(m_glView);
-
-        // #ifdef PLATFORM_DARWIN
-        //  Under macOS, for Qt6/QOpenGLWidget port,
-        //  the initial display shows incorrect pixel
-        //  scaling due to some sort of effect related
-        //  to high-dpi on mac, until the main view is
-        //  resized by the user. This is a workaround
-        //  on macOS to force this resize;
-        //  Also enabling this on other platforms which
-        //  may have HDPI display with pixel doubling
-        //  enabled.
-        QTimer::singleShot(0, this,
-                           [this]()
-                           {
-                               QSize currentSize = size();
-                               resize(currentSize.width() + 1, currentSize.height());
-                               resize(currentSize);
-                           });
-        // #endif
 
         m_resetPolicyTimer = new QTimer(this);
         m_resetPolicyTimer->setSingleShot(true);
@@ -1977,6 +1959,36 @@ namespace Rv
     {
         if (m_session)
             m_session->askForRedraw();
+    }
+
+    void RvDocument::showEvent(QShowEvent* event)
+    {
+        QMainWindow::showEvent(event);
+
+        if (m_hdpiResizeWorkaroundDone)
+            return;
+
+        m_hdpiResizeWorkaroundDone = true;
+
+#if defined(PLATFORM_DARWIN)
+        const bool needWorkaround = true;
+#else
+        const bool needWorkaround = (devicePixelRatio() > 1.0);
+#endif
+
+        if (!needWorkaround)
+            return;
+
+        // Under Qt6/QOpenGLWidget, initial HDPI scaling can be wrong until the
+        // main view is resized once after it is shown. Defer until showEvent so
+        // child widgets (including any QML-backed UI) are fully constructed.
+        QTimer::singleShot(0, this,
+                           [this]()
+                           {
+                               QSize currentSize = size();
+                               resize(currentSize.width() + 1, currentSize.height());
+                               resize(currentSize);
+                           });
     }
 
     void RvDocument::resizeEvent(QResizeEvent* event)


### PR DESCRIPTION
### fix: SG-44910: defer HDPI resize workaround until after window is shown

### Linked issues
NA

### Describe the reason for the change.

- Fixes intermittent Linux startup segfault in `QQmlData::isSignalConnected` triggered from `RvDocument` constructor HDPI resize

### Summarize your change.

- The Qt6 HDPI resize trick was scheduled from the RvDocument constructor, which could race with QML-backed UI startup and crash in QQmlData on Linux. Run it from showEvent instead, and only when HDPI scaling is active.
- Moves the resize workaround to the first `showEvent`, matching the original intent (#709) that it run after the view is shown
- Runs only on macOS or when `devicePixelRatio() > 1.0`

### Describe what you have tested and on which operating system.

Successfully tested on Rocky Linux 9

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.