### PR TITLE
build: Change label name in Conan workflow for the right VFX platform

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # CY2024
+          # CY2025
           - os: "ubuntu-latest"
             rocky-version: "8"
             image: "amd64/rockylinux:8"
@@ -57,7 +57,7 @@ jobs:
             qt-version: "6.5.3"
             cmake-version: "3.31.6"
             python-version: "3.11.8"
-            vfx-platform: "CY2024"
+            vfx-platform: "CY2025"
             extra_repo: "powertools"
             conan-profile: "x86_64_rocky8"
 
@@ -69,7 +69,7 @@ jobs:
             qt-version: "6.5.3"
             cmake-version: "3.31.6"
             python-version: "3.11.8"
-            vfx-platform: "CY2024"
+            vfx-platform: "CY2025"
             extra_repo: "crb"
             conan-profile: "x86_64_rocky9"
             
@@ -331,7 +331,7 @@ jobs:
           $CONAN_EXECUTABLE remote add aswftesting https://linuxfoundation.jfrog.io/artifactory/api/conan/aswf-conan-dev --index 0
 
       - name: Export OpenRVCore recipe to Conan's cache
-        if: ${{ matrix.vfx-platform == 'CY2024' }}
+        if: ${{ matrix.vfx-platform == 'CY2025' }}
         run: |
           export QT_HOME=/__w/OpenRV/OpenRV/deps/Qt/${{ matrix.qt-version}}/gcc_64
           echo "QT_HOME=$QT_HOME" >> $GITHUB_ENV
@@ -400,7 +400,7 @@ jobs:
             #qt-version-short: "6.5"
             #python-version: "3.11"
             #cmake-version: "3.31.6"
-            #vfx-platform: "CY2024"
+            #vfx-platform: "CY2025"
           - os: "macos-14"
             arch-type: "arm64"
             build-type: "Release"
@@ -408,7 +408,7 @@ jobs:
             qt-version-short: "6.5"
             python-version: "3.11"
             cmake-version: "3.31.6"
-            vfx-platform: "CY2024"
+            vfx-platform: "CY2025"
 
     steps:
       - name: Check if it is a schedule job
@@ -523,7 +523,7 @@ jobs:
           /Users/runner/Library/Python/3.11/bin/conan remote add aswftesting https://linuxfoundation.jfrog.io/artifactory/api/conan/aswf-conan-dev --index 0
 
       - name: Export OpenRVCore recipe
-        if: ${{ matrix.vfx-platform == 'CY2024' }}
+        if: ${{ matrix.vfx-platform == 'CY2025' }}
         run: |
           /Users/runner/Library/Python/3.11/bin/conan export openrvcore-conanfile.py
 
@@ -574,7 +574,7 @@ jobs:
             qt-version: "6.5.3"
             python-version: "3.11"
             cmake-version: "3.31.6"
-            vfx-platform: "CY2024"
+            vfx-platform: "CY2025"
             msvc-component: "14.40.17.10.x86.x64"
             msvc-compiler: "14.40.33807"
 
@@ -776,7 +776,7 @@ jobs:
         shell: msys2 {0}
 
       - name: Export OpenRVCore recipe
-        if: ${{ matrix.vfx-platform == 'CY2024' }}
+        if: ${{ matrix.vfx-platform == 'CY2025' }}
         run: |
           conan export openrvcore-conanfile.py
         shell: msys2 {0}


### PR DESCRIPTION
### build: Change label name in Conan workflow for the right VFX platform

### Linked issues
None

### Summarize your change.
Change label name in Conan workflow for the right VFX platform

### Describe the reason for the change.
The build was already CY2025, but the label were wrong.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.