### PR TITLE
fix: SG-44509: Fix automatically mark frame

### DIFF
--- a/src/plugins/rv-packages/annotate_beta/annotate_beta_engine.py
+++ b/src/plugins/rv-packages/annotate_beta/annotate_beta_engine.py
@@ -336,7 +336,7 @@ class AnnotateDrawEngine:
 
         if getattr(self._mode, "_auto_mark", False):
             try:
-                commands.markFrame(frame, True)
+                commands.markFrame(commands.frame(), True)
             except Exception:
                 pass
 


### PR DESCRIPTION
### https://autodesk.atlassian.net/browse/SG-44509

### Summarize your change.

If the "Automatically Mark Annotated Frames" option is enabled, mark the frame based on the global frame number instead of the source frame number since this is what `markFrame` is expected to get.

### Describe the reason for the change.

If the "Automatically Mark Annotated Frames" option was enabled, the mark would be added to the wrong frame or to no frames at all, depending on how far the source frame value was from the global frame value. Since the global frame always starts at 1, clips also starting at 1 would get their marks on the right frame, but those starting at 0, would get the marks on the previous frames, and those starting at something way bigger, like 864000, wouldn't get any marks.

### Describe what you have tested and on which operating system.

Drawing annotations with the "Automatically Mark Annotated Frames" option enabled with different clips was tested on macOS.