### PR TITLE
fix: SG-44533: Insert new line on keyboard shortcut

### DIFF
--- a/src/plugins/rv-packages/annotate_beta/annotate_beta_engine.py
+++ b/src/plugins/rv-packages/annotate_beta/annotate_beta_engine.py
@@ -48,31 +48,6 @@ _SIZE_MIN = 0.001
 #   - existing text scales with the image as you zoom in (fixed WCS stored)
 _FONT_SIZE_WCS_BASE = {"small": 24.0 / 1080.0, "medium": 48.0 / 1080.0, "large": 72.0 / 1080.0}
 
-# US keyboard shift-symbol mapping used for text input
-_SHIFT_MAP = {
-    "1": "!",
-    "2": "@",
-    "3": "#",
-    "4": "$",
-    "5": "%",
-    "6": "^",
-    "7": "&",
-    "8": "*",
-    "9": "(",
-    "0": ")",
-    "-": "_",
-    "=": "+",
-    "[": "{",
-    "]": "}",
-    "\\": "|",
-    ";": ":",
-    "'": '"',
-    ",": "<",
-    ".": ">",
-    "/": "?",
-    "`": "~",
-}
-
 
 class AnnotateDrawEngine:
     def __init__(self, mode):
@@ -147,6 +122,8 @@ class AnnotateDrawEngine:
             ("key-down--backspace", self.on_text_backspace, "Delete char"),
             ("key-down--delete", self.on_text_backspace, "Delete char"),
             ("key-down--space", self.on_text_space, "Insert space"),
+            ("key-down--shift--enter", self.on_text_new_line, "Insert a new line"),
+            ("key-down--shift--keypad-enter", self.on_text_new_line, "Insert a new line"),
             ("key-down--return", lambda event: self.on_text_commit(event, reject=False), "Commit text"),
             ("key-down--enter", lambda event: self.on_text_commit(event, reject=False), "Commit text"),
             ("key-down--keypad-enter", lambda event: self.on_text_commit(event, reject=False), "Commit text"),
@@ -571,7 +548,7 @@ class AnnotateDrawEngine:
 
     def _commit_text(self):
         # Nothing typed — clean up the placeholder node rather than leaving an empty annotation
-        if not self._text_buffer:
+        if not self._text_buffer.strip():
             self._cancel_text()
             return
         self._update_text_display(cursor=False)
@@ -1010,15 +987,10 @@ class AnnotateDrawEngine:
             event.reject()
             return
         parts = event.name().split("--")
-        ch = parts[-1]
-        if len(ch) != 1:
+        char = parts[-1]
+        if len(char) != 1:
             event.reject()
             return
-        has_shift = "shift" in parts[:-1]
-        if has_shift:
-            char = ch.upper() if ch.isalpha() else _SHIFT_MAP.get(ch, ch)
-        else:
-            char = ch
         self._text_buffer += char
         self._ensure_text_node()
         self._update_text_display(cursor=True)
@@ -1037,6 +1009,15 @@ class AnnotateDrawEngine:
             return
         if self._text_buffer:
             self._text_buffer = self._text_buffer[:-1]
+        self._update_text_display(cursor=True)
+
+    def on_text_new_line(self, event):
+        if not self._text_active:
+            event.reject()
+            return
+
+        self._text_buffer += "\n"
+        self._ensure_text_node()
         self._update_text_display(cursor=True)
 
     def on_text_commit(self, event, reject):


### PR DESCRIPTION
### fix: [SG-44533](https://autodesk.atlassian.net/browse/SG-44533): Insert new line on hotkey

### Summarize your change.

A new `on_text_new_line` method was added to insert a new line when the `shift-enter` keyboard shortcut is detected. This was a missing method that is present in the current annotation code in Mu. Note that both "enter" keys (i.e. the regular one and the numpad one) are detected to mirror the same logic as with the `enter` keyboard shortcut for committing text. `strip()` was added to `_commit_text` to make sure not to commit annotations that are only spaces or newlines. Note that the `shift_map` logic was removed because while investigating this shift key issue, I saw that it was actually not used at all. For instance, "!" is already received as `key-down--!` not `key-down--shift--1`, and "A" is `key-down--A` not `key-down--shift--a`.

### Describe the reason for the change.

The new annotation tool was missing support for multi-line text annotations. The `shift-enter` keyboard shortcut should add a new line, just like the current annotation tool does.

### Describe what you have tested and on which operating system.

Adding new lines to text annotations using the `shift-enter` keyboard shortcut was tested on macOS.