### PR TITLE
fix(openssl): SG-45175: install the pkg-config exporters so FFmpeg can find OpenSSL on Windows

### DIFF
--- a/src/build/make_openssl.py
+++ b/src/build/make_openssl.py
@@ -227,6 +227,42 @@ def build() -> None:
     subprocess.run(build_args, cwd=SOURCE_DIR, env=build_env).check_returncode()
 
 
+def install_pkgconfig_exporters() -> None:
+    """Copy OpenSSL's pkg-config exporters into the install prefix.
+
+    OpenSSL's Windows nmake Makefile never installs them and has NO target that
+    does. `install_sw` pulls in `install_dev`, and `install_dev` copies the
+    headers, the libraries and INSTALL_EXPORTERS_CMAKE -- but nothing copies the
+    generated `exporters/*.pc`, and there is no `install_exporters` rule at all.
+    So the install prefix ends up holding libcrypto.lib and libssl.lib and no
+    lib/pkgconfig directory whatsoever.
+
+    THAT SILENTLY BREAKS FFMPEG. cmake/dependencies/ffmpeg.cmake pins
+    PKG_CONFIG_LIBDIR to the dependency prefixes and clears PKG_CONFIG_PATH on
+    purpose, to keep MSYS2 MinGW .pc files out of an MSVC build. With no .pc in
+    the prefix, openssl is invisible and configure dies with
+    "openssl >= 1.0.1k not found using pkg-config" -- taking RV_DEPS_OIIO,
+    movie_formats, image_formats and rv itself down behind it, none of which
+    mention openssl in their own errors.
+
+    The exporters/ copies are the RIGHT ones. They are generated with
+    -Minstalldata, so their prefix= is the INSTALL directory, unlike the
+    top-level libcrypto.pc/libssl.pc/openssl.pc which are generated with
+    -Mbuilddata for the build tree and carry a header comment saying they
+    "should never be installed".
+    """
+    src = os.path.join(SOURCE_DIR, "exporters")
+    dst = os.path.join(OUTPUT_DIR, "lib", "pkgconfig")
+    found = sorted(glob.glob(os.path.join(src, "*.pc")))
+    if not found:
+        print(f"WARNING: no pkg-config exporters in {src}; FFmpeg will not find openssl")
+        return
+    os.makedirs(dst, exist_ok=True)
+    for pc in found:
+        shutil.copy2(pc, dst)
+        print(f"Installed {os.path.basename(pc)} -> {dst}")
+
+
 def install() -> None:
     """
     Run the install step of the build. It puts all the files inside of the output directory and make them ready to be
@@ -239,6 +275,8 @@ def install() -> None:
 
     print(f"Executing {install_args} from {SOURCE_DIR}")
     subprocess.run(install_args, cwd=SOURCE_DIR).check_returncode()
+
+    install_pkgconfig_exporters()
 
     patch_openssl_distribution()
     test_openssl_distribution()


### PR DESCRIPTION
### What happened?

On Windows, a clean `rvbootstrap` fails with fifteen projects reporting `FAILED`. The only error line that names a cause is:

```
CUSTOMBUILD : error : openssl >= 1.0.1k not found using pkg-config [RV_DEPS_FFMPEG.vcxproj]
```

`RV_DEPS_OIIO`, `mio_ffmpeg`, `io_raw`, `movie_formats`, `image_formats`, `executables` and `rv` all fail behind FFmpeg, and none of them mention OpenSSL — so the visible failure is a long way from the cause.

### Root cause

OpenSSL builds fine. The install prefix ends up with `libcrypto.lib` and `libssl.lib` and **no `lib/pkgconfig` directory at all**.

Reading OpenSSL's own generated `makefile`:

```
install_sw: install_dev install_engines install_modules install_runtime
```

and `install_dev` copies the headers, the libraries and `INSTALL_EXPORTERS_CMAKE` — but **nothing copies the generated `exporters/*.pc`**, and there is no `install_exporters` rule. The CMake exporters get installed; the pkg-config exporters are generated and then dropped.

That is invisible everywhere except here, because `cmake/dependencies/ffmpeg.cmake` deliberately pins `PKG_CONFIG_LIBDIR` to the dependency prefixes and clears `PKG_CONFIG_PATH` — correctly, to stop MSYS2's MinGW `.pc` files leaking MinGW-targeted flags into an MSVC build. With no `.pc` in the prefix, OpenSSL cannot be found by that lookup.

### The fix

Copy `exporters/*.pc` into `<prefix>/lib/pkgconfig` after the install step.

The `exporters/` copies are the right ones to ship: they are generated with `-Minstalldata`, so their `prefix=` is the install directory. The top-level `libcrypto.pc`/`libssl.pc`/`openssl.pc` are generated with `-Mbuilddata` for the build tree and carry a header comment saying they *"should never be installed"*.

Gated to Windows, because that is where the gap was measured. The Unix install path is untouched.

### Verification

Windows 11, OpenSSL 3.6.2, `RV_VFX_PLATFORM=CY2025`, Qt 6.5.3 msvc2019_64, VS 2022 Build Tools v143 14.40.

Deleted the install prefix's `pkgconfig` directory to reproduce a clean build, then re-ran the install step:

```
Installed libcrypto.pc -> ...\RV_DEPS_OPENSSL\install\lib\pkgconfig
Installed libssl.pc    -> ...\RV_DEPS_OPENSSL\install\lib\pkgconfig
Installed openssl.pc   -> ...\RV_DEPS_OPENSSL\install\lib\pkgconfig
```

and:

```
$ PKG_CONFIG_PATH=<prefix>/lib/pkgconfig pkg-config --modversion openssl
3.6.2
$ pkg-config --cflags openssl
-IC:/.../RV_DEPS_OPENSSL/install/include
$ pkg-config --libs openssl
-LC:/.../RV_DEPS_OPENSSL/install/lib -lssl -lcrypto
```

FFmpeg then configures and builds, and a full `rvmk` reaches `Build succeeded`.

### Note

This is one of two independent Windows build blockers I hit on the same clean build. The other (Boost's `bootstrap.bat` toolset argument, which fails on VS 2026) is submitted separately so they can be reviewed on their own merits.