### PR TITLE
fix: SG-45139: Fix viewport scaling when moving RV between displays with different DPI

### DIFF
--- a/src/lib/app/RvCommon/GLWindow.cpp
+++ b/src/lib/app/RvCommon/GLWindow.cpp
@@ -23,6 +23,7 @@
 #include <TwkApp/VideoDevice.h>
 #include <TwkGLF/GLVideoDevice.h>
 #include <QOpenGLContext>
+#include <QScreen>
 #include <QtGui/QGuiApplication>
 #include <QKeyEvent>
 #include <QResizeEvent>
@@ -35,6 +36,37 @@ namespace Rv
     using namespace std;
     using namespace TwkApp;
     using namespace IPCore;
+
+    namespace
+    {
+        //
+        //  Sets a flag for the duration of a scope.
+        //
+        //  Holds a reference to the caller's flag, so the destructor clears the
+        //  one and only copy of it on every exit path, including an exception
+        //  thrown from a nested Qt or script callback. Copying is deleted
+        //  because the first destructor to run would clear the flag while the
+        //  other guard still believes it holds it.
+        //
+        //  Declare it as a named local: an unnamed temporary is destroyed at
+        //  the end of its own statement and guards nothing.
+        //
+        struct ScopedFlag
+        {
+            explicit ScopedFlag(bool& f)
+                : m_flag(f)
+            {
+                m_flag = true;
+            }
+
+            ~ScopedFlag() { m_flag = false; }
+
+            ScopedFlag(const ScopedFlag&) = delete;
+            ScopedFlag& operator=(const ScopedFlag&) = delete;
+
+            bool& m_flag;
+        };
+    } // namespace
 
     GLWindow::GLWindow(QOpenGLContext* sharedContext, RvDocument* doc, bool stereo, bool vsync, bool doubleBuffer, int red, int green,
                        int blue, int alpha, bool noResize)
@@ -50,6 +82,8 @@ namespace Rv
         , m_firstPaintCompleted(false)
         , m_postFirstNonEmptyRender(noResize)
         , m_stopProcessingEvents(false)
+        , m_devicePixelRatio(1.0f)
+        , m_syncingDevicePixelRatio(false)
         , m_sharedContext(sharedContext)
     {
         setFormat(GLView::rvGLFormat(stereo, vsync, doubleBuffer, red, green, blue, alpha));
@@ -60,6 +94,18 @@ namespace Rv
 
         m_eventProcessingTimer.setSingleShot(true);
         connect(&m_eventProcessingTimer, SIGNAL(timeout()), this, SLOT(eventProcessingTimeout()));
+
+        m_devicePixelRatio = static_cast<float>(devicePixelRatio());
+
+        //
+        //  Moving to another display is the usual way the ratio changes.
+        //  QWindow emits screenChanged() recursively, so this embedded viewport
+        //  gets it when the top level is dragged to another monitor.
+        //
+        //  Queued: screenChanged() is emitted before devicePixelRatio() reports
+        //  the new value, so a direct call would always see the old ratio.
+        //
+        connect(this, &QWindow::screenChanged, this, [this](QScreen*) { syncDevicePixelRatio(); }, Qt::QueuedConnection);
     }
 
     GLWindow::~GLWindow() {}
@@ -128,6 +174,59 @@ namespace Rv
     {
         if (m_doc)
             m_doc->viewSizeChanged(w, h);
+    }
+
+    void GLWindow::syncDevicePixelRatio()
+    {
+        const float dpr = static_cast<float>(devicePixelRatio());
+
+        if (dpr == m_devicePixelRatio || m_syncingDevicePixelRatio)
+        {
+            return;
+        }
+
+        //  The resize below and the session notification both feed back into
+        //  this window (geometry events, redraw requests, Mu/Python render
+        //  handlers), and we are called from the event handler they run through.
+        const ScopedFlag syncing(m_syncingDevicePixelRatio);
+
+        m_devicePixelRatio = dpr;
+
+        //
+        //  Re-establish the native drawable at the new scale.
+        //
+        //  Qt sizes the surface from the *logical* geometry, and the only thing
+        //  that pushes a new size down to the platform window is a geometry
+        //  change. Moving to a display with a different scale factor leaves the
+        //  logical geometry alone, so nothing re-establishes the drawable: it
+        //  stays at the old pixel size while everything derived from the device
+        //  (glViewport, the default GLFBO, the render geometry) correctly uses
+        //  the new one. GL then clips the frame to the stale surface, which is
+        //  the magnified-corner symptom. Verified with a glReadPixels bounds
+        //  probe: before the poke the surface is logical-sized, after it is not.
+        //
+        //  A one-pixel round trip is the portable way to force that push, and it
+        //  is the same remedy RvDocument::showEvent() already applies to the
+        //  first-show case of this bug. Poking the viewport window rather than
+        //  the whole document keeps it off the main window's layout.
+        //
+        const QSize restore = size();
+        resize(restore.width() + 1, restore.height());
+        resize(restore);
+
+        //
+        //  Notify the session as a resize would: it flushes the renderer's
+        //  image FBOs and fires the "view-size-changed" render event. The poke
+        //  above re-enters resizeGL() and does this too on platforms that
+        //  deliver the resize synchronously, but not on the ones that do not,
+        //  and the notification is idempotent.
+        //
+        if (m_doc)
+        {
+            m_doc->viewSizeChanged(width(), height());
+        }
+
+        requestUpdate();
     }
 
     QImage GLWindow::readPixels(int x, int y, int w, int h)
