### PR TITLE
fix(boost): SG-45176: pass the toolset positionally to bootstrap.bat, which does not parse --with-toolset

### DIFF
--- a/cmake/dependencies/build/boost.cmake
+++ b/cmake/dependencies/build/boost.cmake
@@ -81,6 +81,20 @@ IF(APPLE)
   ENDIF()
 ENDIF()
 
+# WINDOWS: bootstrap.bat DOES NOT PARSE --with-toolset. That spelling belongs to bootstrap.sh. On Windows the toolset is POSITIONAL (bootstrap.bat passes %*
+# straight to build.bat, which maps vc143 -> "msvc : 14.3"), so --with-toolset=msvc-14.3 arrives as an unrecognised option, build.bat falls back to guessing,
+# guess_toolset.bat asks vswhere for the newest Visual Studio, gets VS 2026 (v18) whose version it cannot map, and dies with "Unknown toolset: vcunk". Passing
+# vc143 positionally skips the guess and writes the same `using msvc : 14.3 ;` into project-config.jam that b2's toolset= wants.
+IF(RV_TARGET_WINDOWS)
+  SET(_boost_bootstrap_args
+      vc143
+  )
+ELSE()
+  SET(_boost_bootstrap_args
+      --with-toolset=${_toolset} --with-python=${_boost_python_bin}
+  )
+ENDIF()
+
 EXTERNALPROJECT_ADD(
   ${_target}
   DEPENDS Python::Python
@@ -91,7 +105,7 @@ EXTERNALPROJECT_ADD(
   INSTALL_DIR ${_install_dir}
   URL ${_download_url}
   URL_MD5 ${_download_hash}
-  CONFIGURE_COMMAND ${_bootstrap_command} --with-toolset=${_toolset} --with-python=${_boost_python_bin}
+  CONFIGURE_COMMAND ${_bootstrap_command} ${_boost_bootstrap_args}
   BUILD_COMMAND
     # Ref.: https://www.boost.org/doc/libs/1_70_0/tools/build/doc/html/index.html#bbv2.builtin.features.cflags Ref.:
     # https://www.boost.org/doc/libs/1_76_0/tools/build/doc/html/index.html#bbv2.builtin.features.cflags


### PR DESCRIPTION
### What happened?

On Windows, `RV_DEPS_BOOST`'s configure step fails and takes the build with it:

```
'guess_toolset.bat' is not recognized as an internal or external command
###
### "Could not find a suitable toolset."
###
### Toolsets supported by this script are: borland, como, gcc,
###     clang, clang-win, gcc-nocygwin, intel-win32, mingw,
###     vc12, vc14, vc141, vc142, vc143
###
Failed to build Boost.Build engine.
```

### Root cause

`bootstrap.bat` **does not parse `--with-toolset=`**. That spelling belongs to `bootstrap.sh`. On Windows the toolset is **positional**: `bootstrap.bat` passes `%*` straight through to `build.bat`, and maps `%1` onto what it writes into `project-config.jam` (`vc143` → `msvc : 14.3`).

So `boost.cmake`'s `--with-toolset=msvc-14.3` reaches `build.bat` as an unrecognised *option*, `build.bat` falls back to `:Guess_Toolset`, and `guess_toolset.bat` asks `vswhere` for the newest Visual Studio. On a machine with **Visual Studio 2026** that returns a version its table doesn't know, so it sets `VSUNKCOMNTOOLS`, resolves to `vcunk`, and fails.

Two details worth flagging for review:

- `VSUNKCOMNTOOLS` is checked **after** `VS170COMNTOOLS` in `guess_toolset.bat` and overwrites it, so setting `VS170COMNTOOLS` in the environment does *not* rescue this. The guess has to be skipped, not steered.
- A machine with only VS 2022 installed guesses `vc143` by luck and never sees any of this. **The bug is latent until a newer Visual Studio is present**, which is why it hasn't shown up before.

### The fix

Pass `vc143` positionally on Windows. That skips the guess entirely and writes exactly the same `using msvc : 14.3 ;` that the `toolset=${_toolset}` on the `b2` line already expects, so configure and build agree as they always did.

The non-Windows branch keeps `--with-toolset=` and `--with-python=`, which `bootstrap.sh` does parse.

### Verification

Windows 11 with **both** Visual Studio 2026 (v18, MSVC 14.51) **and** VS 2022 Build Tools (v143, 14.39 and 14.40) installed — the toolchain `docs/build_system/config_windows.md` asks for, on a machine that also has a newer IDE.

- Before: `Unknown toolset: vcunk`, `Failed to build Boost.Build engine.`
- After: bootstrap exits 0, `b2.exe` is built, `project-config.jam` reads `using msvc : 14.3 ;`, `RV_DEPS_BOOST` builds, and a full `rvmk` reaches `Build succeeded`.

### Related

One further Windows-only wrinkle I hit but did **not** include here, because it belongs to Boost rather than to OpenRV: `build.bat` calls `guess_toolset.bat` and `config_toolset.bat`, and `guess_toolset.bat` calls `vswhere_usability_wrapper.cmd`, all without a `.\` prefix — so they depend on `cmd.exe`'s current-directory search being enabled. With this PR the guess path is skipped, so only `config_toolset.bat` remains on that path.

This is one of two independent Windows build blockers on the same clean build; the other (OpenSSL's pkg-config exporters never being installed) is #1404.