### PR TITLE
build: Apple ProRes SDK dependency edge missing on Linux/macOS causing header race

### DIFF
--- a/cmake/dependencies/prores.cmake
+++ b/cmake/dependencies/prores.cmake
@@ -86,10 +86,9 @@ SET(RV_DEPS_APPLE_PRORES_VERSION_INCLUDE_DIR
     ${_include_dir}
     CACHE STRING "Path to installed includes for ${_target}"
 )
-ADD_DEPENDENCIES(Apple::ProRes ${_prores_lib})
-IF(RV_TARGET_WINDOWS)
-  ADD_DEPENDENCIES(Apple::ProRes ${_target})
-ENDIF()
+# ${_target} is the ExternalProject that downloads and extracts the SDK. Dependencies added to an IMPORTED target are followed transitively by its consumers, so
+# this orders MovieFFMpeg's compiles after the extraction.
+ADD_DEPENDENCIES(Apple::ProRes ${_target})
 
 SET(RV_DEPS_APPLE_PRORES_VERSION
     ${_version}


### PR DESCRIPTION
## Problem

An OpenRV community member reported intermittent `ProResDecoder.h: No such file or directory` failures when building with the Apple ProRes SDK enabled on Linux at high parallelism (`-j24`). It was order-dependent, so it looked like a flaky build rather than a missing dependency. Their diagnosis was correct.

## Root cause

`cmake/dependencies/prores.cmake` wired the dependency on the SDK extraction like this:

```cmake
ADD_DEPENDENCIES(Apple::ProRes ${_prores_lib})   # no-op: file path, not a target
IF(RV_TARGET_WINDOWS)
  ADD_DEPENDENCIES(Apple::ProRes ${_target})     # the real edge - Windows only
ENDIF()
```

- `${_prores_lib}` expands to `<build>/RV_DEPS_APPLE/prores/libProResDecoder.a` - a **file path**. `add_dependencies()` accepts target names only ("Add a dependency between top-level targets"), so the call did nothing.
- It produced no diagnostic either. `Apple::ProRes` is `IMPORTED`, so it is never a depender in the target-dependency graph; when a real target follows an imported target's dependencies transitively, CMake silently skips entries that don't resolve to a real target. So `CMP0046` (NEW here, since `CMAKE_MINIMUM_REQUIRED(VERSION 3.27)`) never fired.
- The only real edge to the `RV_DEPS_APPLE` ExternalProject sat inside `IF(RV_TARGET_WINDOWS)`. On Linux and macOS nothing ordered `MovieFFMpeg` after the SDK extraction, even though `src/lib/image/MovieFFMpeg/CMakeLists.txt` both `ADD_DEPENDENCIES` on and links `Apple::ProRes`.
- `MovieFFMpeg.cpp` and `AppleProRes.cpp` include `AppleProRes.h`, which includes `ProResDecoder.h` resolved purely from the `Apple::ProRes` INTERFACE include dir. A parallel build could reach those compiles before the zip was extracted.

Windows was unaffected, which is why this went unnoticed when ProRes support landed.

## Fix

Replace both lines with a single unconditional edge:

```cmake
ADD_DEPENDENCIES(Apple::ProRes ${_target})
```

This is the pattern every other dependency in the repo already uses for an ExternalProject-backed imported target - `bmd.cmake` (the closest twin: user-supplied SDK zip, no build step), `ffmpeg.cmake`, `doctest.cmake`, `jpegturbo.cmake`, and the `DEPENDS` path of `rv_add_imported_library.cmake`. Windows keeps the identical edge it had before, so its behaviour is unchanged by construction.

## Verification (Linux, Ninja, CY2025)

Configured with `-DRV_DEPS_APPLE_PRORES_SDK_ZIP_PATH=.../ProResDecoder_Linux_x86_64-15B54.zip` and compared the generated build graph against a second build directory configured from the unpatched file:

- **With the fix**, `MovieFFMpeg`'s order-only dependencies include `cmake/dependencies/RV_DEPS_APPLE`, and `ninja -t commands` for `AppleProRes.cpp.o` lists the ProRes mkdir / download+extract / stamp steps first and the compile last.
- **Without the fix**, that same command list contains no `RV_DEPS_APPLE` step at all - the only mention of the directory is the `-isystem .../RV_DEPS_APPLE/prores` flag on the compile line, pointing at a directory nothing had been scheduled to create. Every other `RV_DEPS_*` dependency appears in the order-only list; only `RV_DEPS_APPLE` is absent.

A from-scratch `ninja MovieFFMpeg -j24` with the SDK not yet extracted then completes cleanly (exit 0): the ProRes verify-and-extract step runs at 9/333 and completes at 15/333, well ahead of `AppleProRes.cpp.o` at 304/333 and `MovieFFMpeg.cpp.o` at 325/333.

Nothing else in the file changed, and the no-SDK path (early `RETURN()` with the "ProRes SDK path not specified" warning) is untouched.

Thanks to the community member who reported this and tracked down the cause.