@@ -236,6 +335,38 @@ namespace Rv
 
     bool GLWindow::event(QEvent* event)
     {
+        //
+        //  Keep the drawable in step with the device pixel ratio before the
+        //  frame is painted, never after.
+        //
+        //  QPaintDeviceWindow::event() paints inline and returns without
+        //  chaining, so this is the last point we get before paintGL(), and
+        //  QOpenGLWindowPrivate::beginPaint() runs in between. It makes the
+        //  context current, which is where Qt applies a pending drawable
+        //  update, and sets glViewport from the live ratio. Correcting here
+        //  means the poke's NSViewFrameDidChange lands in time for that;
+        //  correcting afterwards, as a queued call, always costs one presented
+        //  frame at the wrong scale, which is visible as a jump when dragging
+        //  across a display boundary.
+        //
+        //  Both paint events matter: requestUpdate() produces UpdateRequest,
+        //  while a backing-scale change reaches us as Paint, because AppKit's
+        //  viewDidChangeBackingProperties only calls setNeedsDisplay. Move is
+        //  here because dragging across a boundary is what changes the scale,
+        //  and catching it there beats waiting for the repaint.
+        //
+        switch (event->type())
+        {
+        case QEvent::UpdateRequest:
+        case QEvent::Paint:
+        case QEvent::Expose:
+        case QEvent::Move:
+            syncDevicePixelRatio();
+            break;
+        default:
+            break;
+        }
+
         // The device (and its translator) is wired by the hosting GLView just
         // after construction; ignore any events that arrive before then.
         if (!m_videoDevice)

--- a/src/lib/app/RvCommon/GLWindow.cpp
+++ b/src/lib/app/RvCommon/GLWindow.cpp
@@ -28,6 +28,7 @@
 #include <QKeyEvent>
 #include <QResizeEvent>
 #include <QtWidgets/QMenu>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 
@@ -180,7 +181,17 @@ namespace Rv
     {
         const float dpr = static_cast<float>(devicePixelRatio());
 
-        if (dpr == m_devicePixelRatio || m_syncingDevicePixelRatio)
+        //
+        //  Compare with a tolerance rather than exactly. Only macOS, which
+        //  reports whole-number ratios, has been tested; a platform that
+        //  derives the ratio from fractional scaling (Windows at 125%, 150%)
+        //  can return values that differ in the last bits from one call to the
+        //  next. An exact comparison would never take the early return there,
+        //  and since the work below ends in requestUpdate() (and the session notification) 
+        //  that brings us back here, that would spin continuously. 
+        //  The tolerance is far below any real difference in scale factor between two displays.
+        //
+        if (std::abs(dpr - m_devicePixelRatio) < 1e-4f || m_syncingDevicePixelRatio)
         {
             return;
         }

--- a/src/lib/app/RvCommon/QTGLVideoDevice.cpp
+++ b/src/lib/app/RvCommon/QTGLVideoDevice.cpp
@@ -27,6 +27,20 @@ namespace Rv
     using namespace TwkGLF;
     using namespace TwkApp;
 
+    namespace
+    {
+        //
+        //  RV_NO_QT_HDPI_SUPPORT pins the ratio to 1 so RV renders at logical
+        //  size on HDPI displays. main.cpp clears Qt's own scaling environment
+        //  variables when it is set, so the two have to agree.
+        //
+        bool qtHighDPISupportDisabled()
+        {
+            static const bool disabled = getenv("RV_NO_QT_HDPI_SUPPORT") != nullptr;
+            return disabled;
+        }
+    } // namespace
+
     QTGLVideoDevice::QTGLVideoDevice(VideoModule* m, const string& name, QOpenGLWidget* view)
         : GLVideoDevice(m, name, ImageOutput | ProvidesSync | SubWindow)
         , m_view(view)
@@ -144,6 +158,35 @@ namespace Rv
         return 0;
     }
 
+    float QTGLVideoDevice::devicePixelRatio() const
+    {
+        if (qtHighDPISupportDisabled())
+        {
+            return 1.0f;
+        }
+
+        //
+        //  Take the ratio straight from the surface Qt sized the default
+        //  framebuffer with. m_devicePixelRatio is a cache refreshed only from
+        //  setPhysicalDevice(), which is only reached when the window moves and
+        //  the screen lookup succeeds -- so dragging RV to a display with a
+        //  different scale factor could leave every size derived from this
+        //  device (width()/height(), and through them the render geometry and
+        //  the default GLFBO) on the old ratio, with glViewport then covering
+        //  the wrong part of the surface.
+        //
+        //  Only the window-backed control viewport is switched over: it is the
+        //  one that follows the user between displays. The widget-backed
+        //  presentation and worker devices keep the cached value.
+        //
+        if (m_window)
+        {
+            return static_cast<float>(m_window->devicePixelRatio());
+        }
+
+        return m_devicePixelRatio;
+    }
+
     void QTGLVideoDevice::setPhysicalDevice(VideoDevice* d)
     {
         TwkGLF::GLVideoDevice::setPhysicalDevice(d);
@@ -153,8 +196,7 @@ namespace Rv
         // may differ from the logical pixel ratio on a per screen basis.
         m_devicePixelRatio = 1.0f;
 
-        static bool noQtHighDPISupport = getenv("RV_NO_QT_HDPI_SUPPORT") != nullptr;
-        if (noQtHighDPISupport)
+        if (qtHighDPISupportDisabled())
         {
             return;
         }

--- a/src/lib/app/RvCommon/RvCommon/GLWindow.h
+++ b/src/lib/app/RvCommon/RvCommon/GLWindow.h
@@ -68,6 +68,14 @@ namespace Rv
 
         float devicePixelRatioF() const;
 
+        //
+        //  Re-establish the surface and notify the session when the device
+        //  pixel ratio changes without a change of logical size. This is what
+        //  moving to a display with a different scale factor does, and which Qt
+        //  reports through no resize of its own. See the definition.
+        //
+        void syncDevicePixelRatio();
+
         QImage readPixels(int x, int y, int w, int h);
 
     public slots:
@@ -94,6 +102,8 @@ namespace Rv
         int m_alpha;
         bool m_postFirstNonEmptyRender;
         bool m_stopProcessingEvents;
+        float m_devicePixelRatio;
+        bool m_syncingDevicePixelRatio;
         QOpenGLContext* m_sharedContext;
     };
 

--- a/src/lib/app/RvCommon/RvCommon/GLWindow.h
+++ b/src/lib/app/RvCommon/RvCommon/GLWindow.h
@@ -68,14 +68,6 @@ namespace Rv
 
         float devicePixelRatioF() const;
 
-        //
-        //  Re-establish the surface and notify the session when the device
-        //  pixel ratio changes without a change of logical size. This is what
-        //  moving to a display with a different scale factor does, and which Qt
-        //  reports through no resize of its own. See the definition.
-        //
-        void syncDevicePixelRatio();
-
         QImage readPixels(int x, int y, int w, int h);
 
     public slots:
@@ -87,6 +79,14 @@ namespace Rv
         void paintGL() override;
 
     private:
+        //
+        //  Re-establish the surface and notify the session when the device
+        //  pixel ratio changes without a change of logical size. This is what
+        //  moving to a display with a different scale factor does, and which Qt
+        //  reports through no resize of its own. See the definition.
+        //
+        void syncDevicePixelRatio();
+
         RvDocument* m_doc;
         QTGLVideoDevice* m_videoDevice;
         unsigned int m_lastKey;

--- a/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
+++ b/src/lib/app/RvCommon/RvCommon/QTGLVideoDevice.h
@@ -107,9 +107,14 @@ namespace Rv
 
         virtual void setPhysicalDevice(VideoDevice* d);
 
-        // Device pixel ratio for high DPI displays
-        // For reference: https://doc.qt.io/qt-6/highdpi.html
-        float devicePixelRatio() const override { return m_devicePixelRatio; }
+        //
+        //  Device pixel ratio for high DPI displays.
+        //  For reference: https://doc.qt.io/qt-6/highdpi.html
+        //
+        //  Window-backed devices report the live ratio of their own surface
+        //  rather than the cached m_devicePixelRatio; see the definition.
+        //
+        float devicePixelRatio() const override;
 
     protected:
         QTGLVideoDevice(const std::string& name, QOpenGLWidget* view);


### PR DESCRIPTION
###

### Linked issues
none

### Summarize your change.
Moving the RV window to a display with a different scale factor left the viewport rendering at
the wrong scale: the image was either magnified into a corner, or drawn small in the bottom-left.
It stayed wrong until the window was manually resized. Dragging *across* a display boundary showed
the same corruption for as long as the window straddled the two screens.

Two independent defects, both introduced when the viewport became a native `QOpenGLWindow`:

1. **The native drawable was never resized.** Qt sizes the surface from *logical* geometry, and
   only a geometry change pushes a new size down to the platform window. A DPI change leaves the
   logical geometry untouched, so the drawable kept its old pixel size while everything derived
   from the video device (`glViewport`), the default `GLFBO`, the render geometry, correctly used
   the new one. GL clipped the frame to the stale surface.

2. **Two competing sources of truth for the device pixel ratio.** `QTGLVideoDevice` sized every
   frame from a cached ratio refreshed only by a screen lookup on the viewport's *centre point*,
   while Qt sized the surface from the live ratio. AppKit flips a window's backing scale on its
   own rule, which does not coincide with that centre-point probe, so the two disagreed for the
   whole time the window straddled two displays.

`GLWindow` now tracks the ratio and, when it changes, re-establishes the drawable and notifies the
session, and does so *before* the frame is painted rather than a turn later. `QTGLVideoDevice`
takes the ratio for the window-backed control viewport straight from its own surface.

### Describe the reason for the change.

`#1375` moved the viewport off `QOpenGLWidget` onto a native `QOpenGLWindow` embedded via
`QWidget::createWindowContainer()`. That PR's own description flagged this area as untested:

> **HDPI.** Coordinate translation now goes through the container widget while rendering goes
> through the window, so `devicePixelRatio` paths deserve a mixed-DPI pass.

This is that pass. The relevant Qt 6.5.3 behaviour, for reviewers:

- `QOpenGLWindow::resizeGL()` has exactly one call site, `resizeEvent()`
  (`qopenglwindow.cpp:641`), and `processGeometryChangeEvent()` only sends a `QResizeEvent` when
  the **logical** size changes (`qguiapplication.cpp:2670`). A DPI change therefore produces no
  `resizeGL()` at all. `QWindowContainer` does not help — it never re-pushes the embedded window's
  geometry on a screen change (`qwindowcontainer.cpp:42,267`).
- `QCocoaGLContext` only calls `[m_context update]` when `m_needsUpdate` is set, and that is set by
  `NSViewFrameDidChange`, `NSWindowDidChangeScreen` and `NSApplicationDidChangeScreenParameters` —
  **not** by a backing-properties change (`qcocoaglcontext.mm:383-398`). A one-pixel resize round
  trip posts `NSViewFrameDidChangeNotification`, which is the portable way to force that update.
  It is the same remedy `RvDocument::showEvent()` already applies to the first-show case.
- `QWindow::devicePixelRatio()` is **not** cached in 6.5.3 — it round-trips to AppKit on every call
  (`qcocoawindow.mm:1927`), and `QOpenGLWindowPrivate::beginPaint()` uses it to set
  `glViewport(0, 0, w*dpr, h*dpr)` immediately before each `paintGL()` (`qopenglwindow.cpp:226`).
  Sourcing the device's ratio from the same place makes divergence impossible by construction.

### Describe what you have tested and on which operating system.


**macOS 15 (Apple silicon), Qt 6.5.3, Release**, on a genuinely mixed-DPI setup: DELL U2725QE
3840x2160 at DPR 1.0 (main) plus the built-in Retina display at DPR 2.0.

Dragging the window back and forth across the display boundary is now visually clean, with no artifact while straddling.

### Add a list of changes, and note any that might need special attention during the review.

**`GLWindow`** (`GLWindow.h`, `GLWindow.cpp`)

- New `syncDevicePixelRatio()` plus `m_devicePixelRatio` / `m_syncingDevicePixelRatio`. On a change
  it does a one-pixel resize round trip on the viewport window to re-establish the drawable, then
  calls `RvDocument::viewSizeChanged()` so the renderer's image FBOs flush and `view-size-changed`
  fires. Poking the viewport window rather than the document keeps it off the main window's layout.
- Called from `GLWindow::event()` **before** delegating to the base class, on `UpdateRequest`,
  `Paint`, `Expose` and `Move`.
- Queued `QWindow::screenChanged` connection as an additional trigger.

**`QTGLVideoDevice`** (`QTGLVideoDevice.h`, `QTGLVideoDevice.cpp`)

- `devicePixelRatio()` becomes out-of-line; for the window-backed control viewport it returns
  `m_window->devicePixelRatio()`. Widget-backed presentation (`ScreenView`) and worker devices keep
  the cached value, so their behaviour is unchanged.
- The `RV_NO_QT_HDPI_SUPPORT` static is hoisted into a shared `qtHighDPISupportDisabled()` helper
  so both paths honour it.
- `setPhysicalDevice()`'s screen lookup is left in place — it still drives the refresh rate and the
  `video-device-changed` event, it just stops being load-bearing for the ratio.

### If possible, provide screenshots.