### PR TITLE
fix: SG-45154: restore view-resized event dropped in the QOpenGLWindow viewport refactor

### DIFF
--- a/src/lib/app/RvCommon/GLView.cpp
+++ b/src/lib/app/RvCommon/GLView.cpp
@@ -20,6 +20,7 @@
 #include <IPCore/Session.h>
 #include <QtWidgets/QVBoxLayout>
 #include <QOpenGLContext>
+#include <QResizeEvent>
 #include <QTimer>
 #include <iostream>
 #include <sstream>
@@ -154,6 +155,44 @@ namespace Rv
         //
         watchParentWindow();
         QTimer::singleShot(0, this, &GLView::watchParentWindow);
+    }
+
+    void GLView::resizeEvent(QResizeEvent* event)
+    {
+        QWidget::resizeEvent(event);
+
+        //
+        //  Report viewport size changes to the UI layer as the "view-resized"
+        //  generic event, contents "oldW oldH|newW newH". Mu and Python
+        //  handlers rely on it -- rvui.mu binds it to implement "Lock Pixel
+        //  Scale During Resize" -- and it is part of the documented event API,
+        //  so the sizes stay in this widget's logical pixels, as they were when
+        //  the viewport was a QOpenGLWidget and this was emitted from
+        //  GLView::event().
+        //
+        //  The layout gives the container (and therefore the GL window) this
+        //  widget's full extent, so our geometry is the viewport's geometry.
+        //
+
+        if (!isVisible())
+            return;
+
+        IPCore::Session* session = m_doc ? m_doc->session() : nullptr;
+        if (!session)
+            return;
+
+        //
+        //  Qt reports an invalid old size on the very first resize; there is no
+        //  previous scale to preserve then, so there is nothing to report.
+        //
+        const QSize oldSize = event->oldSize();
+        if (oldSize.width() == -1 || oldSize.height() == -1)
+            return;
+
+        ostringstream contents;
+        contents << oldSize.width() << " " << oldSize.height() << "|" << event->size().width() << " " << event->size().height();
+
+        session->userGenericEvent("view-resized", contents.str());
     }
 
     void GLView::watchParentWindow()

--- a/src/lib/app/RvCommon/RvCommon/GLView.h
+++ b/src/lib/app/RvCommon/RvCommon/GLView.h
@@ -109,6 +109,7 @@ namespace Rv
 
     protected:
         void showEvent(QShowEvent*) override;
+        void resizeEvent(QResizeEvent*) override;
 
     private:
         RvDocument* m_doc;


### PR DESCRIPTION
### Linked issues

No GitHub issue — tracked internally as **SG-45154**.

Regression from #1375 (SG-43585). Also unblocks re-validation of #1082 / #1063, whose test plan
exercises `View > Lock Pixel Scale During Resize`.

### Summarize your change.

Re-emit the `view-resized` generic event from `GLView::resizeEvent()`.

The event stopped being sent when the viewport moved off `QOpenGLWidget` onto a native
`QOpenGLWindow` in #1375 (a8498fdd). It used to be emitted from the old `GLView::event()`
`QEvent::Resize` branch (`src/lib/app/RvCommon/GLView.cpp:689-707` at `a8498fdd^`), which went away
along with the `QOpenGLWidget`. `GLWindow` only forwards `resizeGL()` to
`RvDocument::viewSizeChanged()`, which sends the unrelated `view-size-changed` **render** event, so
nothing re-emits `view-resized`.

`GLView` is still the widget whose geometry the zero-margin `QVBoxLayout` hands to the container —
and hence to the `GLWindow` — so its `QResizeEvent` carries the same logical-pixel old/new sizes the
event contract has always used. No previous-size cache is needed, and the invalid-old-size first
resize is skipped exactly as before.

### Describe the reason for the change.

Nothing on the consumer side changed in #1375, so the loss was silent:

- `src/lib/app/mu_rvui/rvui.mu:7037` still binds `view-resized` to `viewResized()`
- `src/lib/app/mu_rvui/rvui.mu:6636` — `viewResized()` is the **entire** implementation of
  `View > Lock Pixel Scale During Resize`, via `retainScaleAfterResize()`
- `docs/rv-manuals/rv-reference-manual/rv-reference-manual-chapter-five.md:232` — `view-resized` is
  documented public API with contents `old-w new-w | old-h new-h`

So that menu option has been inert for window resizes, with only `margins-changed` (still emitted
from `IPCore/Session.cpp:5035`) driving scale retention — which makes the feature look like it
half-works. Any user plugin bound to `view-resized` stopped receiving it too.

### Describe what you have tested and on which operating system.

> [!WARNING]
> **Draft: functional verification is still pending.** Opening this early so the regression is on
> record. Do not merge until the checklist below is filled in.

Done so far:

- `GLView::resizeEvent()` type-checks against Qt 6.5.3 (override signature, `QResizeEvent` API).
- `pre-commit run --files src/lib/app/RvCommon/GLView.cpp src/lib/app/RvCommon/RvCommon/GLView.h` —
  clang-format passes with no reformatting.

Still to do:

- [ ] Rocky Linux 9 — build + functional test
- [ ] macOS — build + functional test
- [ ] Windows — build + functional test

Test plan:

1. Probe the event directly in RV's Python console, then resize the main window:
   ```python
   rv.commands.bind("default", "global", "view-resized", lambda e: print("view-resized", e.contents()), "probe")
   ```
   On `main` nothing prints; with this change `oldW oldH|newW newH` prints on every resize.
2. Enable `View > Lock Pixel Scale During Resize`, load
   `rv colorchart,start=1,end=2,width=1920,height=804,fps=24.movieproc`, then resize the window. The
   image must hold its pixel scale (the window reveals more/less area around it) rather than scaling
   with the window.
3. Regression guard: with `Fit Window to First Media Loaded` **and** lock-pixel-scale both on, load
   the same media and resize repeatedly — confirm no crash (this is the combination #1082 probed).
4. Exercise the `w` "Resize Window to Fit" command and confirm the window can still be shrunk below
   image size afterwards (i.e. `RvDocument::resetSizePolicy()` still fires).

### Add a list of changes, and note any that might need special attention during the review.

- `src/lib/app/RvCommon/RvCommon/GLView.h` — declare `resizeEvent()` alongside the existing
  `showEvent()` override.
- `src/lib/app/RvCommon/GLView.cpp` — implement `GLView::resizeEvent()`: chain to
  `QWidget::resizeEvent()`, then emit `view-resized` with `"oldW oldH|newW newH"`.

Worth a careful look during review:

- **Coordinate space.** The sizes are `GLView`'s logical pixels, matching the pre-#1375 contract.
  Emitting from `GLWindow::resizeGL()` instead was deliberately rejected: it would need its own
  previous-size cache, and its `w`/`h` are in the native window's pixel space, which would silently
  change the contract that `rvui.mu:6636`'s `margins()` arithmetic depends on.
- **Guards.** `!isVisible()` mirrors the old branch's visibility guard, and the
  `oldSize() == -1` skip preserves the "no previous scale to retain" first-resize behavior.
  `rvui.mu:6647`'s `state.startupResize` still swallows the first real `view-resized`, so
  `rvui.mu` needed no change.
- **Emission frequency.** `resizeEvent` fires per resize step during a drag, as the old
  `QEvent::Resize` branch did — the handler is the same one that has always absorbed that rate.

### If possible, provide screenshots.

N/A — no visual change beyond the restored resize behavior described above.
